### PR TITLE
docs: add WHY-not-WHAT commenting policy to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,14 @@ Use `/release <version>` (`.claude/commands/release.md`) to execute a full relea
 - `DOCKERHUB_TOKEN` + `DOCKERHUB_USERNAME` (var) — Docker Hub credentials for `spicaengine` org
 - `GCP_CREDENTIALS` — GCP service account JSON for Helm chart sync to GCS
 
+## Comments
+
+- Code must be self-explanatory; do not add comments that restate WHAT the code does.
+- Only comment to explain WHY — non-obvious rationale, tradeoffs, workarounds, or surprising constraints.
+- Prefer clear names and structure over explanatory comments.
+- This applies strictly to source code. Test files may use comments more liberally.
+- Misleading comments are worse than none: if code changes, a stale WHAT-comment lies to the reader.
+
 ## Additional Instructions
 
 @.claude/instructions/performance-optimization.md


### PR DESCRIPTION
## What

Adds a **Comments** section to `CLAUDE.md` documenting the project's commenting convention:

- Code must be self-explanatory; do not add comments that restate WHAT the code does.
- Only comment to explain WHY — non-obvious rationale, tradeoffs, workarounds, or surprising constraints.
- Prefer clear names and structure over explanatory comments.
- This applies strictly to source code. Test files may use comments more liberally.
- Misleading comments are worse than none: if code changes, a stale WHAT-comment lies to the reader.

## Why

Codifies the convention so contributors (and AI assistants reading `CLAUDE.md`) keep source code comment-light and reserve comments for rationale.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)