### PR TITLE
Revert "chore: use pkg_web substitutions instead of custom pkg_stamp"

### DIFF
--- a/stacks/spica/BUILD.bazel
+++ b/stacks/spica/BUILD.bazel
@@ -1,14 +1,25 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_push")
+load("//tools/pkg_stamp:index.bzl", "pkg_stamp")
 load("@build_bazel_rules_nodejs//:index.bzl", "pkg_web")
 
-pkg_web(
-    name = "spica_pkg",
+pkg_stamp(
+    name = "spica_stamp_pkg",
+    srcs = [
+        "//:spica",
+    ],
     substitutions = {
         "0.0.0-PLACEHOLDER": "{BUILD_SCM_VERSION}",
         "COMMIT_HASH_PLACEHOLDER": "{BUILD_SCM_HASH}",
     },
+)
+
+pkg_web(
+    name = "spica_pkg",
+    srcs = [
+        ":spica_stamp_pkg",
+    ],
 )
 
 container_image(
@@ -37,7 +48,7 @@ container_image(
     stamp = True,
     symlinks = {
         "/etc/nginx/nginx.conf": "/container/nginx.conf",
-        "/usr/share/nginx/html": "/spica_pkg/dist/spica",
+        "/usr/share/nginx/html": "/spica_pkg/spica_stamp_pkg/dist/spica",
     },
 )
 


### PR DESCRIPTION
Reverts spica-engine/spica#732