### PR TITLE
refactor: replace Provider usage with direct context value, since the usage will be deprecated in future

### DIFF
--- a/apps/panel/src/contexts/AuthContext.tsx
+++ b/apps/panel/src/contexts/AuthContext.tsx
@@ -91,7 +91,7 @@ export const AuthProvider = ({children}: {children: ReactNode}) => {
     [user, isAuthenticated, login, logout, loading]
   );
 
-  return <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>;
+  return <AuthContext value={contextValue}>{children}</AuthContext>;
 };
 
 export function useAuth() {

--- a/apps/panel/src/contexts/BucketContext.tsx
+++ b/apps/panel/src/contexts/BucketContext.tsx
@@ -334,7 +334,7 @@ export const BucketProvider = ({children}: {children: ReactNode}) => {
     ]
   );
 
-  return <BucketContext.Provider value={contextValue}>{children}</BucketContext.Provider>;
+  return <BucketContext value={contextValue}>{children}</BucketContext>;
 };
 
 export function useBucket() {

--- a/apps/panel/src/contexts/DrawerContext.tsx
+++ b/apps/panel/src/contexts/DrawerContext.tsx
@@ -66,12 +66,12 @@ export const DrawerProvider = ({children}: {children: ReactNode}) => {
   );
 
   return (
-    <DrawerContext.Provider value={contextValue}>
+    <DrawerContext value={contextValue}>
       {children}
       <DrawerShell {...drawerProps} onClose={closeDrawer} isOpen={isOpen}>
         {content}
       </DrawerShell>
-    </DrawerContext.Provider>
+    </DrawerContext>
   );
 };
 


### PR DESCRIPTION
[source](https://react.dev/blog/2024/12/05/react-19#context-as-a-provider)