### PR TITLE
fix(storage): refresh button does not work

### DIFF
--- a/stacks/spica/src/storage/components/image-editor/image-editor.component.html
+++ b/stacks/spica/src/storage/components/image-editor/image-editor.component.html
@@ -12,9 +12,21 @@
     <button mat-icon-button (click)="rotate('right')" title="Rotate Right">
       <mat-icon>rotate_right</mat-icon>
     </button>
-    <button mat-icon-button (click)="doneCropping()" title="Done">
-      <mat-icon>check</mat-icon>
-    </button>
+    <ng-container *matSave="$save | async; let state" [ngSwitch]="state">
+      <button mat-icon-button [disabled]="state == 'saving'" (click)="doneCropping()" title="Done">
+        <mat-icon *ngSwitchDefault>save</mat-icon>
+        <mat-progress-spinner
+          class="save-spinner"
+          *ngSwitchCase="'saving'"
+          [diameter]="18"
+          color="primary"
+          mode="indeterminate"
+        ></mat-progress-spinner>
+        <mat-icon *ngSwitchCase="'saved'">done</mat-icon>
+        <mat-icon *ngSwitchCase="'failed'">clear</mat-icon>
+      </button>
+    </ng-container>
+
     <span class="scaleSlider">
       <mat-label>Scale Percentage</mat-label>
       <mat-slider [thumbLabel]="true" [(ngModel)]="scale" [max]="150" [color]="'warn'">

--- a/stacks/spica/src/storage/components/image-editor/image-editor.component.scss
+++ b/stacks/spica/src/storage/components/image-editor/image-editor.component.scss
@@ -14,4 +14,8 @@
   img {
     max-width: 100%; /* This rule is very important, please do not ignore this! */
   }
+
+  mat-progress-spinner.save-spinner {
+    margin: auto;
+  }
 }

--- a/stacks/spica/src/storage/components/image-editor/image-editor.component.ts
+++ b/stacks/spica/src/storage/components/image-editor/image-editor.component.ts
@@ -3,6 +3,9 @@ import {MatDialogRef, MAT_DIALOG_DATA} from "@angular/material/dialog";
 import {CropperComponent} from "angular-cropperjs";
 import {Storage} from "../../interfaces/storage";
 import {StorageService} from "../../storage.service";
+import {Observable, of, BehaviorSubject} from "rxjs";
+import {SavingState} from "@spica-client/material";
+import {tap, take} from "rxjs/operators";
 
 @Component({
   selector: "storage-image-editor",
@@ -28,6 +31,8 @@ export class ImageEditorComponent implements OnInit {
 
   private _cropperRes = {width: 0, height: 0};
 
+  $save: BehaviorSubject<SavingState> = new BehaviorSubject(SavingState.Pristine);
+
   constructor(
     private storageService: StorageService,
     private dialogRef: MatDialogRef<ImageEditorComponent>,
@@ -46,9 +51,11 @@ export class ImageEditorComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.storageService.getOne(this.data._id).subscribe(storage => {
-      this.storage = storage;
-    });
+    this.storageService
+      .getOne(this.data._id)
+      .pipe(tap(() => this.$save.next(SavingState.Pristine)))
+      .toPromise()
+      .then(storage => (this.storage = storage));
   }
 
   cropperReady() {
@@ -77,6 +84,7 @@ export class ImageEditorComponent implements OnInit {
   }
 
   doneCropping() {
+    this.$save.next(SavingState.Saving);
     this.scaleImage().toBlob(blob => {
       const file = new File([blob], this.storage.name, {type: blob.type});
       this.storageService
@@ -84,7 +92,9 @@ export class ImageEditorComponent implements OnInit {
         .toPromise()
         .then(() => {
           this.dialogRef.close(this.storage._id);
-        });
+          this.$save.next(SavingState.Saved);
+        })
+        .catch(() => this.$save.next(SavingState.Failed));
     });
   }
 

--- a/stacks/spica/src/storage/pages/index/index.component.html
+++ b/stacks/spica/src/storage/pages/index/index.component.html
@@ -1,4 +1,4 @@
-<mat-toolbar *ngIf="storages$ | async">
+<mat-toolbar>
   <div>
     <h4 class="mat-h4">
       <mat-icon>filter_drama</mat-icon>
@@ -32,7 +32,7 @@
       </mat-menu>
     </button>
 
-    <button mat-button>
+    <button mat-button (click)="clearLastUpdates()">
       <mat-icon>refresh</mat-icon>
       Refresh
     </button>
@@ -63,8 +63,18 @@
   </div>
 </mat-toolbar>
 
+<mat-progress-spinner
+  [style.visibility]="(loading$ | async) ? 'visible' : 'hidden'"
+  class="content-spinner"
+  color="accent"
+  [diameter]="40"
+  mode="indeterminate"
+></mat-progress-spinner>
 <mat-grid-list [cols]="cols" rowHeight="1:1" gutterSize="10px">
-  <mat-grid-tile *ngFor="let storage of storages$ | async; let i = index">
+  <mat-grid-tile
+    [style.visibility]="(loading$ | async) ? 'hidden' : 'visible'"
+    *ngFor="let storage of storages$ | async; let i = index"
+  >
     <mat-card class="mat-elevation-z25">
       <mat-card-content>
         <storage-view

--- a/stacks/spica/src/storage/pages/index/index.component.scss
+++ b/stacks/spica/src/storage/pages/index/index.component.scss
@@ -42,6 +42,10 @@
     }
   }
 
+  mat-progress-spinner.content-spinner {
+    margin: auto;
+  }
+
   mat-grid-list {
     margin: 30px;
     margin-top: -85px;

--- a/stacks/spica/src/storage/pages/index/index.component.spec.ts
+++ b/stacks/spica/src/storage/pages/index/index.component.spec.ts
@@ -133,7 +133,7 @@ describe("Storage/IndexComponent", () => {
   });
 
   describe("actions", () => {
-    it("show navigate edit page", fakeAsync(() => {
+    it("show navigate to the edit page", fakeAsync(() => {
       const openSpy = spyOn(fixture.componentInstance.dialog, "open").and.callThrough();
       fixture.debugElement
         .query(
@@ -151,6 +151,7 @@ describe("Storage/IndexComponent", () => {
       tick(500);
       fixture.detectChanges();
 
+      const lastUpdate = fixture.componentInstance.lastUpdates.get("1");
       expect(openSpy).toHaveBeenCalledTimes(1);
       expect(openSpy).toHaveBeenCalledWith(ImageEditorComponent, {
         maxWidth: "80%",
@@ -162,7 +163,7 @@ describe("Storage/IndexComponent", () => {
           content: {
             type: "image/png"
           },
-          url: "http://example/test.png"
+          url: `http://example/test.png?timestamp=${lastUpdate}`
         }
       });
     }));
@@ -225,6 +226,7 @@ describe("Storage/IndexComponent", () => {
     }));
 
     it("should open preview", () => {
+      const lastUpdate = fixture.componentInstance.lastUpdates.get("1");
       const openSpy = spyOn(fixture.componentInstance.dialog, "open").and.callThrough();
       fixture.debugElement
         .query(
@@ -244,9 +246,21 @@ describe("Storage/IndexComponent", () => {
           content: {
             type: "image/png"
           },
-          url: "http://example/test.png"
+          url: `http://example/test.png?timestamp=${lastUpdate}`
         }
       });
+    });
+
+    it("should clear last update time of objects and call refresh.next", () => {
+      const refreshSpy = spyOn(fixture.componentInstance.refresh, "next");
+
+      expect(fixture.componentInstance.lastUpdates.size).toEqual(3);
+
+      fixture.debugElement.query(By.css("mat-toolbar button:nth-child(2)")).nativeElement.click();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.lastUpdates.size).toEqual(0);
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
     });
 
     describe("sorts", () => {

--- a/stacks/spica/src/storage/storage.module.ts
+++ b/stacks/spica/src/storage/storage.module.ts
@@ -20,7 +20,7 @@ import {MatToolbarModule} from "@angular/material/toolbar";
 import {MatTooltipModule} from "@angular/material/tooltip";
 import {InputModule} from "@spica-client/common";
 import {ACTIVITY_FACTORY} from "@spica-client/core/factories/factory";
-import {MatAwareDialogModule, MatClipboardModule} from "@spica-client/material";
+import {MatAwareDialogModule, MatClipboardModule, MatSaveModule} from "@spica-client/material";
 import {provideActivityFactory} from "@spica-client/storage/providers/activity";
 import {AngularCropperjsModule} from "angular-cropperjs";
 import {ImageEditorComponent} from "./components/image-editor/image-editor.component";
@@ -56,6 +56,7 @@ import {StorageRoutingModule} from "./storage-routing.module";
     MatToolbarModule,
     MatClipboardModule,
     MatMenuModule,
+    MatSaveModule,
     InputModule.withPlacers([
       {
         origin: "string",


### PR DESCRIPTION
Additional changes ;
1- Progress spinner on refreshing the storage objects, paginating to another page and saving the edited image.
2- Cache invalidation updated. It was working for only updated images before these changes. From now, the refresh button will clear the cache for all storage objects.