### PR TITLE
fix(api): propagate --payload-size-limit to function HTTP trigger body parser

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -826,7 +826,8 @@ const modules = [
     invocationLogs: args["function-invocation-logs"],
     realtime: true,
     grpcPort: args["grpc-function-port"],
-    functionGrpcMaxMessageSizeBytes: args["function-grpc-max-message-size-bytes"]
+    functionGrpcMaxMessageSizeBytes: args["function-grpc-max-message-size-bytes"],
+    payloadSizeLimit: args["payload-size-limit"]
   }),
   ConfigModule.forRoot(),
   StatusModule.forRoot({

--- a/packages/api/function/enqueuer/src/http.ts
+++ b/packages/api/function/enqueuer/src/http.ts
@@ -31,12 +31,13 @@ export class HttpEnqueuer extends Enqueuer<HttpOptions> {
     private corsOptions: CorsOptions,
     private schedulerUnsubscription: (targetId: string) => void,
     private guardService: IGuardService,
-    private attachStatusTracker?: AttachStatusTracker
+    private attachStatusTracker?: AttachStatusTracker,
+    private payloadSizeLimit?: number
   ) {
     super();
     this.router.use(
       bodyParser.raw({
-        limit: "10mb",
+        limit: this.payloadSizeLimit ? this.payloadSizeLimit * 1024 * 1024 : "10mb",
         type: "*/*"
       }) as any
     );

--- a/packages/api/function/enqueuer/src/http.ts
+++ b/packages/api/function/enqueuer/src/http.ts
@@ -37,7 +37,7 @@ export class HttpEnqueuer extends Enqueuer<HttpOptions> {
     super();
     this.router.use(
       bodyParser.raw({
-        limit: this.payloadSizeLimit ? this.payloadSizeLimit * 1024 * 1024 : "10mb",
+        limit: this.payloadSizeLimit != null ? this.payloadSizeLimit * 1024 * 1024 : "10mb",
         type: "*/*"
       }) as any
     );

--- a/packages/api/function/enqueuer/test/http.spec.ts
+++ b/packages/api/function/enqueuer/test/http.spec.ts
@@ -338,6 +338,62 @@ describe("http enqueuer", () => {
     ).toEqual([123, 34, 116, 101, 115, 116, 34, 58, 49, 125]);
   });
 
+  it("should reject requests exceeding the default 10mb body size limit", async () => {
+    httpEnqueuer.subscribe(noopTarget, {
+      method: HttpMethod.Post,
+      path: "/test",
+      preflight: false
+    });
+    const bodyExceeding10mb = Buffer.alloc(11 * 1024 * 1024, "a");
+    const response = await req
+      .post("/fn-execute/test", bodyExceeding10mb, {"Content-type": "application/octet-stream"})
+      .catch(e => e.response);
+    expect(response.statusCode).toBe(413);
+  });
+
+  it("should respect a custom payloadSizeLimit passed to the constructor", async () => {
+    const module = await Test.createTestingModule({
+      imports: [CoreTestingModule]
+    }).compile();
+    const customApp = module.createNestApplication();
+    const customReq = module.get(Request);
+    await customApp.listen(customReq.socket);
+
+    const customEnqueuer = new HttpEnqueuer(
+      eventQueue as any,
+      httpQueue as any,
+      customApp.getHttpAdapter().getInstance(),
+      corsOptions,
+      jest.fn(),
+      createNoopGuardService(),
+      undefined,
+      1 // 1 MiB custom limit
+    );
+
+    customEnqueuer.subscribe(noopTarget, {
+      method: HttpMethod.Post,
+      path: "/large",
+      preflight: false
+    });
+
+    // Body exceeding 1 MiB should be rejected with 413
+    const bigBody = Buffer.alloc(2 * 1024 * 1024, "a");
+    const rejected = await customReq
+      .post("/fn-execute/large", bigBody, {"Content-type": "application/octet-stream"})
+      .catch(e => e.response);
+    expect(rejected.statusCode).toBe(413);
+
+    // Body within 1 MiB should be accepted
+    httpQueue.enqueue.mockImplementation((id, _req, res) => res.end());
+    const smallBody = Buffer.alloc(512 * 1024, "a");
+    await customReq.post("/fn-execute/large", smallBody, {
+      "Content-type": "application/octet-stream"
+    });
+    expect(httpQueue.enqueue).toHaveBeenCalled();
+
+    await customApp.close();
+  });
+
   it("should dequeue when connection is closed", done => {
     httpQueue.enqueue.mockImplementation((id, req, res) => {
       res.connection.destroy();

--- a/packages/api/function/scheduler/src/scheduler.ts
+++ b/packages/api/function/scheduler/src/scheduler.ts
@@ -117,7 +117,8 @@ export class Scheduler implements OnModuleInit, OnModuleDestroy {
         this.options.corsOptions,
         schedulerUnsubscription,
         this.guardService,
-        this.attachStatusTracker
+        this.attachStatusTracker,
+        this.options.payloadSizeLimit
       )
     );
 

--- a/packages/api/function/src/function.module.ts
+++ b/packages/api/function/src/function.module.ts
@@ -67,7 +67,8 @@ export class FunctionModule {
           spawnEntrypointPath: options.spawnEntrypointPath,
           tsCompilerPath: options.tsCompilerPath,
           grpcPort: options.grpcPort,
-          functionGrpcMaxMessageSizeBytes: options.functionGrpcMaxMessageSizeBytes
+          functionGrpcMaxMessageSizeBytes: options.functionGrpcMaxMessageSizeBytes,
+          payloadSizeLimit: options.payloadSizeLimit
         }),
         ServicesModule.forRoot({
           logExpireAfterSeconds: options.logExpireAfterSeconds,

--- a/packages/interface/function/scheduler/src/index.ts
+++ b/packages/interface/function/scheduler/src/index.ts
@@ -26,6 +26,7 @@ export interface SchedulingOptions {
   tsCompilerPath?: string;
   grpcPort?: number;
   functionGrpcMaxMessageSizeBytes?: number;
+  payloadSizeLimit?: number;
 }
 
 export type Schedule = (event: event.Event) => void;


### PR DESCRIPTION
## Problem

The `HttpEnqueuer` class had a **hardcoded `limit: "10mb"`** in its `bodyParser.raw()` configuration for all function HTTP trigger routes (`/fn-execute/*`). This limit was completely independent of the `--payload-size-limit` CLI flag.

As a result, even when operators configure `--payload-size-limit` to a higher value (e.g. `100` for 100 MiB), requests to function HTTP triggers are still rejected with `413 PayloadTooLargeError` once they exceed 10 MB.

### Stack trace observed in production
```
PayloadTooLargeError: request entity too large
    at readStream (/app/node_modules/raw-body/index.js:163:17)
    at rawParser (/app/node_modules/body-parser/lib/types/raw.js:81:5)
    at Layer.handle [as handle_request] (.../function-enqueuer/node_modules/express/lib/router/layer.js:95:5)
```

## Root Cause

`HttpEnqueuer` in `packages/api/function/enqueuer/src/http.ts` hardcodes the body size limit:

```ts
this.router.use(bodyParser.raw({
  limit: "10mb",  // hardcoded, ignores --payload-size-limit
  type: "*/*"
}));
```

The `--payload-size-limit` flag is wired into the main express app body parser (`JsonBodyParser` / `MergePatchJsonParser`) but was never threaded through to `SchedulingOptions` → `HttpEnqueuer`.

## Fix

1. **`SchedulingOptions` interface** — add optional `payloadSizeLimit?: number`
2. **`HttpEnqueuer`** — accept `payloadSizeLimit` as an optional constructor parameter; apply `payloadSizeLimit * 1024 * 1024` bytes as the body-parser limit (matching the MiB unit used throughout the codebase), falling back to `"10mb"` for backward compatibility
3. **`Scheduler`** — pass `this.options.payloadSizeLimit` when constructing `HttpEnqueuer`
4. **`FunctionModule`** — forward `payloadSizeLimit` to `SchedulerModule.forRoot()`
5. **`main.ts`** — pass `payloadSizeLimit: args["payload-size-limit"]` to `FunctionModule.forRoot()`

## Tests

Added two new tests to `http.spec.ts`:
- Verifies the default 10 MiB limit rejects bodies > 10 MiB (regression guard)
- Verifies a custom `payloadSizeLimit` passed to the constructor is respected (rejects above limit, accepts below)

## Backward Compatibility

The `payloadSizeLimit` parameter is **optional** and defaults to `"10mb"` when not provided, so all existing deployments that do not set `--payload-size-limit` are unaffected.