### PR TITLE
fix(tests): close change stream and stop server properly

### DIFF
--- a/libs/database/realtime/src/database.service.ts
+++ b/libs/database/realtime/src/database.service.ts
@@ -62,6 +62,19 @@ export class RealtimeDatabaseService {
     return !!this.findEmitterName(name, options);
   }
 
+  /**
+   * Designed for only tests, don't use it on the production code
+   */
+  private async destroy() {
+    await Promise.all(
+      Array.from(this.emitters).map(([_, emitter]) => {
+        return this.changeStreams.get(emitter.value.collectionName).close();
+      })
+    );
+    this.emitters.clear();
+    this.changeStreams.clear();
+  }
+
   removeEmitter(name: string, options: FindOptions<any>) {
     const emitterName = this.findEmitterName(name, options);
 

--- a/libs/database/testing/src/start.ts
+++ b/libs/database/testing/src/start.ts
@@ -20,7 +20,7 @@ export async function start(topology: "standalone" | "replset") {
   }
 
   global.__CLEANUPCALLBACKS = global.__CLEANUPCALLBACKS || [];
-  global.__CLEANUPCALLBACKS.push(() => mongod.stop());
+  global.__CLEANUPCALLBACKS.push(() => setTimeout(() => mongod.stop(), 1000));
 
   uri = mongod.getUri() + "&retryWrites=false";
 


### PR DESCRIPTION
1- Add delay to MongoDB server stop call to let clients safely disconnect.
2- Close the change stream after subscribers are unsubscribed, and then stop the MongoDB server safely.
