### PR TITLE
refactor(common): remove ambiguous statusText

### DIFF
--- a/stacks/spica/packages/core/layout/error.interceptor.spec.ts
+++ b/stacks/spica/packages/core/layout/error.interceptor.spec.ts
@@ -39,40 +39,37 @@ describe("Error Interceptor", () => {
   });
 
   it("should navigate to error page with these queryParams", fakeAsync(() => {
+    const routerData = {
+      queryParams: {
+        message: "error message",
+        status: 403,
+        statusText: 'Unknown Error'
+      }
+    };
     service
       .get("testurl")
       .toPromise()
-      .catch(err => {
+      .catch(() => {
         expect(mockRouter.navigate).toHaveBeenCalledWith(["/error"], routerData);
         expect(mockRouter.navigate).toHaveBeenCalledTimes(1);
         mockRouter.navigate.calls.reset();
       });
     httpTesting
       .expectOne("testurl")
-      .flush({message: "error message"}, {status: 403, statusText: "status text"});
-    let routerData = {
-      queryParams: {
-        message: "error message",
-        status: 403,
-        statusText: "status text"
-      }
-    };
+      .flush({message: "error message"}, {status: 403, statusText: ""});
+
   }));
 
   it("should open the snackbar if status code is 500", fakeAsync(() => {
-    service
-      .get("testurl")
-      .toPromise()
-      .catch(err => {});
+    service.get("testurl").toPromise().catch(() => {});
     httpTesting
       .expectOne("testurl")
-      .flush({message: "error message"}, {status: 500, statusText: "status text"});
+      .flush({message: "error message"}, {status: 500, statusText: ''});
     expect(mockRouter.navigate).toHaveBeenCalledTimes(0);
     expect(mockSnackbar.openFromComponent).toHaveBeenCalledTimes(1);
     expect(mockSnackbar.openFromComponent).toHaveBeenCalledWith(SnackbarComponent, {
       data: {
         status: 500,
-        statusText: "status text",
         message: "error message"
       },
       duration: 3000

--- a/stacks/spica/packages/core/layout/error.interceptor.spec.ts
+++ b/stacks/spica/packages/core/layout/error.interceptor.spec.ts
@@ -43,7 +43,7 @@ describe("Error Interceptor", () => {
       queryParams: {
         message: "error message",
         status: 403,
-        statusText: 'Unknown Error'
+        statusText: "Unknown Error"
       }
     };
     service
@@ -57,14 +57,16 @@ describe("Error Interceptor", () => {
     httpTesting
       .expectOne("testurl")
       .flush({message: "error message"}, {status: 403, statusText: ""});
-
   }));
 
   it("should open the snackbar if status code is 500", fakeAsync(() => {
-    service.get("testurl").toPromise().catch(() => {});
+    service
+      .get("testurl")
+      .toPromise()
+      .catch(() => {});
     httpTesting
       .expectOne("testurl")
-      .flush({message: "error message"}, {status: 500, statusText: ''});
+      .flush({message: "error message"}, {status: 500, statusText: ""});
     expect(mockRouter.navigate).toHaveBeenCalledTimes(0);
     expect(mockSnackbar.openFromComponent).toHaveBeenCalledTimes(1);
     expect(mockSnackbar.openFromComponent).toHaveBeenCalledWith(SnackbarComponent, {

--- a/stacks/spica/packages/core/layout/error.interceptor.ts
+++ b/stacks/spica/packages/core/layout/error.interceptor.ts
@@ -33,7 +33,6 @@ export class ErrorInterceptor implements HttpInterceptor {
               this.snackBar.openFromComponent(SnackbarComponent, {
                 data: {
                   status: err.status,
-                  statusText: err.statusText,
                   message: err.error.message
                 } as SnackbarError,
                 duration: 3000

--- a/stacks/spica/packages/core/layout/snackbar/snackbar.component.html
+++ b/stacks/spica/packages/core/layout/snackbar/snackbar.component.html
@@ -1,3 +1,2 @@
 <div>Code: {{ error.status }}</div>
-<div>{{ error.statusText }}</div>
 <div>{{ error.message }}</div>

--- a/stacks/spica/packages/core/layout/snackbar/snackbar.component.spec.ts
+++ b/stacks/spica/packages/core/layout/snackbar/snackbar.component.spec.ts
@@ -15,7 +15,6 @@ class TestComponent {
     this.snackBar.openFromComponent(SnackbarComponent, {
       data: {
         status: 404,
-        statusText: "Not Found",
         message: "Couldn't find."
       } as SnackbarError,
       duration: 3000
@@ -49,8 +48,7 @@ describe("SnackbarComponent", () => {
     const lines = document.body.querySelectorAll("snackbar > div");
 
     expect(lines[0].textContent).toEqual("Code: 404");
-    expect(lines[1].textContent).toEqual("Not Found");
-    expect(lines[2].textContent).toEqual("Couldn't find.");
+    expect(lines[1].textContent).toEqual("Couldn't find.");
   });
 
   it("should close component", async () => {


### PR DESCRIPTION
Between HTTP/1.1 and HTTP/2 there is a slight difference in statusText and its content varies browser-to-browser. It is best to not show it at all to prevent confusion.

See: https://github.com/whatwg/fetch/issues/599