### PR TITLE
fix(bucket): onetomany relation filtering does not work

### DIFF
--- a/stacks/api/bucket/src/utility.ts
+++ b/stacks/api/bucket/src/utility.ts
@@ -16,7 +16,7 @@ export function findRelations(
   for (const field of Object.keys(schema)) {
     if (isObject(schema[field])) {
       findRelations(schema[field].properties, bucketId, `${path}${field}`, targets);
-    } else if (isRelation(schema[field], bucketId)) {
+    } else if (isDesiredRelation(schema[field], bucketId)) {
       targets.set(`${path}${field}`, schema[field].relationType);
     }
   }
@@ -66,7 +66,8 @@ export function findUpdatedFields(
   for (const field of Object.keys(previousSchema)) {
     if (
       !currentSchema.hasOwnProperty(field) ||
-      currentSchema[field].type != previousSchema[field].type
+      currentSchema[field].type != previousSchema[field].type ||
+      hasRelationChanges(previousSchema[field], currentSchema[field])
     ) {
       updatedFields.push(path ? `${path}.${field}` : field);
       //we dont need to check child keys of this key anymore
@@ -124,12 +125,27 @@ export function isObject(schema: any) {
   return schema.type == "object";
 }
 
-export function isRelation(schema: any, bucketId: string) {
-  return schema.type == "relation" && schema.bucketId == bucketId;
+export function isRelation(schema: any) {
+  return schema.type == "relation";
+}
+
+export function isDesiredRelation(schema: any, bucketId: string) {
+  return isRelation(schema) && schema.bucketId == bucketId;
 }
 
 export function isArray(schema: any) {
   return schema.type == "array";
+}
+
+export function hasRelationChanges(previousSchema: any, currentSchema: any) {
+  if (isRelation(previousSchema) && isRelation(currentSchema)) {
+    return (
+      previousSchema.relationType != currentSchema.relationType ||
+      previousSchema.bucketId != currentSchema.bucketId
+    );
+  }
+
+  return false;
 }
 
 export function filterReviver(k: string, v: string) {

--- a/stacks/api/bucket/test/bucket.controller.spec.ts
+++ b/stacks/api/bucket/test/bucket.controller.spec.ts
@@ -884,5 +884,79 @@ describe("Bucket acceptance", () => {
         }
       ]);
     });
+
+    it("should update scores when scores bucket schema relation type changed", async () => {
+      const updatedScoresBucket = {
+        title: "Scores",
+        description: "Scores bucket",
+        properties: {
+          score: {
+            type: "number",
+            options: {}
+          },
+          user: {
+            type: "relation",
+            bucketId: usersBucket._id,
+            //relation type changes
+            relationType: "onetomany",
+            options: {}
+          },
+          setting: {
+            type: "relation",
+            bucketId: settingsBucket._id,
+            relationType: "onetoone",
+            options: {}
+          }
+        }
+      };
+      await req.put(`/bucket/${scoresBucket._id}`, updatedScoresBucket);
+
+      const {body} = await req.get(`/bucket/${scoresBucket._id}/data`);
+
+      expect(body).toEqual([
+        {
+          _id: score._id,
+          score: 500,
+          setting: setting._id
+        }
+      ]);
+    });
+
+    it("should update scores when scores bucket schema relational bucket changed", async () => {
+      const updatedScoresBucket = {
+        title: "Scores",
+        description: "Scores bucket",
+        properties: {
+          score: {
+            type: "number",
+            options: {}
+          },
+          user: {
+            type: "relation",
+            //relational bucket changes
+            bucketId: settingsBucket._id,
+            relationType: "onetoone",
+            options: {}
+          },
+          setting: {
+            type: "relation",
+            bucketId: settingsBucket._id,
+            relationType: "onetoone",
+            options: {}
+          }
+        }
+      };
+      await req.put(`/bucket/${scoresBucket._id}`, updatedScoresBucket);
+
+      const {body} = await req.get(`/bucket/${scoresBucket._id}/data`);
+
+      expect(body).toEqual([
+        {
+          _id: score._id,
+          score: 500,
+          setting: setting._id
+        }
+      ]);
+    });
   });
 });

--- a/stacks/api/bucket/test/utility.spec.ts
+++ b/stacks/api/bucket/test/utility.spec.ts
@@ -5,9 +5,9 @@ import {
   isArray,
   findUpdatedFields,
   getUpdateParams,
-  provideLanguageChangeUpdater
+  provideLanguageChangeUpdater,
+  isDesiredRelation
 } from "@spica-server/bucket/src/utility";
-import {ChangeKind} from "../history/differ";
 
 describe("Utilities", () => {
   it("should check whether schema is object or not", () => {
@@ -28,12 +28,12 @@ describe("Utilities", () => {
       type: "relation",
       bucketId: "id1"
     };
-    expect(isRelation(schema, "id1")).toEqual(true);
+    expect(isDesiredRelation(schema, "id1")).toEqual(true);
 
-    expect(isRelation(schema, "id2")).toEqual(false);
+    expect(isDesiredRelation(schema, "id2")).toEqual(false);
 
     schema.type = "object";
-    expect(isRelation(schema, "id1")).toEqual(false);
+    expect(isDesiredRelation(schema, "id1")).toEqual(false);
   });
 
   it("should check whether schema is array or not", () => {
@@ -129,6 +129,16 @@ describe("Utilities", () => {
               type: "string"
             }
           }
+        },
+        relation_type_updated: {
+          type: "relation",
+          bucketId: "test_bucket",
+          relationType: "onetoone"
+        },
+        relation_bucketId_updated: {
+          type: "relation",
+          bucketId: "bucketid",
+          relationType: "onetoone"
         }
       }
     };
@@ -174,6 +184,16 @@ describe("Utilities", () => {
         },
         nested_root_updated: {
           type: "number"
+        },
+        relation_type_updated: {
+          type: "relation",
+          bucketId: "test_bucket",
+          relationType: "onetomany"
+        },
+        relation_bucketId_updated: {
+          type: "relation",
+          bucketId: "newbucketid",
+          relationType: "onetoone"
         }
       }
     };
@@ -195,7 +215,10 @@ describe("Utilities", () => {
       "root_updated",
 
       "nested_root_removed",
-      "nested_root_updated"
+      "nested_root_updated",
+
+      "relation_type_updated",
+      "relation_bucketId_updated"
     ]);
   });
 

--- a/stacks/spica/src/bucket/components/filter/filter.component.spec.ts
+++ b/stacks/spica/src/bucket/components/filter/filter.component.spec.ts
@@ -162,13 +162,27 @@ describe("FilterComponent", () => {
       });
     });
 
-    it("should generate the filter with relation", () => {
+    it("should generate the filter for onetoone relation", () => {
+      fixture.componentInstance.schema.properties.test2["relationType"] = "onetoone";
       fixture.componentInstance.property = "test2";
       fixture.componentInstance.value = "anobjectid";
       fixture.debugElement.query(By.css("button:first-of-type")).nativeElement.click();
       fixture.detectChanges();
       expect(fixture.componentInstance.filter).toEqual({
         "test2._id": "anobjectid"
+      });
+    });
+
+    it("should generate the filter for onetomany relation", () => {
+      fixture.componentInstance.schema.properties.test2["relationType"] = "onetomany";
+      fixture.componentInstance.property = "test2";
+      fixture.componentInstance.value = ["anobjectid"];
+      fixture.debugElement.query(By.css("button:first-of-type")).nativeElement.click();
+      fixture.detectChanges();
+      expect(fixture.componentInstance.filter).toEqual({
+        "test2._id": {
+          $in: ["anobjectid"]
+        }
       });
     });
 

--- a/stacks/spica/src/bucket/components/filter/filter.component.ts
+++ b/stacks/spica/src/bucket/components/filter/filter.component.ts
@@ -43,7 +43,12 @@ export class FilterComponent implements OnChanges {
 
   apply() {
     if (this.properties[this.property].type == "relation") {
-      this.filter = {[`${this.property}._id`]: this.value};
+      this.filter = {
+        [`${this.property}._id`]:
+          this.properties[this.property]["relationType"] == "onetomany"
+            ? {$in: this.value}
+            : this.value
+      };
     } else if (this.properties[this.property].type == "date") {
       this.filter = {
         [this.property]: {


### PR DESCRIPTION
Also, this pr includes additional changes that will update bucket documents when bucket schema relational field **bucketId** or **relationType** updated.