### PR TITLE
build(api): use slim version of node

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -31,6 +31,8 @@ RUN yarn run build:api
 # test app
 FROM tools AS test
 WORKDIR /app
+RUN apt-get update
+RUN apt-get install libcurl4 -y
 COPY --from=deps /app/node_modules ./node_modules
 COPY apps/api ./apps/api
 COPY libs ./libs

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,4 +1,9 @@
-FROM node:22-alpine AS base
+FROM node:22-slim AS base
+
+# install necessary tools
+FROM base AS tools
+RUN apt update
+RUN apt install git -y
 
 # install app deps to nodejs image
 FROM base AS deps
@@ -7,6 +12,7 @@ COPY package.json yarn.lock ./
 COPY apps/api/package.json ./apps/api/package.json
 RUN yarn install --frozen-lockfile
 
+# install app production deps to nodejs image
 FROM base AS deps-production
 WORKDIR /app
 COPY package.json yarn.lock ./
@@ -22,7 +28,8 @@ COPY libs ./libs
 COPY nx.json package.json tsconfig.json yarn.lock ./
 RUN yarn run build:api
 
-FROM base AS test
+# test app
+FROM tools AS test
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY apps/api ./apps/api
@@ -36,7 +43,7 @@ RUN yarn nx run-many -t test --projects=$PROJECTS --exclude=$EXCLUDE
 
 # start app from tools, because app executes many mongodb commands
 # copy deps and build
-FROM base AS runner
+FROM tools AS runner
 WORKDIR /app
 COPY --from=build /app/dist ./dist
 COPY --from=deps-production /app/node_modules ./node_modules

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -2,8 +2,7 @@ FROM node:22-slim AS base
 
 # install necessary tools
 FROM base AS tools
-RUN apt update
-RUN apt install git -y
+RUN apt-get update && apt-get install git -y
 
 # install app deps to nodejs image
 FROM base AS deps
@@ -31,8 +30,7 @@ RUN yarn run build:api
 # test app
 FROM tools AS test
 WORKDIR /app
-RUN apt-get update
-RUN apt-get install libcurl4 -y
+RUN apt-get update && apt-get install libcurl4 -y
 COPY --from=deps /app/node_modules ./node_modules
 COPY apps/api ./apps/api
 COPY libs ./libs

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bullseye AS base
+FROM node:22-alpine AS base
 
 # install app deps to nodejs image
 FROM base AS deps
@@ -19,10 +19,7 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY apps/api ./apps/api
 COPY libs ./libs
-COPY nx.json ./
-COPY package.json ./
-COPY tsconfig.json ./
-COPY yarn.lock ./
+COPY nx.json package.json tsconfig.json yarn.lock ./
 RUN yarn run build:api
 
 FROM base AS test
@@ -30,13 +27,8 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY apps/api ./apps/api
 COPY libs ./libs
-COPY nx.json ./
-COPY package.json ./
-COPY tsconfig.json ./
-COPY yarn.lock ./
-COPY jest.flaky.setup.js ./
-COPY jest.preset.js ./
-COPY jest.setup.js ./
+COPY nx.json package.json tsconfig.json yarn.lock ./
+COPY jest.flaky.setup.js jest.preset.js jest.setup.js ./
 COPY *.env ./
 ARG PROJECTS=""
 ARG EXCLUDE=""


### PR DESCRIPTION
I try to use node:22-alpine to reduce image size, but there are errors in tests because mongodb-memory-server package does not work on this version of node image.