### PR TITLE
fix(function): enable/disable function trigger

### DIFF
--- a/stacks/api/function/src/function.service.ts
+++ b/stacks/api/function/src/function.service.ts
@@ -14,11 +14,8 @@ export class FunctionService extends BaseCollection<Function>("function") {
       const emitHandlers = (fn: Function, kind: ChangeKind) => {
         for (const handler in fn.triggers) {
           const trigger = fn.triggers[handler];
-          if (!trigger.active) {
-            continue;
-          }
           observer.next({
-            kind,
+            kind: trigger.active ? kind : ChangeKind.Removed,
             options: trigger.options,
             type: trigger.type,
             target: {

--- a/stacks/spica/src/function/interface.ts
+++ b/stacks/spica/src/function/interface.ts
@@ -62,7 +62,8 @@ export function emptyTrigger(handler?: string): Trigger {
   return {
     handler: handler,
     options: {},
-    type: undefined
+    type: undefined,
+    active: true
   };
 }
 

--- a/stacks/spica/src/function/pages/add/add.component.html
+++ b/stacks/spica/src/function/pages/add/add.component.html
@@ -182,8 +182,8 @@
                 [required]="options.required?.indexOf(propertyKv.key) > -1"
               >
               </span>
-              <mat-slide-toggle name="status" [(ngModel)]="trigger.status">
-                {{ trigger.status ? "Active" : "Deactive" }}
+              <mat-slide-toggle name="status" [(ngModel)]="trigger.active">
+                {{ trigger.active ? "Active" : "Deactive" }}
               </mat-slide-toggle>
             </ng-container>
           </ng-container>

--- a/stacks/spica/src/function/pages/add/add.component.spec.ts
+++ b/stacks/spica/src/function/pages/add/add.component.spec.ts
@@ -107,11 +107,12 @@ describe("Function Add", () => {
     fixture.componentInstance.deleteTrigger(2);
 
     expect(func.triggers).toEqual([
-      {handler: "handler1", options: {}, type: undefined},
+      {handler: "handler1", options: {}, type: undefined, active: true},
       {
         handler: "handler2",
         options: {},
-        type: undefined
+        type: undefined,
+        active: true
       }
     ]);
 


### PR DESCRIPTION
On the client-side, slide-toggle changes the status property of trigger but the property that needed to be change is **active**. Also, the emptyTrigger function returns a new trigger that doesn't have active property. So it causes to insert trigger with **active: true** to the database even if trigger disabled before insert. 

On the server-side, deleted if logic continues to running without **observer.next()** called when active value is false. It blocks the unsubscribe to the trigger. New logic will call observer.next with ChangeKind.Removed so it will be an unsubscribed to trigger.