### PR TITLE
fix(bucket): default values of date do not work properly

### DIFF
--- a/stacks/api/bucket/src/bucket.schema.resolver.ts
+++ b/stacks/api/bucket/src/bucket.schema.resolver.ts
@@ -43,6 +43,8 @@ export function provideBucketSchemaResolver(validator: Validator, bs: BucketServ
   validator.registerUriResolver(uri => resolver.resolve(uri));
   let keywords = getCustomKeywords(validator);
   keywords.forEach(keyword => validator.registerKeyword(keyword.name, keyword.def));
+  //format should run after default;
+  validator.registerKeyword("format", validator["formatKeywordDefinition"]);
   return resolver;
 }
 
@@ -59,7 +61,7 @@ export function getCustomKeywords(validator: Validator) {
 
             if (defaultValueHandler) {
               parentData[propertyName] = defaultValueHandler.create(
-                data == defaultValueHandler.keyword ? undefined : data
+                data == defaultValueHandler.keyword || parentSchema["readOnly"] ? undefined : data
               );
             } else if (!defaultValueHandler && parentSchema["readOnly"]) {
               parentData[propertyName] = schema;

--- a/stacks/api/bucket/src/graphql/schema.ts
+++ b/stacks/api/bucket/src/graphql/schema.ts
@@ -21,7 +21,7 @@ enum UpdateType {
   Unset
 }
 
-export function createSchema(bucket: Bucket, staticTypes: string) {
+export function createSchema(bucket: Bucket, staticTypes: string, bucketIds: string[]) {
   let name = getBucketName(bucket._id);
 
   let schema = `
@@ -45,9 +45,9 @@ export function createSchema(bucket: Bucket, staticTypes: string) {
       }
     `;
 
-  let types = createInterface(Prefix.Type, Suffix.Type, name, bucket, []);
+  let types = createInterface(Prefix.Type, Suffix.Type, name, bucket, [], bucketIds);
 
-  let inputs = createInterface(Prefix.Input, Suffix.Input, name, bucket, []);
+  let inputs = createInterface(Prefix.Input, Suffix.Input, name, bucket, [], bucketIds);
 
   schema = schema + types + inputs;
 
@@ -59,7 +59,8 @@ function createInterface(
   suffix: string,
   name: string,
   schema: any,
-  extras: string[]
+  extras: string[],
+  bucketIds: string[]
 ) {
   let properties = [];
 
@@ -70,7 +71,7 @@ function createInterface(
   for (const [key, value] of Object.entries(schema.properties) as any) {
     let isRequired = schema.required && schema.required.includes(key);
 
-    let property = createProperty(name, prefix, suffix, key, value, isRequired, extras);
+    let property = createProperty(name, prefix, suffix, key, value, isRequired, extras, bucketIds);
 
     properties.push(property);
   }
@@ -100,9 +101,19 @@ function createProperty(
   key: string,
   value: any,
   isRequired: Boolean,
-  extras: string[]
+  extras: string[],
+  bucketIds: string[]
 ) {
-  return `${key} : ${createPropertyValue(name, prefix, suffix, key, value, isRequired, extras)}`;
+  return `${key} : ${createPropertyValue(
+    name,
+    prefix,
+    suffix,
+    key,
+    value,
+    isRequired,
+    extras,
+    bucketIds
+  )}`;
 }
 
 function createPropertyValue(
@@ -112,7 +123,8 @@ function createPropertyValue(
   key: string,
   value: any,
   isRequired: Boolean,
-  extras: string[]
+  extras: string[],
+  bucketIds: string[]
 ) {
   let result;
 
@@ -133,7 +145,8 @@ function createPropertyValue(
         key,
         value.items,
         false,
-        extras
+        extras,
+        bucketIds
       )}]`;
       break;
 
@@ -158,7 +171,7 @@ function createPropertyValue(
       break;
 
     case "object":
-      let extra = createInterface(prefix, suffix, `${name}_${key}`, value, []);
+      let extra = createInterface(prefix, suffix, `${name}_${key}`, value, [], bucketIds);
       extras.push(extra);
       result = `${name}_${key}` + suffix;
       break;
@@ -180,17 +193,22 @@ function createPropertyValue(
       break;
 
     case "relation":
-      if (!value.bucketId) {
-        throw Error(`Related bucket must be provided for ${key} field of ${name}.`);
+      if (!bucketIds.includes(value.bucketId)) {
+        throw Error(`Related bucket '${value.bucketId}' does not exist.`);
       }
 
-      let relatedBucketName = getBucketName(value.bucketId);
-      result = prefix == Prefix.Type ? relatedBucketName : "String";
-      result = value.relationType == "onetoone" ? result : `[${result}]`;
+      result = prefix == Prefix.Type ? getBucketName(value.bucketId) : "String";
+
+      if (value.relationType == "onetomany") {
+        result = `[${result}]`;
+      } else if (value.relationType != "onetoone") {
+        throw Error(`Unknown relation type for '${key}' field of ${name}.`);
+      }
+
       break;
 
     default:
-      throw Error(`Unknown type ${value.type} on ${key} field of ${name}.`);
+      throw Error(`Unknown type '${value.type}' on '${key}' field of ${name}.`);
   }
 
   if (isRequired && prefix == Prefix.Input) {

--- a/stacks/api/bucket/test/bucket.schema.resolver.spec.ts
+++ b/stacks/api/bucket/test/bucket.schema.resolver.spec.ts
@@ -245,7 +245,7 @@ describe("Bucket Schema Resolver", () => {
       expect(validator.registerUriResolver).toHaveBeenCalledTimes(1);
       expect(validator.registerUriResolver).toEqual(jasmine.any(Function));
 
-      expect(validator.registerKeyword).toHaveBeenCalledTimes(1);
+      expect(validator.registerKeyword).toHaveBeenCalledTimes(2);
       expect(validator.registerKeyword.calls.first().args[0]).toEqual(
         "default",
         "should work when custom default keyword registered "

--- a/stacks/api/bucket/test/graphql/schema.spec.ts
+++ b/stacks/api/bucket/test/graphql/schema.spec.ts
@@ -75,7 +75,7 @@ describe("Schema", () => {
 
     it("should create schema for bucket", () => {
       bucket.required = ["title"];
-      let schema = createSchema(bucket, staticTypes);
+      let schema = createSchema(bucket, staticTypes, []);
 
       expect(format(schema)).toEqual(
         format(
@@ -111,7 +111,7 @@ describe("Schema", () => {
         }
       };
 
-      let schema = createSchema(bucket, "");
+      let schema = createSchema(bucket, "", []);
       expect(format(schema)).toEqual(
         format(
           `
@@ -152,7 +152,7 @@ describe("Schema", () => {
         }
       };
 
-      let schema = createSchema(bucket, "");
+      let schema = createSchema(bucket, "", []);
 
       expect(format(schema)).toEqual(
         format(
@@ -193,7 +193,7 @@ describe("Schema", () => {
         }
       };
 
-      let schema = createSchema(bucket, "");
+      let schema = createSchema(bucket, "", ["otherid", "anotherid"]);
 
       expect(format(schema)).toEqual(
         format(`
@@ -244,7 +244,7 @@ describe("Schema", () => {
         }
       };
 
-      let schema = createSchema(bucket, "");
+      let schema = createSchema(bucket, "", []);
 
       expect(format(schema)).toEqual(
         format(`


### PR DESCRIPTION
Custom keywords that we registered for schema validation should keep their registration index. The reason of this bug is **default** keyword runs after the **format** keyword cause of bucket schema resolver registered a new default keyword after the format keyword registered.