### PR TITLE
fix(bucket): prevent to define bucket property name that include any non-word character

### DIFF
--- a/stacks/api/bucket/src/graphql/schema.ts
+++ b/stacks/api/bucket/src/graphql/schema.ts
@@ -41,7 +41,7 @@ function validateProperties(
       errors.push({
         target: baseName + "." + key,
         reason:
-          "Name specification must start with an alphabetic character and can not include any non-letter character."
+          "Name specification must start with an alphabetic character and can not include any non-word character."
       });
 
       delete bucket.properties[key];
@@ -71,7 +71,7 @@ function validateDefinition(
   if (definition.enum && !validateEnum(definition.enum)) {
     const reason = !definition.enum.length
       ? "Enum values must contain at least one item."
-      : "Enum values must start with an alphabetic character and can not include any non-letter character.";
+      : "Enum values must start with an alphabetic character and can not include any non-word character.";
     errors.push({
       target: name,
       reason: reason

--- a/stacks/api/bucket/src/schemas/bucket.schema.json
+++ b/stacks/api/bucket/src/schemas/bucket.schema.json
@@ -187,6 +187,9 @@
     },
     "properties": {
       "type": "object",
+      "propertyNames": {
+        "pattern": "^\\w*$"
+      },
       "patternProperties": {
         "": {
           "allOf": [

--- a/stacks/api/bucket/test/graphql/graphql.spec.ts
+++ b/stacks/api/bucket/test/graphql/graphql.spec.ts
@@ -1760,7 +1760,7 @@ describe("GraphQLController", () => {
               bucketId: "000000000000000000000000",
               relationType: "onetomany"
             },
-            "123asd?qwe*": {
+            "3dmodels": {
               type: "color"
             },
             invalid_enums: {
@@ -1768,7 +1768,7 @@ describe("GraphQLController", () => {
               enum: ["?invalid*", "valid"]
             }
           },
-          required: ["relation_field", "123asd?qwe*", "invalid_enums"]
+          required: ["relation_field", "3dmodels", "invalid_enums"]
         })
         .then(r => r.body);
       bucketName = getBucketName(bucket._id);
@@ -1796,14 +1796,14 @@ describe("GraphQLController", () => {
           reason: "Related bucket '000000000000000000000000' does not exist."
         },
         {
-          target: `${bucketName}.123asd?qwe*`,
+          target: `${bucketName}.3dmodels`,
           reason:
-            "Name specification must start with an alphabetic character and can not include any non-letter character."
+            "Name specification must start with an alphabetic character and can not include any non-word character."
         },
         {
           target: `${bucketName}.invalid_enums`,
           reason:
-            "Enum values must start with an alphabetic character and can not include any non-letter character."
+            "Enum values must start with an alphabetic character and can not include any non-word character."
         }
       ]);
 

--- a/stacks/api/bucket/test/graphql/schema.spec.ts
+++ b/stacks/api/bucket/test/graphql/schema.spec.ts
@@ -48,7 +48,7 @@ describe("Schema", () => {
           {
             target: "Bucket_id.123invalid,name?*.",
             reason:
-              "Name specification must start with an alphabetic character and can not include any non-letter character."
+              "Name specification must start with an alphabetic character and can not include any non-word character."
           }
         ]);
       });
@@ -77,7 +77,7 @@ describe("Schema", () => {
           {
             target: "Bucket_id.shapes",
             reason:
-              "Enum values must start with an alphabetic character and can not include any non-letter character."
+              "Enum values must start with an alphabetic character and can not include any non-word character."
           }
         ]);
       });

--- a/stacks/spica/src/bucket/pages/add-field-modal/add-field-modal.component.html
+++ b/stacks/spica/src/bucket/pages/add-field-modal/add-field-modal.component.html
@@ -176,9 +176,13 @@
         "
         ngModel
         required
+        pattern="^\w*$"
       />
       <mat-error *ngIf="pnm?.errors?.required">
         Property name is required.
+      </mat-error>
+      <mat-error *ngIf="pnm?.errors?.pattern">
+        Property name can not include any non-word character.
       </mat-error>
     </mat-form-field>
     <button


### PR DESCRIPTION
@akhnos @TolgaYigit We should check and update our projects that include non-word bucket property name before merging this PR.