### PR TITLE
refactor(function): batching settings and devkit/database connection 

### DIFF
--- a/stacks/api/function/scheduler/src/scheduler.ts
+++ b/stacks/api/function/scheduler/src/scheduler.ts
@@ -217,6 +217,17 @@ export class Scheduler implements OnModuleInit, OnModuleDestroy {
       worker.attach(stdout, stderr);
 
       const timeoutInSeconds = Math.min(this.options.timeout, event.target.context.timeout);
+
+      if (target.context.batch && !this.timeouts.has(workerId)) {
+        this.timeouts.set(
+          workerId,
+          setTimeout(() => {
+            console.log(`worker ${workerId} is shutting down..`);
+            this.batching.delete(workerId);
+          }, timeoutInSeconds * 1000 - 1000)
+        );
+      }
+
       this.timeouts.set(
         event.id,
         setTimeout(() => {
@@ -300,6 +311,7 @@ export class Scheduler implements OnModuleInit, OnModuleDestroy {
           : ""
       }
     });
+
     worker.once("exit", () => this.lostWorker(id));
     this.pool.set(id, worker);
   }

--- a/stacks/api/function/src/schema/enqueuer.resolver.ts
+++ b/stacks/api/function/src/schema/enqueuer.resolver.ts
@@ -57,11 +57,11 @@ export function generate({body}: {body: Function}) {
                     properties: {
                       limit: {
                         type: "number",
-                        minimum: 1
+                        default: Number.MAX_SAFE_INTEGER
                       },
                       deadline: {
                         type: "number",
-                        minimum: 1
+                        default: Number.MAX_SAFE_INTEGER
                       }
                     }
                   },

--- a/stacks/api/function/src/schema/function.json
+++ b/stacks/api/function/src/schema/function.json
@@ -22,7 +22,8 @@
       "default": 100
     },
     "timeout": {
-      "type": "number"
+      "type": "number",
+      "minimum": 2
     },
     "language": {
       "type": "string",

--- a/stacks/spica/src/function/interface.ts
+++ b/stacks/spica/src/function/interface.ts
@@ -39,10 +39,7 @@ export interface Trigger extends TriggerDescription {
 export interface TriggerDescription<T = any> {
   type: string;
   active?: boolean;
-  batch?: {
-    deadline: number;
-    limit: number;
-  };
+  batch?: any;
   options: T;
 }
 

--- a/stacks/spica/src/function/pages/add/add.component.html
+++ b/stacks/spica/src/function/pages/add/add.component.html
@@ -200,7 +200,7 @@
               thumbLabel
               [displayWith]="formatTimeout"
               tickInterval="auto"
-              min="1"
+              min="2"
               [max]="timeout"
               [ngModel]="function.timeout || timeout"
               (ngModelChange)="function.timeout = $event"
@@ -448,47 +448,17 @@
                 [matAwareDialog]="{
                   title: 'IMPORTANT CONFIRMATION! PLEASE READ CAREFULLY',
                   templateOrDescription:
-                    'You can enable batching to run multiple process in the same worker. This action will
-                share memory in each process. To enable batching, you have to set \'Deadline\' (seconds
-                to wait after each process) and \'Maximum batch amount\' (total process count for
-                batching). We recommend \'Deadline\' to be less than 10 seconds and \'Maximum batch
-                amount\' to be less than 100 generally.',
+                    'By default, each process is running on the fresh workers parallelly. You can enable batching to run multiple processes in the same worker. This action will share memory in each process but keep in mind that will may cause to long process queue.',
                   answer: '',
                   noAnswer: true
                 }"
+                [matAwareDialogDisabled]="batching"
                 (cancel)="batching = false"
                 [(ngModel)]="batching"
                 name="batching"
                 labelPosition="before"
                 >Batching
               </mat-slide-toggle>
-
-              <mat-form-field *ngIf="batching">
-                <mat-label>Deadline (s)</mat-label>
-                <input
-                  matInput
-                  type="number"
-                  placeholder="Deadline"
-                  #nameModel="ngModel"
-                  [min]="batching ? 1 : 0"
-                  [(ngModel)]="batchingDeadline"
-                  name="deadline"
-                  [required]="batching"
-                />
-              </mat-form-field>
-              <mat-form-field *ngIf="batching">
-                <mat-label>Maximum batch amount</mat-label>
-                <input
-                  matInput
-                  type="number"
-                  placeholder="Amount"
-                  #nameModel="ngModel"
-                  [min]="batching ? 2 : 0"
-                  [(ngModel)]="maxBatchCount"
-                  name="limit"
-                  [required]="batching"
-                />
-              </mat-form-field>
             </div>
           </mat-list-item>
         </div>

--- a/stacks/spica/src/function/pages/add/add.component.ts
+++ b/stacks/spica/src/function/pages/add/add.component.ts
@@ -89,10 +89,6 @@ export class AddComponent implements OnInit, OnDestroy {
 
   triggersEditMode = [];
 
-  batchingDeadline: number = 0;
-
-  maxBatchCount: number = 0;
-
   batching: boolean = false;
 
   browserFullscreenKeywords = {
@@ -311,8 +307,6 @@ export class AddComponent implements OnInit, OnDestroy {
 
   resetBatchOptions() {
     this.batching = false;
-    this.maxBatchCount = 0;
-    this.batchingDeadline = 0;
   }
 
   ngOnInit() {
@@ -341,8 +335,6 @@ export class AddComponent implements OnInit, OnDestroy {
             this.triggersEditMode[index] = false;
             if (trigger.batch) {
               this.batching = true;
-              this.maxBatchCount = Math.max(this.maxBatchCount, trigger.batch.limit);
-              this.batchingDeadline = Math.max(this.batchingDeadline, trigger.batch.deadline);
             }
           }
           this.getDependencies();
@@ -435,10 +427,7 @@ export class AddComponent implements OnInit, OnDestroy {
 
     for (const trigger of this.function.triggers) {
       if (this.batching) {
-        trigger.batch = {
-          deadline: this.batchingDeadline,
-          limit: this.maxBatchCount
-        };
+        trigger.batch = {};
       } else {
         delete trigger.batch;
       }


### PR DESCRIPTION
We implemented new logic to the devkit database package that closes the database connection a second before function timeout. This implementation leads the worker to can not perform any action about the database in this phase. Therefore, we marked these kinds of workers as unable to run the process, hence the process will be assigned to the next worker. One of the other requirements for this implementation was the batching deadline and limit count must not be reached before function timeout. Therefore, we set these variables maximum integer as default and remove these inputs from the client.