### PR TITLE
fix(passport): fix GET /passport/identify crashing with ERR_HTTP_HEADERS_SENT

### DIFF
--- a/packages/api/passport/src/passport.identity.controller.ts
+++ b/packages/api/passport/src/passport.identity.controller.ts
@@ -165,7 +165,7 @@ export class PassportIdentityController {
   async completeIdentifyWithState(state: string, identity: Identity, expires: number) {
     const res = this.stateReqs.get(state);
     this.stateReqs.delete(state);
-    if (!res || res.headerSent) {
+    if (!res || res.headersSent) {
       return;
     }
 
@@ -201,7 +201,7 @@ export class PassportIdentityController {
 
   async _identify(identifier: string, password: string, state: string, expires: number, res) {
     const catchError = e => {
-      if (!res.headerSent) {
+      if (!res.headersSent) {
         res.status(e.status || 500).json(e.response || e);
       }
     };
@@ -239,14 +239,14 @@ export class PassportIdentityController {
     @Query("identifier") identifier: string,
     @Query("password") password: string,
     @Query("state") state: string,
-    @Req() req: any,
+    @Res() res: any,
     @Query("expires", NUMBER) expires?: number
   ) {
-    req.res.append(
+    res.append(
       "Warning",
       `299 "Identify with 'GET' method has been deprecated. Use 'POST' instead."`
     );
-    this._identify(identifier, password, state, expires, req.res);
+    return this._identify(identifier, password, state, expires, res);
   }
 
   @Post("identify")

--- a/packages/api/passport/test/e2e.spec.ts
+++ b/packages/api/passport/test/e2e.spec.ts
@@ -571,6 +571,28 @@ describe("E2E Tests", () => {
       );
       expect(refreshToken.token).toBeUndefined();
     });
+
+    it("should identify via GET /passport/identify and return a valid token", async () => {
+      const response = await req.get("/passport/identify", {
+        identifier: "spica",
+        password: "spica"
+      });
+
+      expect(response.statusCode).toEqual(200);
+      expect(response.body).toBeDefined();
+      expect(response.body.token).toBeDefined();
+      expect(response.body.scheme).toEqual("IDENTITY");
+      expect(response.headers["warning"]).toContain("299");
+    });
+
+    it("should return 401 via GET /passport/identify when credentials are wrong", async () => {
+      const response = await req.get("/passport/identify", {
+        identifier: "spica",
+        password: "wrongpassword"
+      });
+
+      expect(response.statusCode).toEqual(401);
+    });
   });
 
   describe("SSO", () => {


### PR DESCRIPTION
## Problem

`GET /passport/identify` crashed the Node.js process with `ERR_HTTP_HEADERS_SENT`. Two bugs combined to cause this:

### Bug 1 — Missing `@Res()` decorator on the GET handler

The GET `identify` handler did not use the `@Res()` decorator, so NestJS auto-sent an empty `200` response as soon as the handler returned. Because `_identify()` was not awaited, the handler returned immediately—before `_identify` finished. When `_identify` later called `res.cookie()` / `res.json()`, the headers were already sent, throwing a fatal error.

**Fix:** Add `@Res() res: any` to the GET handler signature (matching the POST handler pattern). This tells NestJS the handler manages its own response, preventing auto-send. Also added `return` to the `_identify()` call.

### Bug 2 — Typo `res.headerSent` instead of `res.headersSent`

Inside `_identify`'s `catchError` callback (and `completeIdentifyWithState`), the guard condition read:
```ts
if (!res.headerSent) { ... }   // always undefined — property doesn't exist
```
The correct Express property is `res.headersSent`. With the typo, the guard never fired, so the error handler would always attempt to write to the response regardless of whether it was already sent.

**Fix:** `res.headerSent` → `res.headersSent` in both locations.

## Changes

- `packages/api/passport/src/passport.identity.controller.ts`
  - Add `@Res() res: any` to `GET identify` handler; remove unused `@Req()` from that handler
  - Add `return` to `_identify()` call in the GET handler
  - Fix `res.headerSent` → `res.headersSent` in `_identify` catchError
  - Fix `res.headerSent` → `res.headersSent` in `completeIdentifyWithState`

- `packages/api/passport/test/e2e.spec.ts`
  - Add test: `GET /passport/identify` with valid credentials returns 200 with token + Warning header
  - Add test: `GET /passport/identify` with invalid credentials returns 401

## Test results

```
PASS  test/e2e.spec.ts (280s)
Tests: 38 passed, 1 skipped, 39 total
```