### PR TITLE
fix(passport): list storage resources properly on the policy edit page

### DIFF
--- a/stacks/spica/src/passport/services/policy-services/services.ts
+++ b/stacks/spica/src/passport/services/policy-services/services.ts
@@ -80,7 +80,7 @@ const storageResource = {
   source: "api:/storage",
   primary: "name",
   requiredAction: "storage:index",
-  maps: [paginationMap, asteriskMap("url")]
+  maps: [asteriskMap("url")]
 };
 
 const preferenceResource = {


### PR DESCRIPTION
The storage controller was returning objects with pagination as default. We changed the controller default behavior in previous commits, so the method that handles storage objects with pagination should be removed.