### PR TITLE
fix(api): use activeTargetWorkers for concurrency check

### DIFF
--- a/packages/api/function/scheduler/src/scheduler.ts
+++ b/packages/api/function/scheduler/src/scheduler.ts
@@ -268,8 +268,11 @@ export class Scheduler implements OnModuleInit, OnModuleDestroy {
       return available;
     }
 
+    const activeTargetWorkers = sameTargets.filter(
+      ({worker}) => worker.state != WorkerState.Timeouted && worker.state != WorkerState.Outdated
+    );
     const fresh = workers.find(({worker}) => worker.state == WorkerState.Fresh);
-    if (sameTargets.length < this.options.maxConcurrency) {
+    if (activeTargetWorkers.length < this.options.maxConcurrency) {
       return fresh;
     }
     return;


### PR DESCRIPTION
## Problem

In `takeAWorker`, the concurrency gate was comparing against `sameTargets.length` — which includes **all** workers for that target, even ones in `Timeouted` or `Outdated` state. These workers are effectively dead and should not count toward `maxConcurrency`, but they were blocking fresh workers from being assigned to new events.

## Change

Introduce `activeTargetWorkers` by filtering `sameTargets` to exclude `Timeouted` and `Outdated` workers. The concurrency check now uses this filtered count instead of the raw `sameTargets.length`.

```ts
const activeTargetWorkers = sameTargets.filter(
  ({worker}) => worker.state != WorkerState.Timeouted && worker.state != WorkerState.Outdated
);
if (activeTargetWorkers.length < this.options.maxConcurrency) {
  return fresh;
}
```

## Impact

- Functions that previously had timed-out or outdated workers occupying concurrency slots will now correctly accept new invocations up to `maxConcurrency`.
- No behaviour change when all same-target workers are in healthy states.