### PR TITLE
chore(docker): set NODE_ENV=production in runner stages

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -5,6 +5,7 @@ FROM base AS runner
 WORKDIR /app
 COPY dist .
 RUN yarn install --production --network-timeout 600000
+ENV NODE_ENV=production
 ENV DEFAULT_PASSWORD=spica
 ENV FUNCTION_GRPC_ADDRESS=0.0.0.0:5688
 ENTRYPOINT ["node","src/main.js"]

--- a/apps/migrate/Dockerfile
+++ b/apps/migrate/Dockerfile
@@ -5,4 +5,5 @@ FROM base AS runner
 WORKDIR /app
 COPY dist .
 RUN yarn install --production --network-timeout 600000
+ENV NODE_ENV=production
 ENTRYPOINT ["node","src/main.js"]

--- a/apps/mongoreplicationcontroller/Dockerfile
+++ b/apps/mongoreplicationcontroller/Dockerfile
@@ -17,4 +17,5 @@ FROM tools AS runner
 WORKDIR /app
 COPY dist .
 RUN yarn install --production --network-timeout 600000
+ENV NODE_ENV=production
 ENTRYPOINT ["node","src/main.js"]


### PR DESCRIPTION
## Context

The production images never set `NODE_ENV`. All three Node-based images launch `node src/main.js` with `NODE_ENV` unset, so at runtime Node, Express (under NestJS), and the many npm libraries that branch on `NODE_ENV` fall back to their *development* code paths — extra logging, no view/route caching, looser error verbosity, and skipped production optimizations.

`yarn install --production` (already present) only prunes devDeps at build time; it does **not** set the runtime `NODE_ENV`.

## Change

Add `ENV NODE_ENV=production` to the `runner` stage of each Node-based Dockerfile:

- `apps/api/Dockerfile` — main API server
- `apps/migrate/Dockerfile` — migration runner
- `apps/mongoreplicationcontroller/Dockerfile` — replication controller

The image is the single source of truth — both `deployment.yaml` and the Helm chart inherit it (neither overrides `NODE_ENV`).

### Not changed
- `apps/panel/Dockerfile` — nginx serving a static Angular build; `NODE_ENV` has no runtime effect there.
- k8s / Helm manifests — they inherit from the image; adding it there would be a redundant second source of truth.

## Notes

The repo's own code only branches on `NODE_ENV === "test"` / `!== "development"` (`activity.interceptor.ts`, `migrate.ts`, panel `logger.ts`); none break when it becomes `"production"`. Tests run outside Docker and are unaffected.

## Verification

```
docker run --rm <image> node -e "console.log(process.env.NODE_ENV)"   # → production
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)