### PR TITLE
fix(cli): build @spica-server/sync before bundling cli

### DIFF
--- a/apps/cli/project.json
+++ b/apps/cli/project.json
@@ -7,6 +7,7 @@
   "targets": {
     "bundle": {
       "executor": "@nx/esbuild:esbuild",
+      "dependsOn": [{"projects": ["sync"], "target": "build"}],
       "outputs": ["{workspaceRoot}/dist/apps/cli"],
       "options": {
         "main": "apps/cli/index.ts",


### PR DESCRIPTION
The cli bundle (esbuild) imports runtime values from the shared @spica-server/sync package introduced in #1837, but the bundle target had no build dependency on it. In the release npm job — a fresh checkout with no prior build — packages/sync/dist was never produced, so esbuild failed to resolve @spica-server/sync and the cli publish aborted (which fail-fast-cancelled the rest of the npm matrix).

Add a build dependency on the sync project so its dist exists before the cli is bundled. Only sync is needed: the other @spica-server imports in the cli are type-only and erased by esbuild.