### PR TITLE
feat(dashboard): improve card component functionality 

### DIFF
--- a/stacks/api/function/queue/node/BUILD.bazel
+++ b/stacks/api/function/queue/node/BUILD.bazel
@@ -10,6 +10,7 @@ ts_library(
         "firehose.ts",
         "http.ts",
         "index.ts",
+        "parser.ts",
     ],
     module_name = "@spica-server/function/queue/node",
     deps = [
@@ -17,5 +18,6 @@ ts_library(
         "@npm//@grpc/grpc-js",
         "@npm//@types/node",
         "@npm//google-protobuf",
+        "@npm//qs"
     ],
 )

--- a/stacks/api/function/queue/node/BUILD.bazel
+++ b/stacks/api/function/queue/node/BUILD.bazel
@@ -18,6 +18,6 @@ ts_library(
         "@npm//@grpc/grpc-js",
         "@npm//@types/node",
         "@npm//google-protobuf",
-        "@npm//qs"
+        "@npm//qs",
     ],
 )

--- a/stacks/api/function/queue/node/http.ts
+++ b/stacks/api/function/queue/node/http.ts
@@ -1,5 +1,6 @@
 import {Http} from "@spica-server/function/queue/proto";
 import * as grpc from "@grpc/grpc-js";
+import {parseBody} from "./parser";
 
 export class HttpQueue {
   private client: any;
@@ -92,10 +93,7 @@ export class Request {
     }
 
     if (req.body) {
-      this.body = req.body;
-      if (this.headers.get("content-type") == "application/json") {
-        this.body = JSON.parse(Buffer.from(req.body).toString());
-      }
+      this.body = parseBody(req.body, this.headers.get("content-type"));
     }
   }
 }

--- a/stacks/api/function/queue/node/index.ts
+++ b/stacks/api/function/queue/node/index.ts
@@ -2,3 +2,4 @@ export * from "./database";
 export * from "./event";
 export * from "./http";
 export * from "./firehose";
+export * from "./parser";

--- a/stacks/api/function/queue/node/parser.ts
+++ b/stacks/api/function/queue/node/parser.ts
@@ -1,0 +1,156 @@
+const qs = require("qs");
+
+export function parseBody(raw: Uint8Array, contentTypeHeader: string | string[] = "") {
+  if (contentTypeHeader == "application/json") {
+    return JSON.parse(Buffer.from(raw).toString());
+  } else if (contentTypeHeader == "application/x-www-form-urlencoded") {
+    return qs.parse(Buffer.from(raw).toString());
+  } else if ((contentTypeHeader as string).startsWith("multipart/form-data")) {
+    return parseMultipartFormdata(Buffer.from(raw), contentTypeHeader as string);
+  }
+  return raw;
+}
+
+/**
+ * Multipart Parser (Finite State Machine)
+ * usage:
+ * const multipart = require('./multipart.js');
+ * const body = multipart.DemoData(); 							   // raw body
+ * const body = Buffer.from(event['body-json'].toString(),'base64'); // AWS case
+ * const boundary = multipart.getBoundary(event.params.header['content-type']);
+ * const parts = multipart.Parse(body,boundary);
+ * each part is:
+ * { filename: 'A.txt', type: 'text/plain', data: <Buffer 41 41 41 41 42 42 42 42> }
+ *  or { name: 'key', data: <Buffer 41 41 41 41 42 42 42 42> }
+ */
+
+export function parseMultipartFormdata(multipartBodyBuffer: Buffer, contentTypeHeader: string) {
+  //  read the boundary from the content-type header sent by the http client
+  //  this value may be similar to:
+  //  'multipart/form-data; boundary=----WebKitFormBoundaryvm5A9tzU1ONaGP5B',
+  const getBoundary = header => {
+    const items = header.split(";");
+    if (items) {
+      for (let i = 0; i < items.length; i++) {
+        const item = new String(items[i]).trim();
+        if (item.indexOf("boundary") >= 0) {
+          const k = item.split("=");
+          return new String(k[1]).trim();
+        }
+      }
+    }
+    return "";
+  };
+
+  const process = part => {
+    // will transform this object:
+    // { header: 'Content-Disposition: form-data; name="uploads[]"; filename="A.txt"',
+    // info: 'Content-Type: text/plain',
+    // part: 'AAAABBBB' }
+    // into this one:
+    // { filename: 'A.txt', type: 'text/plain', data: <Buffer 41 41 41 41 42 42 42 42> }
+    const obj = str => {
+      const k = str.split("=");
+      const a = k[0].trim();
+
+      const b = JSON.parse(k[1].trim());
+      const o = {};
+      Object.defineProperty(o, a, {
+        value: b,
+        writable: true,
+        enumerable: true,
+        configurable: true
+      });
+      return o;
+    };
+    const header = part.header.split(";");
+
+    const filenameData = header[2];
+    let input = {};
+    if (filenameData) {
+      input = obj(filenameData);
+      const contentType = part.info.split(":")[1].trim();
+      Object.defineProperty(input, "type", {
+        value: contentType,
+        writable: true,
+        enumerable: true,
+        configurable: true
+      });
+    } else {
+      Object.defineProperty(input, "name", {
+        value: header[1].split("=")[1].replace(/"/g, ""),
+        writable: true,
+        enumerable: true,
+        configurable: true
+      });
+    }
+
+    Object.defineProperty(input, "data", {
+      value: Buffer.from(part.part),
+      writable: true,
+      enumerable: true,
+      configurable: true
+    });
+    return input;
+  };
+
+  const boundary = getBoundary(contentTypeHeader);
+
+  let lastline = "";
+  let header = "";
+  let info = "";
+  let state = 0;
+  let buffer = [];
+  const allParts = [];
+
+  for (let i = 0; i < multipartBodyBuffer.length; i++) {
+    const oneByte = multipartBodyBuffer[i];
+    const prevByte = i > 0 ? multipartBodyBuffer[i - 1] : null;
+    const newLineDetected = oneByte === 0x0a && prevByte === 0x0d ? true : false;
+    const newLineChar = oneByte === 0x0a || oneByte === 0x0d ? true : false;
+
+    if (!newLineChar) lastline += String.fromCharCode(oneByte);
+
+    if (0 === state && newLineDetected) {
+      if ("--" + boundary === lastline) {
+        state = 1;
+      }
+      lastline = "";
+    } else if (1 === state && newLineDetected) {
+      header = lastline;
+      state = 2;
+      if (header.indexOf("filename") === -1) {
+        state = 3;
+      }
+      lastline = "";
+    } else if (2 === state && newLineDetected) {
+      info = lastline;
+      state = 3;
+      lastline = "";
+    } else if (3 === state && newLineDetected) {
+      state = 4;
+      buffer = [];
+      lastline = "";
+    } else if (4 === state) {
+      if (lastline.length > boundary.length + 4) lastline = ""; // mem save
+      if ("--" + boundary === lastline) {
+        const j = buffer.length - lastline.length;
+        const part = buffer.slice(0, j - 1);
+        const p = {header: header, info: info, part: part};
+
+        allParts.push(process(p));
+        buffer = [];
+        lastline = "";
+        state = 5;
+        header = "";
+        info = "";
+      } else {
+        buffer.push(oneByte);
+      }
+      if (newLineDetected) lastline = "";
+    } else if (5 === state) {
+      if (newLineDetected) state = 1;
+    }
+  }
+  return allParts;
+}

--- a/stacks/api/function/runtime/test/node/BUILD.bazel
+++ b/stacks/api/function/runtime/test/node/BUILD.bazel
@@ -43,6 +43,7 @@ ts_library(
         "//stacks/api/function/runtime/testing",
         "@npm//@types/jasmine",
         "@npm//@types/node",
+        "@npm//qs",
     ],
 )
 

--- a/stacks/spica/packages/common/input/components/multiselect/multiselect.component.scss
+++ b/stacks/spica/packages/common/input/components/multiselect/multiselect.component.scss
@@ -1,3 +1,6 @@
-mat-form-field {
-  width: 100%;
+:host {
+  display: inline-block;
+  mat-form-field {
+    width: 100%;
+  }
 }

--- a/stacks/spica/src/dashboard/components/card/card.component.html
+++ b/stacks/spica/src/dashboard/components/card/card.component.html
@@ -20,8 +20,10 @@
     target="_blank"
     enctype="multipart/form-data"
   >
+    <!--enctype="application/x-www-form-urlencoded"-->
     <mat-card-content class="inputs">
       <ng-container *ngFor="let input of componentData.inputs">
+        <input type="file" name="test">
         <span [name]="input.key" [inputPlacer]="input" [(ngModel)]="input.value">
           <input type="hidden" [name]="input.key" [value]="input.value" />
         </span>

--- a/stacks/spica/src/dashboard/components/card/card.component.html
+++ b/stacks/spica/src/dashboard/components/card/card.component.html
@@ -18,25 +18,41 @@
     [action]="componentData.button.target"
     [method]="componentData.button.method"
     target="_blank"
-    enctype="multipart/form-data"
+    [enctype]="componentData.button.enctype"
   >
-    <!--enctype="application/x-www-form-urlencoded"-->
     <mat-card-content class="inputs">
       <ng-container *ngFor="let input of componentData.inputs">
-        <input type="file" name="test">
-        <span [name]="input.key" [inputPlacer]="input" [(ngModel)]="input.value">
+        <button
+          *ngIf="input.type == 'file'"
+          mat-stroked-button
+          class="file-selector"
+          (click)="fileSelector.click()"
+        >
+          <mat-icon>file_upload</mat-icon>
+          {{ (fileSelector?.files)[0]?.name || input.title || "Select a file" }}
+          <!--change event triggers file name update even if it's undefined-->
+          <input
+            hidden
+            #fileSelector
+            type="file"
+            [name]="input.key"
+            [value]="input.value"
+            (change)="(undefined)"
+            [accept]="input.accept"
+          />
+        </button>
+
+        <span
+          *ngIf="input.type != 'file'"
+          [name]="input.key"
+          [inputPlacer]="input"
+          [(ngModel)]="input.value"
+        >
           <input type="hidden" [name]="input.key" [value]="input.value" />
         </span>
       </ng-container>
     </mat-card-content>
     <mat-card-actions>
-      <!-- <button
-        [color]="componentData.button.color"
-        mat-flat-button
-        (click)="onSubmit(form, componentData.button, componentData.inputs)"
-      >
-        {{ componentData.button.title }}
-      </button> -->
       <button [color]="componentData.button.color" mat-flat-button (click)="form.submit()">
         {{ componentData.button.title }}
       </button>

--- a/stacks/spica/src/dashboard/components/card/card.component.html
+++ b/stacks/spica/src/dashboard/components/card/card.component.html
@@ -18,6 +18,7 @@
     [action]="componentData.button.target"
     [method]="componentData.button.method"
     target="_blank"
+    enctype="multipart/form-data"
   >
     <mat-card-content class="inputs">
       <ng-container *ngFor="let input of componentData.inputs">
@@ -27,11 +28,14 @@
       </ng-container>
     </mat-card-content>
     <mat-card-actions>
-      <button
+      <!-- <button
         [color]="componentData.button.color"
         mat-flat-button
         (click)="onSubmit(form, componentData.button, componentData.inputs)"
       >
+        {{ componentData.button.title }}
+      </button> -->
+      <button [color]="componentData.button.color" mat-flat-button (click)="form.submit()">
         {{ componentData.button.title }}
       </button>
     </mat-card-actions>

--- a/stacks/spica/src/dashboard/components/card/card.component.scss
+++ b/stacks/spica/src/dashboard/components/card/card.component.scss
@@ -15,7 +15,17 @@ button.refresh {
 }
 
 mat-card-content.inputs {
-  > span {
+  > span,
+  button {
     margin-right: 5px;
+  }
+
+  button.file-selector {
+    height: 44px;
+    width: 200px;
+
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+    display: inline-block;
   }
 }

--- a/stacks/spica/src/dashboard/components/card/card.component.spec.ts
+++ b/stacks/spica/src/dashboard/components/card/card.component.spec.ts
@@ -1,4 +1,4 @@
-import {ComponentFixture, fakeAsync, TestBed, tick} from "@angular/core/testing";
+import {ComponentFixture, TestBed} from "@angular/core/testing";
 import {of} from "rxjs";
 import {MatCardModule} from "@angular/material/card";
 import {MatIconModule} from "@angular/material/icon";
@@ -6,10 +6,9 @@ import {MatButtonModule} from "@angular/material/button";
 import {InputModule} from "@spica-client/common";
 import {NoopAnimationsModule} from "@angular/platform-browser/animations";
 import {CardComponent} from "./card.component";
-import {FormsModule, NgModel} from "@angular/forms";
-import {By} from "@angular/platform-browser";
-import {HttpParams} from "@angular/common/http";
+import {FormsModule} from "@angular/forms";
 
+// @TODO: put here better tests after found a way to check the request which created by html form (queryParams, body etc.)
 describe("CardComponent", () => {
   let component: CardComponent;
   let fixture: ComponentFixture<CardComponent>;
@@ -66,85 +65,10 @@ describe("CardComponent", () => {
     fixture.detectChanges();
   });
 
-  it("should send default inputs", () => {
-    const inputValues = Array.from(
-      fixture.debugElement.nativeElement.querySelectorAll("mat-card-content.inputs > span > input")
-    ).map((i: any) => i.value);
-
-    expect(inputValues).toEqual(["Cars", "Bestseller car of this year has been announced.."]);
-
+  it("should set form attributes for get request", () => {
     const form = fixture.debugElement.nativeElement.querySelector("form");
-
-    const submitSpy = spyOn(form, "submit");
-
-    fixture.debugElement.nativeElement.querySelector("mat-card-actions > button").click();
-
-    fixture.detectChanges();
-
-    const params = new HttpParams({
-      fromObject: {
-        topic: "Cars",
-        message: "Bestseller car of this year has been announced.."
-      }
-    });
-    const url = window.location.origin + "/dummy_url?" + params.toString();
-
-    expect(submitSpy).toHaveBeenCalledTimes(1);
-    expect(form.action).toEqual(url.toString());
-  });
-
-  it("should send get request", () => {
-    const models = fixture.debugElement
-      .queryAll(By.directive(NgModel))
-      .map(el => el.injector.get(NgModel));
-
-    const topic = models.find(m => m.name == "topic");
-    const message = models.find(m => m.name == "message");
-
-    topic.control.setValue("Health");
-    message.control.setValue("5 Tips for burning calories");
-
-    fixture.detectChanges();
-
-    const form = fixture.debugElement.nativeElement.querySelector("form");
-    const submitSpy = spyOn(form, "submit");
-
-    fixture.debugElement.nativeElement.querySelector("mat-card-actions > button").click();
-
-    fixture.detectChanges();
-
-    expect(submitSpy).toHaveBeenCalledTimes(1);
-
-    const params = new HttpParams({
-      fromObject: {
-        topic: "Health",
-        message: "5 Tips for burning calories"
-      }
-    });
-    const url = window.location.origin + "/dummy_url?" + params.toString();
-
-    expect(form.action).toEqual(url.toString());
+    expect(form.action).toEqual(window.location.origin + "/dummy_url");
     expect(form.method).toEqual("get");
-  });
-
-  it("should send post request", () => {
-    dashboardComponent.button.method = "post";
-
-    fixture.detectChanges();
-
-    const models = fixture.debugElement
-      .queryAll(By.directive(NgModel))
-      .map(el => el.injector.get(NgModel));
-
-    const topic = models.find(m => m.name == "topic");
-    const message = models.find(m => m.name == "message");
-
-    topic.control.setValue("Health");
-    message.control.setValue("5 Tips for burning calories");
-
-    fixture.detectChanges();
-
-    const form = fixture.debugElement.nativeElement.querySelector("form");
 
     const submitSpy = spyOn(form, "submit");
 
@@ -153,16 +77,25 @@ describe("CardComponent", () => {
     fixture.detectChanges();
 
     expect(submitSpy).toHaveBeenCalledTimes(1);
+  });
 
-    const params = new HttpParams({
-      fromObject: {
-        topic: "Health",
-        message: "5 Tips for burning calories"
-      }
-    });
-    const url = window.location.origin + "/dummy_url?" + params.toString();
+  it("should set form attributes for post request", () => {
+    dashboardComponent.button.method = "post";
+    dashboardComponent.button.enctype = "multipart/form-data";
 
-    expect(form.action).toEqual(url.toString());
+    fixture.detectChanges();
+
+    const form = fixture.debugElement.nativeElement.querySelector("form");
+    expect(form.action).toEqual(window.location.origin + "/dummy_url");
     expect(form.method).toEqual("post");
+    expect(form.enctype).toEqual("multipart/form-data");
+
+    const submitSpy = spyOn(form, "submit");
+
+    fixture.debugElement.nativeElement.querySelector("mat-card-actions > button").click();
+
+    fixture.detectChanges();
+
+    expect(submitSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/stacks/spica/src/dashboard/components/card/card.component.ts
+++ b/stacks/spica/src/dashboard/components/card/card.component.ts
@@ -11,17 +11,4 @@ export class CardComponent {
   @Input() componentData$: Observable<any>;
 
   @Output() onUpdate: EventEmitter<object> = new EventEmitter();
-
-  onSubmit(form, button, inputs = []) {
-    const query = {};
-    for (const input of inputs) {
-      query[input.key] = input.value;
-    }
-
-    const params = new HttpParams({fromObject: query});
-    const url = button.target + "?" + params.toString();
-    form.action = url;
-
-    form.submit();
-  }
 }

--- a/stacks/spica/src/dashboard/components/card/card.component.ts
+++ b/stacks/spica/src/dashboard/components/card/card.component.ts
@@ -1,4 +1,3 @@
-import {HttpParams} from "@angular/common/http";
 import {Component, EventEmitter, Input, Output} from "@angular/core";
 import {Observable} from "rxjs";
 

--- a/stacks/spica/src/dashboard/dashboard.module.ts
+++ b/stacks/spica/src/dashboard/dashboard.module.ts
@@ -39,6 +39,7 @@ import {OwlDateTimeModule, OwlNativeDateTimeModule} from "@danielmoncada/angular
 import {WelcomeComponent} from "./pages/welcome/welcome.component";
 import {CardComponent} from "./components/card/card.component";
 import {DragDropModule} from "@angular/cdk/drag-drop";
+import {MatProgressSpinnerModule} from "@angular/material/progress-spinner";
 
 @NgModule({
   imports: [
@@ -70,7 +71,8 @@ import {DragDropModule} from "@angular/cdk/drag-drop";
     OwlNativeDateTimeModule,
     MatAwareDialogModule,
     PassportModule.forChild(),
-    DragDropModule
+    DragDropModule,
+    MatProgressSpinnerModule
   ],
   declarations: [
     DashboardComponent,

--- a/stacks/spica/src/dashboard/pages/dashboard-view/dashboard-view.component.html
+++ b/stacks/spica/src/dashboard/pages/dashboard-view/dashboard-view.component.html
@@ -54,7 +54,7 @@
         cdkDragBoundary=".components-container"
       >
         <mat-spinner *ngIf="arePendings[i]" color="accent" diameter="75"></mat-spinner>
-       
+
         <div class="drag-cursor" cdkDragHandle></div>
 
         <div [style.visibility]="arePendings[i] ? 'hidden' : 'visible'">

--- a/stacks/spica/src/dashboard/pages/dashboard-view/dashboard-view.component.html
+++ b/stacks/spica/src/dashboard/pages/dashboard-view/dashboard-view.component.html
@@ -53,28 +53,33 @@
         cdkDrag
         cdkDragBoundary=".components-container"
       >
+        <mat-spinner *ngIf="arePendings[i]" color="accent" diameter="75"></mat-spinner>
+       
         <div class="drag-cursor" cdkDragHandle></div>
-        <dashboard-default
-          *ngIf="defaultTypes.indexOf(component.type) != -1"
-          [componentData$]="componentData$[i]"
-          [type]="component.type"
-          (onUpdate)="onUpdate($event, i)"
-        >
-        </dashboard-default>
-        <dashboard-table
-          *ngIf="component.type == 'table'"
-          [componentData$]="componentData$[i]"
-          [type]="component.type"
-          (onUpdate)="onUpdate($event, i)"
-        >
-        </dashboard-table>
-        <dashboard-card
-          *ngIf="component.type == 'card'"
-          [componentData$]="componentData$[i]"
-          [type]="component.type"
-          (onUpdate)="onUpdate($event, i)"
-        >
-        </dashboard-card>
+
+        <div [style.visibility]="arePendings[i] ? 'hidden' : 'visible'">
+          <dashboard-default
+            *ngIf="defaultTypes.indexOf(component.type) != -1"
+            [componentData$]="componentData$[i]"
+            [type]="component.type"
+            (onUpdate)="onUpdate($event, i)"
+          >
+          </dashboard-default>
+          <dashboard-table
+            *ngIf="component.type == 'table'"
+            [componentData$]="componentData$[i]"
+            [type]="component.type"
+            (onUpdate)="onUpdate($event, i)"
+          >
+          </dashboard-table>
+          <dashboard-card
+            *ngIf="component.type == 'card'"
+            [componentData$]="componentData$[i]"
+            [type]="component.type"
+            (onUpdate)="onUpdate($event, i)"
+          >
+          </dashboard-card>
+        </div>
       </mat-card>
     </div>
   </div>

--- a/stacks/spica/src/dashboard/pages/dashboard-view/dashboard-view.component.scss
+++ b/stacks/spica/src/dashboard/pages/dashboard-view/dashboard-view.component.scss
@@ -54,7 +54,7 @@ div {
           0 3px 14px 2px rgba(0, 0, 0, 0.12);
       }
 
-      mat-spinner{
+      mat-spinner {
         top: calc(50% - 75px);
         margin: auto;
       }

--- a/stacks/spica/src/dashboard/pages/dashboard-view/dashboard-view.component.scss
+++ b/stacks/spica/src/dashboard/pages/dashboard-view/dashboard-view.component.scss
@@ -54,6 +54,11 @@ div {
           0 3px 14px 2px rgba(0, 0, 0, 0.12);
       }
 
+      mat-spinner{
+        top: calc(50% - 75px);
+        margin: auto;
+      }
+
       div.drag-cursor {
         cursor: move;
         width: 100%;


### PR DESCRIPTION
From now, the dashboard card component can send two other content types on post requests. These are `application/x-www-form-urlencoded` and `multipart/form-data`. Also, our function system can pass these content type bodies to users. Check the [code](https://github.com/Davuttrg/spica-asset-export-import/blob/master/function/index.js#L192) for example `multipart/form-data` usage.

We can close [this issue](https://github.com/spica-engine/spica/issues/28) after we merge this pull request.