### PR TITLE
ci(claude-review): grant write perms and actually post the review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
@@ -38,7 +38,11 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # --comment makes the review post inline findings on the diff.
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
+          # Post a tracking comment on the PR with the review output, so the result is
+          # always visible even when there are no inline findings.
+          track_progress: true
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
-      issues: write
+      pull-requests: read
+      issues: read
+      # Required so the action can exchange this for the Claude GitHub App token,
+      # which is what actually posts the review (it does not use GITHUB_TOKEN's
+      # permissions above - hence these can stay read-only).
       id-token: write
 
     steps:


### PR DESCRIPTION
## Problem

The **Claude Code Review** workflow runs on every PR but **never posts a review**. On PR #1837 the job went green yet produced no comment.

## Root cause — it was config, not permissions

The action authenticates GitHub via the **Claude GitHub App** (OIDC → app token), not the workflow's `GITHUB_TOKEN`. The job log confirms it:

```
OIDC token successfully obtained
Exchanging OIDC token for app token...
App token successfully obtained
Using GITHUB_TOKEN from OIDC
```

So posting capability was already there (the App token has write). The actual gap: the prompt ran in **report-only** mode, so the action logged `No buffered inline comments` and posted nothing.

## Fix (least privilege — workflow token stays read-only)

- `--comment` so the review posts inline findings on the diff.
- `track_progress: true` so a review comment is always posted, visible even with no inline findings.
- Workflow `permissions` stay read-only; `id-token: write` remains (needed only to obtain the App token via OIDC — it is not repo write).

## Must merge to `master` to take effect

`anthropics/claude-code-action` validates this workflow file against the **default branch** before issuing its app token:

> Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch.

So the change is inert on a feature branch and only activates once on `master`. **The `claude-review` check on this PR will itself show that expected "Workflow validation failed" error — it is safe to ignore** (the action's own message says so), and it is not a required check. After merge, PRs will get a posted review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
