### PR TITLE
fix(storage): make awss3 credentials path optional, fall back to AWS SDK default credential chain

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -355,7 +355,7 @@ const args = yargsInstance
     "function-asset-awss3-credentials-path": {
       string: true,
       description:
-        "Path to the AWS credentials JSON file ({accessKeyId, secretAccessKey, region}) for function asset storage."
+        "Path to the AWS credentials JSON file ({accessKeyId, secretAccessKey, region}) for function asset storage. Optional; when omitted, the AWS SDK default credential provider chain is used (environment variables, web identity tokens such as EKS IRSA, instance profiles)."
     },
     "function-asset-awss3-bucket-name": {
       string: true,
@@ -400,7 +400,8 @@ const args = yargsInstance
     },
     "awss3-credentials-path": {
       string: true,
-      description: "Path for the credentials file to authorize on aws."
+      description:
+        "Path for the credentials file to authorize on aws. Optional; when omitted, the AWS SDK default credential provider chain is used (environment variables, web identity tokens such as EKS IRSA, instance profiles)."
     },
     "awss3-bucket-name": {
       string: true,
@@ -696,21 +697,18 @@ Example: http(s)://doomed-d45f1.spica.io/api`
       );
     }
 
-    if (
-      args["storage-strategy"] == "awss3" &&
-      (!args["awss3-credentials-path"] || !args["awss3-bucket-name"])
-    ) {
+    if (args["storage-strategy"] == "awss3" && !args["awss3-bucket-name"]) {
       throw new TypeError(
-        "--awss3-credentials-path and --awss3-bucket-name options must be present when --storage-strategy is set to 'awss3'."
+        "--awss3-bucket-name option must be present when --storage-strategy is set to 'awss3'."
       );
     }
 
     if (
       args["function-asset-storage-strategy"] == "awss3" &&
-      (!args["function-asset-awss3-credentials-path"] || !args["function-asset-awss3-bucket-name"])
+      !args["function-asset-awss3-bucket-name"]
     ) {
       throw new TypeError(
-        "--function-asset-awss3-credentials-path and --function-asset-awss3-bucket-name must be present when --function-asset-storage-strategy is set to 'awss3'."
+        "--function-asset-awss3-bucket-name must be present when --function-asset-storage-strategy is set to 'awss3'."
       );
     }
 

--- a/packages/api/function/asset-storage/src/strategy/awss3.ts
+++ b/packages/api/function/asset-storage/src/strategy/awss3.ts
@@ -18,13 +18,13 @@ export class AWSS3Strategy implements FunctionAssetStrategy {
   private readonly s3: S3Client;
 
   constructor(
-    private readonly credentialsPath: string,
+    private readonly credentialsPath: string | undefined,
     private readonly bucketName: string,
     s3?: S3Client
   ) {
     if (s3) {
       this.s3 = s3;
-    } else {
+    } else if (this.credentialsPath) {
       const config = this.getCredentials();
       this.s3 = new S3Client({
         credentials: {
@@ -33,11 +33,16 @@ export class AWSS3Strategy implements FunctionAssetStrategy {
         },
         region: config.region
       });
+    } else {
+      // No credentials file provided: fall back to the AWS SDK default
+      // credential provider chain (environment variables, web identity tokens
+      // such as EKS IRSA, ECS/EC2 instance profiles, shared config files).
+      this.s3 = new S3Client({});
     }
   }
 
   private getCredentials(): AwsCredentials {
-    return JSON.parse(readFileSync(this.credentialsPath, "utf-8"));
+    return JSON.parse(readFileSync(this.credentialsPath!, "utf-8"));
   }
 
   async read(key: string): Promise<Buffer> {

--- a/packages/api/function/asset-storage/test/awss3.strategy.spec.ts
+++ b/packages/api/function/asset-storage/test/awss3.strategy.spec.ts
@@ -17,6 +17,11 @@ describe("AWSS3Strategy", () => {
     jest.resetAllMocks();
   });
 
+  it("should initialize s3 client with the default credential provider chain when credentials path is not provided", () => {
+    const strategyWithoutCredentials = new AWSS3Strategy(undefined, bucketName);
+    expect(strategyWithoutCredentials["s3"]).toBeDefined();
+  });
+
   it("should read a file by streaming body", async () => {
     const {Readable} = await import("stream");
     const fakeBody = Readable.from([Buffer.from("content")]);

--- a/packages/api/storage/src/strategy/aws.s3.ts
+++ b/packages/api/storage/src/strategy/aws.s3.ts
@@ -15,40 +15,28 @@ import {S3Store} from "@tus/s3-store";
 import {BaseStrategy} from "./base-strategy.js";
 import {ProxyReadResult} from "./strategy.js";
 import {StorageObjectMeta} from "@spica-server/interface-storage";
+import type {S3ClientConfig} from "@aws-sdk/client-s3";
 
 export class AWSS3 extends BaseStrategy {
   s3: S3Client;
 
   constructor(
-    private credentialsPath: string,
+    private credentialsPath: string | undefined,
     private bucketName: string,
     resumableUploadExpiresIn: number
   ) {
     super(resumableUploadExpiresIn);
-    const config = this.getConfig();
-    this.s3 = new S3Client({
-      credentials: {
-        accessKeyId: config.accessKeyId,
-        secretAccessKey: config.secretAccessKey
-      },
-      region: config.region
-    });
+    this.s3 = new S3Client(this.getClientConfig());
 
     this.initializeTusServer();
   }
 
   protected initializeTusServer() {
-    const config = this.getConfig();
-
     const datastore = new S3Store({
       partSize: 8 * 1024 * 1024, // Each uploaded part will have ~8MiB,
       s3ClientConfig: {
         bucket: this.bucketName,
-        region: config.region,
-        credentials: {
-          accessKeyId: config.accessKeyId,
-          secretAccessKey: config.secretAccessKey
-        }
+        ...this.getClientConfig()
       },
       expirationPeriodInMilliseconds: this.resumableUploadExpiresIn
     });
@@ -57,7 +45,24 @@ export class AWSS3 extends BaseStrategy {
   }
 
   getConfig() {
-    return JSON.parse(readFileSync(this.credentialsPath, "utf-8"));
+    return JSON.parse(readFileSync(this.credentialsPath!, "utf-8"));
+  }
+
+  private getClientConfig(): S3ClientConfig {
+    // When no credentials file is provided, fall back to the AWS SDK default
+    // credential provider chain (environment variables, web identity tokens
+    // such as EKS IRSA, ECS/EC2 instance profiles, shared config files).
+    if (!this.credentialsPath) {
+      return {};
+    }
+    const config = this.getConfig();
+    return {
+      credentials: {
+        accessKeyId: config.accessKeyId,
+        secretAccessKey: config.secretAccessKey
+      },
+      region: config.region
+    };
   }
 
   writeStream(id: string, data: ReadStream, mimeType?: string): Promise<void> {

--- a/packages/api/storage/test/strategy/aws.s3.spec.ts
+++ b/packages/api/storage/test/strategy/aws.s3.spec.ts
@@ -47,6 +47,11 @@ describe("AWSS3", () => {
     it("should store credentials path", () => {
       expect(service["credentialsPath"]).toEqual(credentialsPath);
     });
+
+    it("should initialize s3 client with the default credential provider chain when credentials path is not provided", () => {
+      const serviceWithoutCredentials = new AWSS3(undefined, "test-bucket", 60000);
+      expect(serviceWithoutCredentials.s3).toBeDefined();
+    });
   });
 
   describe("getConfig", () => {


### PR DESCRIPTION
## Problem

When `--storage-strategy` is set to `awss3`, the API refuses to start unless `--awss3-credentials-path` is also provided:

```
--awss3-credentials-path and --awss3-bucket-name options must be present when --storage-strategy is set to 'awss3'.
```

and the `AWSS3` strategy unconditionally does `JSON.parse(readFileSync(credentialsPath))` expecting static `{accessKeyId, secretAccessKey, region}` keys, passing them explicitly to `S3Client`.

This makes it impossible to use any **role-based credential source** — EKS IRSA (web identity tokens), ECS task roles, or EC2 instance profiles — which are AWS's recommended way to grant S3 access to workloads:

- The credentials file is read **once at startup**, so short-lived STS credentials written to a file expire and break the running server.
- No `sessionToken` is passed to `S3Client`, so temporary credentials are rejected outright.
- The only thing that works today is a long-lived IAM user access key mounted as a file, which is a security anti-pattern.

## Fix

Make the credentials file **optional** for both the storage strategy and the function asset-storage strategy:

- `apps/api/src/main.ts`: only the bucket name is required for `awss3` strategies; option descriptions document the fallback.
- `packages/api/storage/src/strategy/aws.s3.ts`: when no credentials path is given, construct `S3Client` (and the tus `S3Store`) with no explicit credentials so the **AWS SDK default credential provider chain** resolves them (env vars → web identity / IRSA → ECS/EC2 instance profiles → shared config).
- `packages/api/function/asset-storage/src/strategy/awss3.ts`: same fallback.

When `--awss3-credentials-path` **is** provided, behavior is unchanged — existing deployments keep working exactly as before.

## Tests

Added constructor coverage in both specs for the no-credentials-path case.