### PR TITLE
fix(common): order of array items and fix object property names

### DIFF
--- a/stacks/spica/packages/common/src/input/components/array/array.component.html
+++ b/stacks/spica/packages/common/src/input/components/array/array.component.html
@@ -2,14 +2,16 @@
   <h3 class="mat-h3">{{ schema.title }}</h3>
   <mat-hint *ngIf="schema.description">{{ schema.description }}</mat-hint>
   <mat-card-content>
-    <div>
+    <div cdkDropList [cdkDropListDisabled]="_disabled" (cdkDropListDropped)="drop($event)">
       <button
         *ngFor="let item of _values; let index = index"
         class="mat-elevation-z0"
+        [class.drag-box]="!_disabled"
         mat-icon-button
         mat-raised-button
         [color]="_activeIndex == index && 'primary'"
         (click)="_activeIndex = index"
+        cdkDrag
       >
         {{ index + 1 }}
       </button>

--- a/stacks/spica/packages/common/src/input/components/array/array.component.scss
+++ b/stacks/spica/packages/common/src/input/components/array/array.component.scss
@@ -37,6 +37,31 @@
             }
           }
         }
+        .drag-box {
+          cursor: move;
+          .cdk-drag-preview {
+            box-sizing: border-box;
+            border-radius: 4px;
+            box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14),
+              0 3px 14px 2px rgba(0, 0, 0, 0.12);
+          }
+
+          .cdk-drag-placeholder {
+            opacity: 0;
+          }
+
+          .cdk-drag-animating {
+            transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+          }
+
+          .drag-box:last-child {
+            border: none;
+          }
+
+          .drag-list.cdk-drop-list-dragging .drag-box:not(.cdk-drag-placeholder) {
+            transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+          }
+        }
       }
     }
   }

--- a/stacks/spica/packages/common/src/input/components/array/array.component.ts
+++ b/stacks/spica/packages/common/src/input/components/array/array.component.ts
@@ -2,7 +2,7 @@ import {Component, forwardRef, HostListener, Inject, ViewChild} from "@angular/c
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from "@angular/forms";
 import {INPUT_SCHEMA, InternalPropertySchema} from "../../input";
 import {InputResolver} from "../../input.resolver";
-
+import {CdkDragDrop, moveItemInArray} from "@angular/cdk/drag-drop";
 @Component({
   templateUrl: "./array.component.html",
   styleUrls: ["./array.component.scss"],
@@ -75,5 +75,9 @@ export class ArrayComponent implements ControlValueAccessor {
 
   setDisabledState?(isDisabled: boolean): void {
     this._disabled = isDisabled;
+  }
+
+  drop(event: CdkDragDrop<string[]>) {
+    moveItemInArray(this._values, event.previousIndex, event.currentIndex);
   }
 }

--- a/stacks/spica/packages/common/src/input/components/object/object.component.html
+++ b/stacks/spica/packages/common/src/input/components/object/object.component.html
@@ -7,7 +7,7 @@
     <span
       *ngFor="let property of schema.properties | keyvalue"
       [inputPlacer]="property.value"
-      [name]="property.key"
+      [name]="schema.$name + property.key"
       [required]="schema.required && schema.required.indexOf(property.key) > -1"
       [(ngModel)]="_value[property.key]"
       (ngModelChange)="callOnChange()"

--- a/stacks/spica/packages/common/src/input/components/object/object.component.ts
+++ b/stacks/spica/packages/common/src/input/components/object/object.component.ts
@@ -1,7 +1,7 @@
 import {Component, forwardRef, HostListener, Inject} from "@angular/core";
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from "@angular/forms";
 
-import {INPUT_SCHEMA, InputSchema} from "../../input";
+import {INPUT_SCHEMA, InternalPropertySchema} from "../../input";
 
 @Component({
   templateUrl: "./object.component.html",
@@ -13,7 +13,7 @@ export class ObjectComponent implements ControlValueAccessor {
   _disabled: boolean = false;
   _onChangeFn: any;
   _onTouchedFn: any;
-  constructor(@Inject(INPUT_SCHEMA) public schema: InputSchema) {}
+  constructor(@Inject(INPUT_SCHEMA) public schema: InternalPropertySchema) {}
 
   @HostListener("click")
   callOnTouched(): void {

--- a/stacks/spica/packages/common/src/input/input.module.ts
+++ b/stacks/spica/packages/common/src/input/input.module.ts
@@ -40,6 +40,7 @@ import {InputSchemaPlacer} from "./input-schema-placer/input.schema.placer";
 import {InputPlacerComponent} from "./input.placer";
 import {InputResolver} from "./input.resolver";
 import {NgModelParentDirective} from "./ngmodel.parent";
+import {DragDropModule} from "@angular/cdk/drag-drop";
 import {
   MaxValidator,
   MinItemsValidator,
@@ -72,7 +73,8 @@ export function coerceObject() {
     MatDatepickerModule,
     MatCheckboxModule,
     MatTooltipModule,
-    MatNativeDateModule
+    MatNativeDateModule,
+    DragDropModule
   ],
   exports: [InputPlacerComponent, InputSchemaPlacer, MaxValidator, MinValidator],
   declarations: [


### PR DESCRIPTION
This PR contains these changes;

1. add ability for order items of an array
2. prepend root path as name to object properties