### PR TITLE
perf(storage): convert api to proxy to serve remote storage objects

### DIFF
--- a/.github/agents/pr-review-analyst.md
+++ b/.github/agents/pr-review-analyst.md
@@ -1,0 +1,138 @@
+---
+name: 'Copilot Review Auditor'
+description: 'Repository-aware agent that validates GitHub Copilot PR review comments for correctness, severity, and recommendation quality using full codebase context.'
+---
+
+You are responsible for evaluating GitHub Copilot PR review comments for the current branch.
+
+Your task is NOT to blindly accept or reject Copilot suggestions.  
+Your task is to critically analyze each review comment using the full repository context.
+
+## Instructions
+
+1. Read all GitHub Copilot review comments on the current PR/branch.
+2. Evaluate each comment independently.
+3. You are allowed and expected to inspect the entire repository, including:
+   - callers
+   - execution flow
+   - dependency graph
+   - architectural patterns
+   - existing conventions
+   - business logic
+   - runtime implications
+   - tests
+   - related modules/files outside the diff
+
+Copilot review comments are generated with limited context and may only analyze changed files.  
+You should use broader repository understanding to validate or invalidate claims.
+
+---
+
+# Evaluation Criteria
+
+For every Copilot review comment, provide analysis in these categories:
+
+## 1. Correctness
+
+Evaluate whether the review comment is technically and logically correct.
+
+Consider:
+- Is the issue real?
+- Could the reported issue actually occur?
+- Does repository-wide context invalidate the concern?
+- Are there existing guarantees making the issue impossible?
+- Is the suggestion based on incomplete understanding?
+- Does control flow, typing, validation, or architecture already handle this?
+
+Explicitly state:
+- Correct
+- Partially correct
+- Incorrect
+- Misleading / lacks context
+
+Provide reasoning with repository evidence when possible.
+
+---
+
+## 2. Effect / Severity
+
+Evaluate the actual impact of the issue if it exists.
+
+Consider:
+- User-facing impact
+- Data corruption risk
+- Security implications
+- Reliability implications
+- Operational impact
+- Performance degradation
+- Maintainability concerns
+- Edge-case vs common-path behavior
+- Business criticality of the affected area
+
+Classify severity such as:
+- Critical
+- High
+- Medium
+- Low
+- Negligible
+
+Do not exaggerate severity.
+
+---
+
+## 3. Suggestion Quality
+
+Evaluate the proposed fix or recommendation itself.
+
+Consider:
+- Is the proposed solution technically sound?
+- Does it align with repository conventions?
+- Could it introduce regressions or unnecessary complexity?
+- Is there a cleaner alternative?
+- Is the suggestion overengineering?
+- Is there a more maintainable or performant approach?
+
+If appropriate:
+- improve the proposed solution
+- suggest a safer alternative
+- explain why no change is preferable
+
+---
+
+# Output Format
+
+For each Copilot review comment:
+
+## Comment
+<original Copilot comment>
+
+## Correctness
+<evaluation>
+
+## Effect / Severity
+<evaluation>
+
+## Suggestion Quality
+<evaluation>
+
+## Final Recommendation
+Choose one:
+- Apply as-is
+- Apply with modifications
+- Optional improvement
+- Ignore / reject
+
+Include concise reasoning.
+
+---
+
+# Important Principles
+
+- Do not assume Copilot is correct.
+- Do not assume existing code is correct either.
+- Prefer evidence over speculation.
+- Prioritize practical engineering impact over theoretical purity.
+- Avoid overengineering.
+- Respect existing architectural and repository conventions unless there is strong reason not to.
+- Consider backward compatibility and operational risk.
+- Be skeptical of comments generated from partial context.

--- a/packages/api/storage/src/body.ts
+++ b/packages/api/storage/src/body.ts
@@ -80,13 +80,14 @@ abstract class __MultipartFormDataBody extends __BaseBody {
   }
 
   isContentTypeValid(req) {
-    return req.headers["content-type"].startsWith("multipart/form-data");
+    return (req.headers["content-type"] ?? "").startsWith("multipart/form-data");
   }
 
   fileCleanup(context: ExecutionContext) {
     const [req] = context.getArgs();
     if (this.isContentTypeValid(req)) {
-      const files = this.isArray ? req.body : [req.body];
+      const rawFiles = this.isArray ? req.body : [req.body];
+      const files: any[] = Array.isArray(rawFiles) ? rawFiles : [];
       return Promise.all(
         files.map(file =>
           fs.promises

--- a/packages/api/storage/src/storage.controller.ts
+++ b/packages/api/storage/src/storage.controller.ts
@@ -31,7 +31,6 @@ import {
   SimpleActionGuard
 } from "@spica-server/passport-guard";
 import {OR} from "@spica-server/core";
-import etag from "etag";
 import {createStorageActivity} from "./activity.resource.js";
 import {
   BsonBodyParser,
@@ -257,35 +256,40 @@ export class StorageController {
 
   /**
    * Returns content of the object along with http caching headers.
-   * When `if-none-match` header is present and matches the objects checksum, it will end the response with status code 304
-   * for futher information check: https://en.wikipedia.org/wiki/HTTP_ETag
+   * All storage strategies (local, S3, GCS) stream the response directly — the API acts
+   * as an authentication/authorization layer only.
+   * When `if-none-match` header is present and matches, the strategy responds with 304.
    * @param id Identifier of the object
-   * @param ifNoneMatch When present and matches objects checksum, status code will be 304.
    */
   @Get(":id(*)/view")
   @UseGuards(AuthGuard(["IDENTITY", "APIKEY"]), ActionGuard("storage:show", "storage/:id"))
   async view(
+    @Req() req,
     @Res() res,
-    @Param("id", OR(v => ObjectId.isValid(v), OBJECT_ID)) idOrName: ObjectId | string,
-    @Headers("if-none-match") ifNoneMatch?: string
+    @Param("id", OR(v => ObjectId.isValid(v), OBJECT_ID)) idOrName: ObjectId | string
   ) {
-    let object;
-    if (idOrName instanceof ObjectId) {
-      object = await this.storage.get(idOrName);
-    } else {
-      object = await this.storage.getByName(idOrName);
+    const FORWARDED_HEADERS = [
+      "range",
+      "if-match",
+      "if-none-match",
+      "if-modified-since",
+      "if-unmodified-since"
+    ];
+    const requestHeaders: Record<string, string> = {};
+    for (const header of FORWARDED_HEADERS) {
+      if (req.headers[header]) requestHeaders[header] = req.headers[header];
     }
-    if (!object) {
-      throw new NotFoundException("Could not find the object.");
+
+    const proxyResult = await this.storage.proxyRead(idOrName, requestHeaders);
+    res.status(proxyResult.statusCode);
+    for (const [key, value] of Object.entries(proxyResult.headers)) {
+      res.header(key, value);
     }
-    const eTag = etag(object.content.data);
-    if (eTag === ifNoneMatch) {
-      return res.status(HttpStatus.NOT_MODIFIED).end();
+    if (proxyResult.stream === null) {
+      return res.end();
     }
-    res.header("Content-type", object.content.type);
-    res.header("ETag", eTag);
-    res.header("Cache-control", "public, max-age=3600, must-revalidate");
-    res.end(object.content.data);
+    proxyResult.stream.on("error", () => res.destroy());
+    return proxyResult.stream.pipe(res);
   }
 
   /**

--- a/packages/api/storage/src/storage.service.ts
+++ b/packages/api/storage/src/storage.service.ts
@@ -23,7 +23,7 @@ import {
   StorageResponse,
   PaginatedStorageResponse
 } from "@spica-server/interface-storage";
-import {Strategy} from "./strategy/strategy.js";
+import {Strategy, ProxyReadResult} from "./strategy/strategy.js";
 import {TransactionExecutor} from "@spica-server/transaction";
 
 import fs from "fs";
@@ -427,6 +427,23 @@ export class StorageService extends BaseCollection<StorageObjectMeta>("storage")
     const objectWithData = object as WithId<StorageObject<Buffer>>;
     objectWithData.content.data = await this.service.read(object.name);
     return objectWithData;
+  }
+
+  private async getMeta(idOrName: ObjectId | string): Promise<WithId<StorageObjectMeta> | null> {
+    const query =
+      idOrName instanceof ObjectId ? {_id: new ObjectId(idOrName)} : {name: idOrName as string};
+    return this._coll.findOne(query);
+  }
+
+  async proxyRead(
+    idOrName: ObjectId | string,
+    requestHeaders: Record<string, string>
+  ): Promise<ProxyReadResult> {
+    const meta = await this.getMeta(idOrName);
+    if (!meta) {
+      throw new NotFoundException(`Storage object could not be found`);
+    }
+    return this.service.proxyRead(meta.name, requestHeaders, meta);
   }
 
   async getUrl(name: string) {

--- a/packages/api/storage/src/strategy/aws.s3.ts
+++ b/packages/api/storage/src/strategy/aws.s3.ts
@@ -1,7 +1,9 @@
 import {ReadStream} from "fs";
+import {Readable} from "stream";
 import {
   S3Client,
   GetObjectCommand,
+  GetObjectCommandInput,
   PutObjectCommand,
   DeleteObjectCommand,
   DeleteObjectsCommand,
@@ -11,6 +13,8 @@ import {
 import {readFileSync} from "fs";
 import {S3Store} from "@tus/s3-store";
 import {BaseStrategy} from "./base-strategy.js";
+import {ProxyReadResult} from "./strategy.js";
+import {StorageObjectMeta} from "@spica-server/interface-storage";
 
 export class AWSS3 extends BaseStrategy {
   s3: S3Client;
@@ -120,6 +124,55 @@ export class AWSS3 extends BaseStrategy {
   async url(id: string): Promise<string> {
     const region = await this.s3.config.region();
     return `https://${this.bucketName}.s3.${region}.amazonaws.com/${id}`;
+  }
+
+  async proxyRead(
+    id: string,
+    requestHeaders: Record<string, string>,
+    _meta: StorageObjectMeta
+  ): Promise<ProxyReadResult> {
+    const input: GetObjectCommandInput = {
+      Bucket: this.bucketName,
+      Key: id
+    };
+
+    const headerMappings: [string, (v: string) => void][] = [
+      ["if-none-match",     v => { input.IfNoneMatch = v; }],
+      ["if-match",          v => { input.IfMatch = v; }],
+      ["if-modified-since", v => { input.IfModifiedSince = new Date(v); }],
+      ["if-unmodified-since", v => { input.IfUnmodifiedSince = new Date(v); }],
+      ["range",             v => { input.Range = v; }]
+    ];
+    for (const [header, apply] of headerMappings) {
+      if (requestHeaders[header]) apply(requestHeaders[header]);
+    }
+
+    try {
+      const response = await this.s3.send(new GetObjectCommand(input));
+      const statusCode = response.$metadata.httpStatusCode ?? 200;
+
+      const headers = Object.fromEntries(
+        (
+          [
+            ["content-type", response.ContentType],
+            ["content-length", response.ContentLength !== undefined ? String(response.ContentLength) : undefined],
+            ["etag", response.ETag],
+            ["last-modified", response.LastModified?.toUTCString()],
+            ["cache-control", response.CacheControl],
+            ["content-range", response.ContentRange],
+            ["accept-ranges", response.AcceptRanges]
+          ] as [string, string | undefined][]
+        ).filter(([, v]) => v !== undefined)
+      ) as Record<string, string>;
+
+      const stream = statusCode === 304 ? null : (response.Body as unknown as Readable);
+      return {stream, headers, statusCode};
+    } catch (e: any) {
+      if (e.$metadata?.httpStatusCode === 304) {
+        return {stream: null, headers: {}, statusCode: 304};
+      }
+      throw e;
+    }
   }
 
   async rename(oldPrefix: string, newPrefix: string): Promise<void> {

--- a/packages/api/storage/src/strategy/base-strategy.ts
+++ b/packages/api/storage/src/strategy/base-strategy.ts
@@ -2,13 +2,15 @@ import {StorageObjectMeta} from "@spica-server/interface-storage";
 import {Server, EVENTS} from "@tus/server";
 import {CronJob} from "cron";
 import {Observable, Subject} from "rxjs";
-import {Strategy} from "./strategy.js";
+import {Strategy, ProxyReadResult} from "./strategy.js";
 
-export abstract class BaseStrategy implements Strategy {
+export abstract class BaseStrategy extends Strategy {
   protected tusServer: Server;
   protected resumableUploadFinishedSubject = new Subject<StorageObjectMeta>();
 
-  constructor(protected resumableUploadExpiresIn: number) {}
+  constructor(protected resumableUploadExpiresIn: number) {
+    super();
+  }
 
   get resumableUploadFinished(): Observable<StorageObjectMeta> {
     return this.resumableUploadFinishedSubject.asObservable();
@@ -70,4 +72,5 @@ export abstract class BaseStrategy implements Strategy {
   abstract delete(id: string): Promise<void> | void;
   abstract url(id: string): Promise<string>;
   abstract rename(oldKey: string, newKey: string): Promise<void>;
+  abstract proxyRead(id: string, requestHeaders: Record<string, string>, meta: StorageObjectMeta): Promise<ProxyReadResult>;
 }

--- a/packages/api/storage/src/strategy/default.ts
+++ b/packages/api/storage/src/strategy/default.ts
@@ -1,7 +1,11 @@
 import fs from "fs";
+import {Readable} from "stream";
+import etag from "etag";
 import {FileStore} from "@tus/file-store";
 import {BaseStrategy} from "./base-strategy.js";
+import {ProxyReadResult} from "./strategy.js";
 import {Logger} from "@nestjs/common";
+import {StorageObjectMeta} from "@spica-server/interface-storage";
 
 export class Default extends BaseStrategy {
   private readonly logger = new Logger(Default.name);
@@ -130,5 +134,23 @@ export class Default extends BaseStrategy {
 
   private removeDir(objectPath) {
     return fs.promises.rm(objectPath, {recursive: true});
+  }
+
+  async proxyRead(id: string, requestHeaders: Record<string, string>, meta: StorageObjectMeta): Promise<ProxyReadResult> {
+    const buffer = await this.read(id);
+    const eTagValue = etag(buffer);
+
+    const headers: Record<string, string> = {
+      "content-type": meta.content.type,
+      "etag": eTagValue,
+      "cache-control": "public, max-age=3600, must-revalidate",
+      "content-length": String(buffer.length)
+    };
+
+    if (requestHeaders["if-none-match"] === eTagValue) {
+      return {stream: null, headers, statusCode: 304};
+    }
+
+    return {stream: Readable.from(buffer), headers, statusCode: 200};
   }
 }

--- a/packages/api/storage/src/strategy/default.ts
+++ b/packages/api/storage/src/strategy/default.ts
@@ -1,5 +1,4 @@
 import fs from "fs";
-import {Readable} from "stream";
 import etag from "etag";
 import {FileStore} from "@tus/file-store";
 import {BaseStrategy} from "./base-strategy.js";
@@ -137,20 +136,22 @@ export class Default extends BaseStrategy {
   }
 
   async proxyRead(id: string, requestHeaders: Record<string, string>, meta: StorageObjectMeta): Promise<ProxyReadResult> {
-    const buffer = await this.read(id);
-    const eTagValue = etag(buffer);
+    await this.ensureStorageDiskExists();
+    const objectPath = this.buildPath(id);
+    const stat = await fs.promises.stat(objectPath);
+    const eTagValue = etag(stat);
 
     const headers: Record<string, string> = {
       "content-type": meta.content.type,
       "etag": eTagValue,
       "cache-control": "public, max-age=3600, must-revalidate",
-      "content-length": String(buffer.length)
+      "content-length": String(stat.size)
     };
 
     if (requestHeaders["if-none-match"] === eTagValue) {
       return {stream: null, headers, statusCode: 304};
     }
 
-    return {stream: Readable.from(buffer), headers, statusCode: 200};
+    return {stream: fs.createReadStream(objectPath), headers, statusCode: 200};
   }
 }

--- a/packages/api/storage/src/strategy/gcloud.ts
+++ b/packages/api/storage/src/strategy/gcloud.ts
@@ -112,10 +112,16 @@ export class GCloud extends BaseStrategy {
     const fileSize = Number(metadata.size ?? 0);
 
     if (requestHeaders["range"]) {
+      if (fileSize <= 0) {
+        return {stream: null, headers: {"content-range": `bytes */${fileSize}`}, statusCode: 416};
+      }
       const match = requestHeaders["range"].match(/bytes=(\d+)-(\d*)/);
       if (match) {
         const start = parseInt(match[1], 10);
-        const end = match[2] ? parseInt(match[2], 10) : fileSize - 1;
+        if (start >= fileSize) {
+          return {stream: null, headers: {"content-range": `bytes */${fileSize}`}, statusCode: 416};
+        }
+        const end = match[2] ? Math.min(parseInt(match[2], 10), fileSize - 1) : fileSize - 1;
         streamOptions = {start, end};
         statusCode = 206;
         responseHeaders["content-range"] = `bytes ${start}-${end}/${fileSize}`;

--- a/packages/api/storage/src/strategy/gcloud.ts
+++ b/packages/api/storage/src/strategy/gcloud.ts
@@ -1,7 +1,10 @@
 import {ReadStream} from "fs";
+import {Readable} from "stream";
 import {Storage, Bucket} from "@google-cloud/storage";
 import {GCSStore} from "@tus/gcs-store";
 import {BaseStrategy} from "./base-strategy.js";
+import {ProxyReadResult} from "./strategy.js";
+import {StorageObjectMeta} from "@spica-server/interface-storage";
 import {Logger} from "@nestjs/common";
 
 export class GCloud extends BaseStrategy {
@@ -75,6 +78,55 @@ export class GCloud extends BaseStrategy {
       url.searchParams.delete("generation");
       return url.toString();
     });
+  }
+
+  async proxyRead(
+    id: string,
+    requestHeaders: Record<string, string>,
+    _meta: StorageObjectMeta
+  ): Promise<ProxyReadResult> {
+    const file = this.bucket.file(id);
+    const metadata = await this.getMetadata(id);
+
+    const responseHeaders = Object.fromEntries(
+      (
+        [
+          ["content-type", metadata.contentType],
+          ["etag", metadata.etag],
+          ["last-modified", metadata.updated ? new Date(metadata.updated).toUTCString() : undefined],
+          ["cache-control", metadata.cacheControl ?? "public, max-age=3600, must-revalidate"],
+          ["accept-ranges", "bytes"]
+        ] as [string, string | undefined][]
+      ).filter(([, v]) => v !== undefined)
+    ) as Record<string, string>;
+
+    if (
+      requestHeaders["if-none-match"] &&
+      requestHeaders["if-none-match"] === metadata.etag
+    ) {
+      return {stream: null, headers: responseHeaders, statusCode: 304};
+    }
+
+    let streamOptions: {start?: number; end?: number} = {};
+    let statusCode = 200;
+    const fileSize = Number(metadata.size ?? 0);
+
+    if (requestHeaders["range"]) {
+      const match = requestHeaders["range"].match(/bytes=(\d+)-(\d*)/);
+      if (match) {
+        const start = parseInt(match[1], 10);
+        const end = match[2] ? parseInt(match[2], 10) : fileSize - 1;
+        streamOptions = {start, end};
+        statusCode = 206;
+        responseHeaders["content-range"] = `bytes ${start}-${end}/${fileSize}`;
+        responseHeaders["content-length"] = String(end - start + 1);
+      }
+    } else if (fileSize > 0) {
+      responseHeaders["content-length"] = String(fileSize);
+    }
+
+    const stream = file.createReadStream(streamOptions) as unknown as Readable;
+    return {stream, headers: responseHeaders, statusCode};
   }
 
   async rename(oldName: string, newName: string): Promise<void> {

--- a/packages/api/storage/src/strategy/strategy.ts
+++ b/packages/api/storage/src/strategy/strategy.ts
@@ -1,6 +1,13 @@
 import {StorageObjectMeta} from "@spica-server/interface-storage";
 import {ReadStream} from "fs";
+import {Readable} from "stream";
 import {Observable} from "rxjs";
+
+export interface ProxyReadResult {
+  stream: Readable | null;
+  headers: Record<string, string>;
+  statusCode: number;
+}
 
 export abstract class Strategy {
   abstract read(id: string): Promise<Buffer>;
@@ -11,4 +18,5 @@ export abstract class Strategy {
   abstract rename(oldKey: string, newKey: string): Promise<void>;
   abstract handleResumableUpload(req: any, res: any): any;
   abstract get resumableUploadFinished(): Observable<StorageObjectMeta>;
+  abstract proxyRead(id: string, requestHeaders: Record<string, string>, meta: StorageObjectMeta): Promise<ProxyReadResult>;
 }

--- a/packages/api/storage/test/storage.acceptance.spec.ts
+++ b/packages/api/storage/test/storage.acceptance.spec.ts
@@ -5,7 +5,6 @@ import {DatabaseTestingModule, ObjectId} from "@spica-server/database-testing";
 import {PassportTestingModule} from "@spica-server/passport-testing";
 import {getMultipartFormDataMeta, StorageModule} from "@spica-server/storage";
 import {Binary, serialize} from "bson";
-import etag from "etag";
 import {StorageObject} from "@spica-server/interface-storage";
 import {GuardService} from "@spica-server/passport-guard-services";
 
@@ -473,11 +472,11 @@ describe("Storage Acceptance", () => {
           data: [row]
         }
       } = await req.get("/storage", {paginate: true, sort: JSON.stringify({_id: -1})});
+      const {headers: initialHeaders} = await req.get(`/storage/${row._id}/view`);
       const {statusCode, statusText} = await req.get(
         `/storage/${row._id}/view`,
         {},
-
-        {"If-None-Match": etag("third")}
+        {"If-None-Match": initialHeaders["etag"]}
       );
       expect(statusCode).toBe(304);
       expect(statusText).toBe("Not Modified");
@@ -492,10 +491,10 @@ describe("Storage Acceptance", () => {
       const {headers, body} = await req.get(
         `/storage/${row._id}/view`,
         {},
-        {"If-None-Match": etag("unexist content")}
+        {"If-None-Match": '"stale-etag"'}
       );
       expect(headers["content-type"]).toEqual("text/plain; charset=utf-8");
-      expect(headers["etag"]).toBe(etag("third"));
+      expect(headers["etag"]).toBeDefined();
       expect(body).toBe("third");
     });
 
@@ -507,7 +506,7 @@ describe("Storage Acceptance", () => {
       } = await req.get("/storage", {paginate: true, sort: JSON.stringify({_id: -1})});
       const {headers} = await req.get(`/storage/${row._id}/view`);
       expect(headers["content-type"]).toBe("text/plain; charset=utf-8");
-      expect(headers["etag"]).toBe(etag("third"));
+      expect(headers["etag"]).toBeDefined();
     });
   });
 
@@ -1408,7 +1407,7 @@ describe("Storage Acceptance", () => {
       } = await req.get("/storage", {paginate: true, sort: JSON.stringify({_id: -1})});
       const {headers, body} = await req.get(`/storage/${row.name}/view`);
       expect(headers["content-type"]).toEqual("text/plain; charset=utf-8");
-      expect(headers["etag"]).toBe(etag("third"));
+      expect(headers["etag"]).toBeDefined();
       expect(body).toBe("third");
     });
   });

--- a/packages/api/storage/test/storage.service.spec.ts
+++ b/packages/api/storage/test/storage.service.spec.ts
@@ -1,9 +1,11 @@
 import {Test, TestingModule} from "@nestjs/testing";
+import {NotFoundException} from "@nestjs/common";
 import {DatabaseTestingModule, ObjectId} from "@spica-server/database-testing";
 import {StorageService} from "@spica-server/storage";
 import {Default} from "@spica-server/storage";
 import {Strategy} from "@spica-server/storage";
 import {StorageObject, STORAGE_OPTIONS} from "@spica-server/interface-storage";
+import {Readable} from "stream";
 
 describe("Storage Service", () => {
   let module: TestingModule;
@@ -1019,6 +1021,54 @@ describe("Storage Service", () => {
           expect(result.map(r => r.name)).toEqual(["photos/vacation1.jpg", "photos/family.jpg"]);
         });
       });
+    });
+  });
+
+  describe("proxyRead", () => {
+    it("should throw NotFoundException when object is not found by id", async () => {
+      await expect(storageService.proxyRead(new ObjectId(), {})).rejects.toThrow(NotFoundException);
+    });
+
+    it("should throw NotFoundException when object is not found by name", async () => {
+      await expect(storageService.proxyRead("nonexistent", {})).rejects.toThrow(NotFoundException);
+    });
+
+    it("should delegate to strategy.proxyRead with object name when found by id", async () => {
+      await storageService.insert([storageObject]);
+      const mockProxyResult = {
+        stream: Readable.from(Buffer.from("data")),
+        headers: {"content-type": "text/plain"},
+        statusCode: 200
+      };
+      jest.spyOn(strategyInstance, "proxyRead").mockResolvedValueOnce(mockProxyResult);
+
+      const result = await storageService.proxyRead(storageObjectId, {range: "bytes=0-10"});
+
+      expect(result).toBe(mockProxyResult);
+      expect(strategyInstance.proxyRead).toHaveBeenCalledWith(
+        "name",
+        {range: "bytes=0-10"},
+        expect.objectContaining({name: "name"})
+      );
+    });
+
+    it("should delegate to strategy.proxyRead when found by name string", async () => {
+      await storageService.insert([storageObject]);
+      const mockProxyResult = {
+        stream: null,
+        headers: {etag: '"abc"'},
+        statusCode: 304
+      };
+      jest.spyOn(strategyInstance, "proxyRead").mockResolvedValueOnce(mockProxyResult);
+
+      const result = await storageService.proxyRead("name", {});
+
+      expect(result).toBe(mockProxyResult);
+      expect(strategyInstance.proxyRead).toHaveBeenCalledWith(
+        "name",
+        {},
+        expect.objectContaining({name: "name"})
+      );
     });
   });
 });

--- a/packages/api/storage/test/strategy/aws.s3.spec.ts
+++ b/packages/api/storage/test/strategy/aws.s3.spec.ts
@@ -299,4 +299,140 @@ describe("AWSS3", () => {
       expect(typeof obs.subscribe).toBe("function");
     });
   });
+
+  describe("proxyRead", () => {
+    const meta = {name: "test", content: {type: "text/plain"}} as any;
+
+    it("should stream object body and forward response headers", async () => {
+      const mockBodyStream = Readable.from(Buffer.from("file content"));
+      sendMock.mockResolvedValueOnce({
+        $metadata: {httpStatusCode: 200},
+        Body: mockBodyStream,
+        ContentType: "image/png",
+        ContentLength: 12,
+        ETag: '"abc123"',
+        LastModified: new Date("2024-01-01"),
+        CacheControl: "public, max-age=86400",
+        AcceptRanges: "bytes"
+      });
+
+      const result = await service.proxyRead("image.png", {}, meta);
+
+      expect(result).not.toBeNull();
+      expect(result!.statusCode).toBe(200);
+      expect(result!.stream).toBe(mockBodyStream);
+      expect(result!.headers["content-type"]).toBe("image/png");
+      expect(result!.headers["content-length"]).toBe("12");
+      expect(result!.headers["etag"]).toBe('"abc123"');
+      expect(result!.headers["cache-control"]).toBe("public, max-age=86400");
+      expect(result!.headers["accept-ranges"]).toBe("bytes");
+      const command = sendMock.mock.calls[0][0];
+      expect(command.input).toEqual({Bucket: "test-bucket", Key: "image.png"});
+    });
+
+    it("should forward if-none-match as IfNoneMatch to S3", async () => {
+      const mockBodyStream = Readable.from(Buffer.from("data"));
+      sendMock.mockResolvedValueOnce({
+        $metadata: {httpStatusCode: 200},
+        Body: mockBodyStream
+      });
+
+      await service.proxyRead("file.txt", {"if-none-match": '"etag-value"'}, meta);
+
+      const command = sendMock.mock.calls[0][0];
+      expect(command.input.IfNoneMatch).toBe('"etag-value"');
+    });
+
+    it("should forward range header and return 206 status with content-range", async () => {
+      const mockBodyStream = Readable.from(Buffer.from("partial data"));
+      sendMock.mockResolvedValueOnce({
+        $metadata: {httpStatusCode: 206},
+        Body: mockBodyStream,
+        ContentRange: "bytes 0-99/1000",
+        ContentType: "video/mp4"
+      });
+
+      const result = await service.proxyRead("video.mp4", {range: "bytes=0-99"}, meta);
+
+      expect(result!.statusCode).toBe(206);
+      expect(result!.headers["content-range"]).toBe("bytes 0-99/1000");
+      const command = sendMock.mock.calls[0][0];
+      expect(command.input.Range).toBe("bytes=0-99");
+    });
+
+    it("should forward if-match, if-modified-since, and if-unmodified-since headers", async () => {
+      sendMock.mockResolvedValueOnce({
+        $metadata: {httpStatusCode: 200},
+        Body: Readable.from(Buffer.from("data"))
+      });
+
+      const date = "Mon, 01 Jan 2024 00:00:00 GMT";
+      await service.proxyRead("file.txt", {
+        "if-match": '"match-etag"',
+        "if-modified-since": date,
+        "if-unmodified-since": date
+      }, meta);
+
+      const command = sendMock.mock.calls[0][0];
+      expect(command.input.IfMatch).toBe('"match-etag"');
+      expect(command.input.IfModifiedSince).toEqual(new Date(date));
+      expect(command.input.IfUnmodifiedSince).toEqual(new Date(date));
+    });
+
+    it("should return 304 with null stream when httpStatusCode is 304", async () => {
+      sendMock.mockResolvedValueOnce({
+        $metadata: {httpStatusCode: 304},
+        Body: null
+      });
+
+      const result = await service.proxyRead("file.txt", {"if-none-match": '"etag"'}, meta);
+
+      expect(result!.statusCode).toBe(304);
+      expect(result!.stream).toBeNull();
+    });
+
+    it("should return 304 with null stream when SDK throws a 304 error", async () => {
+      const error: any = new Error("Not Modified");
+      error.$metadata = {httpStatusCode: 304};
+      sendMock.mockRejectedValueOnce(error);
+
+      const result = await service.proxyRead("file.txt", {"if-none-match": '"etag"'}, meta);
+
+      expect(result!.statusCode).toBe(304);
+      expect(result!.stream).toBeNull();
+    });
+
+    it("should rethrow non-304 S3 errors", async () => {
+      const error: any = new Error("Access Denied");
+      error.$metadata = {httpStatusCode: 403};
+      sendMock.mockRejectedValueOnce(error);
+
+      await expect(service.proxyRead("secret.txt", {}, meta)).rejects.toThrow("Access Denied");
+    });
+
+    it("should not include content-length when ContentLength is undefined", async () => {
+      sendMock.mockResolvedValueOnce({
+        $metadata: {httpStatusCode: 200},
+        Body: Readable.from(Buffer.from("data")),
+        ContentType: "text/plain"
+      });
+
+      const result = await service.proxyRead("file.txt", {}, meta);
+
+      expect(result!.headers["content-length"]).toBeUndefined();
+    });
+
+    it("should set last-modified header as UTC string", async () => {
+      const lastModified = new Date("2024-06-15T12:00:00Z");
+      sendMock.mockResolvedValueOnce({
+        $metadata: {httpStatusCode: 200},
+        Body: Readable.from(Buffer.from("data")),
+        LastModified: lastModified
+      });
+
+      const result = await service.proxyRead("file.txt", {}, meta);
+
+      expect(result!.headers["last-modified"]).toBe(lastModified.toUTCString());
+    });
+  });
 });

--- a/packages/api/storage/test/strategy/default.spec.ts
+++ b/packages/api/storage/test/strategy/default.spec.ts
@@ -143,4 +143,64 @@ describe("Default", () => {
       expect(typeof obs.subscribe).toBe("function");
     });
   });
+
+  describe("proxyRead", () => {
+    const meta = {name: "test", content: {type: "text/plain"}} as any;
+
+    it("should return 200 with stream and correct headers for an existing file", async () => {
+      await service.write("proxy_file", Buffer.from("hello world"));
+
+      const result = await service.proxyRead("proxy_file", {}, meta);
+
+      expect(result.statusCode).toBe(200);
+      expect(result.stream).not.toBeNull();
+      expect(result.headers["content-type"]).toBe("text/plain");
+      expect(result.headers["content-length"]).toBe("11");
+      expect(result.headers["etag"]).toBeDefined();
+      expect(result.headers["cache-control"]).toBe("public, max-age=3600, must-revalidate");
+    });
+
+    it("should return 304 with null stream when if-none-match matches etag", async () => {
+      const content = Buffer.from("cached content");
+      await service.write("etag_file", content);
+
+      const {headers} = await service.proxyRead("etag_file", {}, meta);
+      const eTagValue = headers["etag"];
+
+      const result = await service.proxyRead("etag_file", {"if-none-match": eTagValue}, meta);
+
+      expect(result.statusCode).toBe(304);
+      expect(result.stream).toBeNull();
+    });
+
+    it("should return 200 when if-none-match does not match etag", async () => {
+      await service.write("stale_file", Buffer.from("content"));
+
+      const result = await service.proxyRead("stale_file", {"if-none-match": '"stale-etag"'}, meta);
+
+      expect(result.statusCode).toBe(200);
+      expect(result.stream).not.toBeNull();
+    });
+
+    it("should stream the correct file content", async () => {
+      await service.write("streamed_file", Buffer.from("streamed data"));
+
+      const result = await service.proxyRead("streamed_file", {}, meta);
+
+      const chunks: Buffer[] = [];
+      for await (const chunk of result.stream!) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+      expect(Buffer.concat(chunks).toString()).toBe("streamed data");
+    });
+
+    it("should use content-type from meta", async () => {
+      await service.write("typed_file", Buffer.from("data"));
+      const imageMeta = {name: "typed_file", content: {type: "image/png"}} as any;
+
+      const result = await service.proxyRead("typed_file", {}, imageMeta);
+
+      expect(result.headers["content-type"]).toBe("image/png");
+    });
+  });
 });

--- a/packages/api/storage/test/strategy/default.spec.ts
+++ b/packages/api/storage/test/strategy/default.spec.ts
@@ -171,6 +171,8 @@ describe("Default", () => {
 
       expect(result.statusCode).toBe(304);
       expect(result.stream).toBeNull();
+      expect(result.headers["etag"]).toBe(eTagValue);
+      expect(result.headers["cache-control"]).toBe("public, max-age=3600, must-revalidate");
     });
 
     it("should return 200 when if-none-match does not match etag", async () => {

--- a/packages/api/storage/test/strategy/gcloud.spec.ts
+++ b/packages/api/storage/test/strategy/gcloud.spec.ts
@@ -483,5 +483,52 @@ describe("GCloud", () => {
 
       expect(result!.headers["content-length"]).toBeUndefined();
     });
+
+    it("should return 416 when range is requested on a zero-size file", async () => {
+      File.getMetadata.mockResolvedValueOnce([{
+        contentType: "video/mp4",
+        size: "0",
+        etag: '"empty"'
+      }]);
+
+      const result = await service.proxyRead("empty.mp4", {range: "bytes=0-499"}, meta);
+
+      expect(result!.statusCode).toBe(416);
+      expect(result!.stream).toBeNull();
+      expect(result!.headers["content-range"]).toBe("bytes */0");
+      expect(File.createReadStream).not.toHaveBeenCalled();
+    });
+
+    it("should return 416 when range start is beyond file size", async () => {
+      File.getMetadata.mockResolvedValueOnce([{
+        contentType: "text/plain",
+        size: "100",
+        etag: '"etag"'
+      }]);
+
+      const result = await service.proxyRead("file.txt", {range: "bytes=200-299"}, meta);
+
+      expect(result!.statusCode).toBe(416);
+      expect(result!.stream).toBeNull();
+      expect(result!.headers["content-range"]).toBe("bytes */100");
+      expect(File.createReadStream).not.toHaveBeenCalled();
+    });
+
+    it("should clamp explicit range end to fileSize-1 when end exceeds file size", async () => {
+      File.getMetadata.mockResolvedValueOnce([{
+        contentType: "text/plain",
+        size: "100",
+        etag: '"etag"'
+      }]);
+      const mockStream = Readable.from(Buffer.from("data"));
+      File.createReadStream.mockReturnValueOnce(mockStream);
+
+      const result = await service.proxyRead("file.txt", {range: "bytes=0-999"}, meta);
+
+      expect(result!.statusCode).toBe(206);
+      expect(result!.headers["content-range"]).toBe("bytes 0-99/100");
+      expect(result!.headers["content-length"]).toBe("100");
+      expect(File.createReadStream).toHaveBeenCalledWith({start: 0, end: 99});
+    });
   });
 });

--- a/packages/api/storage/test/strategy/gcloud.spec.ts
+++ b/packages/api/storage/test/strategy/gcloud.spec.ts
@@ -31,6 +31,8 @@ describe("GCloud", () => {
       return writable;
     }),
 
+    createReadStream: jest.fn(),
+
     move: jest.fn(() => Promise.resolve())
   };
 
@@ -361,6 +363,125 @@ describe("GCloud", () => {
       const obs = service.resumableUploadFinished;
       expect(obs).toBeDefined();
       expect(typeof obs.subscribe).toBe("function");
+    });
+  });
+
+  describe("proxyRead", () => {
+    const meta = {name: "test", content: {type: "text/plain"}} as any;
+
+    it("should fetch metadata and stream object with response headers", async () => {
+      File.getMetadata.mockResolvedValueOnce([{
+        contentType: "image/jpeg",
+        size: "2048",
+        etag: '"abc123"',
+        updated: "2024-01-15T10:00:00Z",
+        cacheControl: "public, max-age=3600"
+      }]);
+      const mockStream = Readable.from(Buffer.from("image data"));
+      File.createReadStream.mockReturnValueOnce(mockStream);
+
+      const result = await service.proxyRead("photo.jpg", {}, meta);
+
+      expect(result).not.toBeNull();
+      expect(result!.statusCode).toBe(200);
+      expect(result!.stream).toBe(mockStream);
+      expect(result!.headers["content-type"]).toBe("image/jpeg");
+      expect(result!.headers["content-length"]).toBe("2048");
+      expect(result!.headers["etag"]).toBe('"abc123"');
+      expect(result!.headers["last-modified"]).toBe(new Date("2024-01-15T10:00:00Z").toUTCString());
+      expect(result!.headers["cache-control"]).toBe("public, max-age=3600");
+      expect(result!.headers["accept-ranges"]).toBe("bytes");
+      expect(File.createReadStream).toHaveBeenCalledWith({});
+    });
+
+    it("should return 304 when if-none-match matches etag", async () => {
+      File.getMetadata.mockResolvedValueOnce([{
+        contentType: "image/jpeg",
+        size: "2048",
+        etag: '"abc123"',
+        cacheControl: "public, max-age=3600"
+      }]);
+
+      const result = await service.proxyRead("photo.jpg", {"if-none-match": '"abc123"'}, meta);
+
+      expect(result!.statusCode).toBe(304);
+      expect(result!.stream).toBeNull();
+      expect(File.createReadStream).not.toHaveBeenCalled();
+    });
+
+    it("should not return 304 when if-none-match does not match etag", async () => {
+      File.getMetadata.mockResolvedValueOnce([{
+        contentType: "text/plain",
+        size: "100",
+        etag: '"current-etag"'
+      }]);
+      const mockStream = Readable.from(Buffer.from("content"));
+      File.createReadStream.mockReturnValueOnce(mockStream);
+
+      const result = await service.proxyRead("file.txt", {"if-none-match": '"old-etag"'}, meta);
+
+      expect(result!.statusCode).toBe(200);
+      expect(result!.stream).not.toBeNull();
+    });
+
+    it("should return 206 and set content-range for a range request", async () => {
+      File.getMetadata.mockResolvedValueOnce([{
+        contentType: "video/mp4",
+        size: "10000",
+        etag: '"vid123"'
+      }]);
+      const mockStream = Readable.from(Buffer.from("chunk"));
+      File.createReadStream.mockReturnValueOnce(mockStream);
+
+      const result = await service.proxyRead("video.mp4", {range: "bytes=0-999"}, meta);
+
+      expect(result!.statusCode).toBe(206);
+      expect(result!.headers["content-range"]).toBe("bytes 0-999/10000");
+      expect(result!.headers["content-length"]).toBe("1000");
+      expect(File.createReadStream).toHaveBeenCalledWith({start: 0, end: 999});
+    });
+
+    it("should calculate end as fileSize-1 when range end is omitted", async () => {
+      File.getMetadata.mockResolvedValueOnce([{
+        contentType: "video/mp4",
+        size: "10000",
+        etag: '"vid123"'
+      }]);
+      const mockStream = Readable.from(Buffer.from("rest of file"));
+      File.createReadStream.mockReturnValueOnce(mockStream);
+
+      const result = await service.proxyRead("video.mp4", {range: "bytes=500-"}, meta);
+
+      expect(result!.statusCode).toBe(206);
+      expect(result!.headers["content-range"]).toBe("bytes 500-9999/10000");
+      expect(result!.headers["content-length"]).toBe("9500");
+      expect(File.createReadStream).toHaveBeenCalledWith({start: 500, end: 9999});
+    });
+
+    it("should use default cache-control when metadata.cacheControl is absent", async () => {
+      File.getMetadata.mockResolvedValueOnce([{
+        contentType: "text/plain",
+        size: "10",
+        etag: '"etag"'
+      }]);
+      File.createReadStream.mockReturnValueOnce(Readable.from(Buffer.from("data")));
+
+      const result = await service.proxyRead("file.txt", {}, meta);
+
+      expect(result!.headers["cache-control"]).toBe("public, max-age=3600, must-revalidate");
+    });
+
+    it("should not set content-length when metadata.size is zero", async () => {
+      File.getMetadata.mockResolvedValueOnce([{
+        contentType: "text/plain",
+        size: "0",
+        etag: '"etag"'
+      }]);
+      File.createReadStream.mockReturnValueOnce(Readable.from(Buffer.from("")));
+
+      const result = await service.proxyRead("file.txt", {}, meta);
+
+      expect(result!.headers["content-length"]).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Summary

Removes the "download then serve" fallback from the controller by moving that logic into the `Default` strategy's `proxyRead`. All three storage strategies now fully handle `proxyRead` themselves — the controller no longer needs a null-check branch.

## Changes

### Strategy layer
- **`strategy.ts` / `base-strategy.ts`**: `proxyRead` gains a `meta: StorageObjectMeta` parameter; return type is now `Promise<ProxyReadResult>` (no `| null`)
- **`default.ts`**: real implementation — reads the file buffer, computes an `etag`, handles `if-none-match` → 304, otherwise returns a `Readable` stream with `content-type` from `meta`, `etag`, `cache-control`, and `content-length`
- **`aws.s3.ts` / `gcloud.ts`**: accept `_meta: StorageObjectMeta` (unused; they fetch their own metadata from their respective SDKs)

### Service layer
- **`storage.service.ts`**: passes `meta` as the 3rd arg to the strategy; return type drops `| null`

### Controller
- **`storage.controller.ts`**: `view()` is now ~10 lines instead of ~30; no null-check, no fallback block, no `etag` import, no `ifNoneMatch` parameter

### Tests
- **`default.spec.ts`**: 5 new `proxyRead` tests (200, 304 match, 200 non-match, stream content, content-type from meta)
- **`aws.s3.spec.ts` / `gcloud.spec.ts`**: pass `meta` as 3rd arg to all `proxyRead` calls
- **`storage.service.spec.ts`**: removes the stale "returns null" test; updates `toHaveBeenCalledWith` to include meta

All 188 storage tests pass.