### PR TITLE
build(ci): fix failing deploy job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
           name: "Deploying artifacts"
           command: |
             (cd stacks/spica && yarn ng build --prod --progress=false)
-            yarn bazel run deploy.replace --config=release -- -- --force
+            yarn bazel run deploy.replace -- --config=release -- --force
 
 workflows:
   version: 2


### PR DESCRIPTION
This was an issue that had been failing on my local environment. However, I didn't notice it for the first time. 

After this fix, we are good to go. Our deployment pipeline won't fail hopefully. 