### PR TITLE
fix(devkit): publish @spica-devkit/testing with public access

### DIFF
--- a/packages/devkit/testing/package.json
+++ b/packages/devkit/testing/package.json
@@ -18,6 +18,9 @@
     }
   },
   "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "axios": "^1.8.2",
     "dockerode": "^4.0.4",


### PR DESCRIPTION
## Problem

During the `0.18.42` release, the **`Release npm package (devkit:testing)`** job failed:

```
402 Payment Required - PUT https://registry.npmjs.org/@spica-devkit%2ftesting
You must sign up for private packages
```

`@spica-devkit/testing` (added in #1837) is a brand-new scoped package. npm publishes scoped packages as **restricted (private)** by default, and the org has no private-package plan — so the first publish is rejected with 402. The other `@spica-devkit/*` packages are unaffected only because they already exist on npm as public.

## Fix

Add `publishConfig.access: "public"` to `packages/devkit/testing/package.json`. The shared `packages/devkit/rollup.config.js` copies this file into `dist/`, and `nx-release-publish` honors `publishConfig.access`.

## Validation

`yarn nx bundle devkit/testing` → `dist/package.json` now contains:

```json
"publishConfig": { "access": "public" }
```

## Context

Part of the `0.18.42` release recovery. After this merges, the `0.18.42` tag will be moved to include it and the remaining npm packages (auth, identity, storage, testing) will be published. cli/bucket/database@0.18.42 are already live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)