### PR TITLE
docs: correct devkit npm package scope to @spica-devkit/*

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -95,7 +95,7 @@ curl -s "https://hub.docker.com/v2/repositories/spicaengine/mongoreplicationcont
 ### npm packages
 Check all six packages are published at the new version:
 ```bash
-for pkg in "@spica/cli" "@spica/devkit-auth" "@spica/devkit-bucket" "@spica/devkit-database" "@spica/devkit-identity" "@spica/devkit-storage"; do
+for pkg in "@spica/cli" "@spica-devkit/auth" "@spica-devkit/bucket" "@spica-devkit/database" "@spica-devkit/identity" "@spica-devkit/storage"; do
   ver=$(npm view "$pkg" version 2>/dev/null || echo "NOT FOUND")
   echo "$pkg: $ver"
 done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ Use `/release <version>` (`.claude/commands/release.md`) to execute a full relea
 | Artifact | Where | Tag format |
 |---|---|---|
 | Docker images | Docker Hub `spicaengine/{api,panel,migrate,mongoreplicationcontroller}` | `<version>` |
-| npm packages | npmjs.com `@spica/{cli,devkit-auth,devkit-bucket,devkit-database,devkit-identity,devkit-storage}` | `<version>` |
+| npm packages | npmjs.com `@spica/cli` + `@spica-devkit/{auth,bucket,database,identity,storage}` | `<version>` |
 | Helm chart | GCS bucket `gs://spica-charts` / `https://spica-charts.storage.googleapis.com` | `<version>` |
 
 ### GitHub Actions workflows involved


### PR DESCRIPTION
## Summary
- The release docs (`CLAUDE.md` and `.claude/commands/release.md`) listed the devkit npm packages as `@spica/devkit-*`, but they are actually published under the `@spica-devkit` scope (e.g. `@spica-devkit/bucket`).
- This caused the npm verification step during the `0.18.40` release to report false `NOT FOUND` results even though all packages published successfully.
- Corrected both references to `@spica-devkit/{auth,bucket,database,identity,storage}` (verified live on npm at `0.18.40`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)