### PR TITLE
fix(cli): compatibility of creating a project on windows

### DIFF
--- a/stacks/cli/src/commands/project/start.ts
+++ b/stacks/cli/src/commands/project/start.ts
@@ -15,6 +15,13 @@ import {projectName} from "../../validator";
 function streamToBuffer(stream: Stream): Promise<Buffer> {
   return new Promise(resolve => {
     const response = [];
+    if (process.platform.includes("win")) {
+      stream.once("resume", () => {
+        setTimeout(() => {
+          resolve(Buffer.concat(response));
+        }, 2000);
+      });
+    }
     stream.on("data", chunk => response.push(chunk));
     stream.on("end", () => resolve(Buffer.concat(response)));
   });


### PR DESCRIPTION
Couldn't create a project in windows with the new CLI. It was stuck in the "Initiating replication between database containers" part forever.