### PR TITLE
build(ci): check if building a pull request before merge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,10 +29,11 @@ commands:
             # We do this because we want our tests to be prospective. Basically, we test whether will these test pass if we merge it onto target branch.
             # NOTE: Branches that have conflicts with the target branch will fail directly.
             # See: https://ideas.circleci.com/ideas/CCI-I-926
-            URL="https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CI_PULL_REQUEST//*pull\//}"
-            export CIRCLE_TARGET_BRANCH=$(curl -s "$URL" | jq -e '.base.ref' | tr -d '"')
-            git merge --ff-only "origin/$CIRCLE_TARGET_BRANCH"
-
+            if [ ! -z $CI_PULL_REQUEST ]; then
+                URL="https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CI_PULL_REQUEST//*pull\//}"
+                export CIRCLE_TARGET_BRANCH=$(curl -s "$URL" | jq -e '.base.ref' | tr -d '"')
+                git merge --ff-only "origin/$CIRCLE_TARGET_BRANCH"
+            fi
 executors:
   default-executor:
     working_directory: ~/spica


### PR DESCRIPTION
This commit fixes a problem that has been introduced within the previous commit. @emre2345 @htuna07 


See: https://app.circleci.com/jobs/github/spica-engine/spica/3225