### PR TITLE
fix(cli): fail loudly when a sync list endpoint returns a non-list body

### DIFF
--- a/packages/sync/src/fs-utils.ts
+++ b/packages/sync/src/fs-utils.ts
@@ -66,11 +66,24 @@ export function sanitizeSlug(slug: string): string {
 
 /**
  * Unwrap a list response that may be paginated ({ data: T[] }) or a plain array (T[]).
- * Use this defensively whenever the API might paginate.
+ *
+ * Throws on anything else: a non-list body (e.g. the panel's HTML SPA fallback
+ * served with HTTP 200 when the context URL points at the panel instead of the
+ * API) would otherwise be silently treated as an empty remote, producing a
+ * plan that wipes or recreates everything. Fail loudly with a hint instead.
  */
 export function unwrapList<T>(res: T[] | {data: T[]}): T[] {
   if (Array.isArray(res)) return res;
-  return (res as {data: T[]}).data ?? [];
+  if (res && typeof res === "object" && Array.isArray((res as {data: T[]}).data)) {
+    return (res as {data: T[]}).data;
+  }
+  const body = res as unknown;
+  const got =
+    typeof body === "string" ? `${body.slice(0, 80).replace(/\s+/g, " ")}…` : typeof body;
+  throw new Error(
+    `Expected a list response but got: ${got}. ` +
+      `Check that your context URL points at the Spica API (e.g. ".../api"), not the panel.`
+  );
 }
 
 /**

--- a/packages/sync/src/modules/function.ts
+++ b/packages/sync/src/modules/function.ts
@@ -13,6 +13,7 @@ import {
   readYaml,
   removeDir,
   sanitizeSlug,
+  unwrapList,
   writeText,
   writeYaml
 } from "../fs-utils";
@@ -144,7 +145,8 @@ export const functionModule: FunctionModule = {
   },
 
   async readRemote(http) {
-    const fns = await http.get<FunctionSchema[]>("function");
+    const res = await http.get<FunctionSchema[] | {data: FunctionSchema[]}>("function");
+    const fns = unwrapList(res);
 
     return Promise.all(
       fns.map(async fn => {

--- a/packages/sync/src/modules/policy.ts
+++ b/packages/sync/src/modules/policy.ts
@@ -1,6 +1,13 @@
 import {SyncHttpClient} from "../http";
 import {diffSchemaFields, renderSchemaDetail} from "../planner";
-import {deleteLocalSchema, omit, readLocalSchemas, sanitizeSlug, writeLocalSchema} from "../fs-utils";
+import {
+  deleteLocalSchema,
+  omit,
+  readLocalSchemas,
+  sanitizeSlug,
+  unwrapList,
+  writeLocalSchema
+} from "../fs-utils";
 import {LocalResource, RemoteResource, ResourceModule} from "../types";
 
 interface Policy {
@@ -26,8 +33,7 @@ export const policyModule: ResourceModule<Policy> = {
 
   async readRemote(http) {
     const res = await http.get<{data: Policy[]} | Policy[]>("passport/policy");
-    // The policy endpoint may paginate and return {data: [...]}
-    const items: Policy[] = Array.isArray(res) ? res : ((res as any).data ?? []);
+    const items = unwrapList(res);
     // Filter out system policies which cannot be modified
     return items
       .filter(p => !p.system)

--- a/packages/sync/test/fs-utils.spec.ts
+++ b/packages/sync/test/fs-utils.spec.ts
@@ -46,15 +46,19 @@ describe("unwrapList", () => {
     expect(unwrapList({data: items})).toEqual(items);
   });
 
-  it("returns an empty array when data is undefined", () => {
-    expect(unwrapList({} as any)).toEqual([]);
-  });
-
   it("returns an empty array when data is an empty array", () => {
     expect(unwrapList({data: []})).toEqual([]);
   });
 
   it("returns a plain empty array as-is", () => {
     expect(unwrapList([])).toEqual([]);
+  });
+
+  it("throws on an object without a data array", () => {
+    expect(() => unwrapList({} as any)).toThrow(/context URL/);
+  });
+
+  it("throws with a hint when the body is a non-list (e.g. panel HTML)", () => {
+    expect(() => unwrapList("<!doctype html><html></html>" as any)).toThrow(/context URL/);
   });
 });

--- a/packages/sync/test/modules/function.spec.ts
+++ b/packages/sync/test/modules/function.spec.ts
@@ -132,6 +132,32 @@ describe("functionModule.readRemote", () => {
     expect(result[0].data.schema.env_vars).toEqual(["ev-id-1"]);
     expect(result[0].data.schema.secrets).toEqual(["sec-id-1"]);
   });
+
+  it("unwraps a paginated {data: [...]} response from the function endpoint", async () => {
+    mockHttp.get.mockImplementation((url: string) => {
+      if (url === "function")
+        return Promise.resolve({data: [{_id: "fn1", name: "MyFn", language: "javascript"}]});
+      if (url === "function/fn1/index") return Promise.resolve({index: ""});
+      if (url === "function/fn1/dependencies") return Promise.resolve([]);
+      return Promise.resolve([]);
+    });
+
+    const result = await functionModule.readRemote(mockHttp);
+    expect(result).toHaveLength(1);
+    expect(result[0].slug).toBe("MyFn");
+  });
+
+  // Regression: a context URL pointing at the panel returns an HTML SPA page with
+  // HTTP 200. Previously `fns.map` crashed cryptically; now we fail with a hint
+  // instead of silently treating it as an empty remote.
+  it("throws a helpful error when the endpoint returns a non-list body (e.g. panel HTML)", async () => {
+    mockHttp.get.mockImplementation((url: string) => {
+      if (url === "function") return Promise.resolve("<!doctype html><html><body>Panel</body></html>");
+      return Promise.resolve([]);
+    });
+
+    await expect(functionModule.readRemote(mockHttp)).rejects.toThrow(/context URL/);
+  });
 });
 
 describe("functionModule.create", () => {


### PR DESCRIPTION
## Symptom

```
✔ Fetching remote Policy
✔ Fetching remote Bucket
✔ Fetching remote Environment Variable
✔ Fetching remote Secret
✖ Fetching remote Function
fns.map is not a function
```

## Root cause (verified against a live instance — it is NOT pagination)

The crash happens when the active context URL points at the **panel** instead of the **API**. The panel serves its HTML SPA fallback with **HTTP 200** for unknown paths, so `GET <url>/function` returns an HTML string, not JSON. Probed directly:

| Request | Result |
|---|---|
| `GET http://localhost:4300/function` | **200 `text/html`** — panel `index.html` |
| `GET http://localhost:4300/api/function` | 401 JSON — the real API |

The axios interceptor hands that HTML string back as the body. Then:

- **`function`** does `fns.map(...)` on a string → **`fns.map is not a function`** (loud ✖).
- **`bucket`/`policy`/`env-var`/`secret`** run it through `unwrapList`, which returned `[]` for any non-array → a **misleading ✔** that silently treats the remote as empty. That is the more dangerous failure: a subsequent `apply`/`fetch` would act on a plan that wants to recreate/wipe everything.

(For the record, the live API returns functions as a **plain array**, not a `{data: [...]}` envelope — so the original "add `unwrapList` to dodge pagination" idea would only have converted the loud crash into the same silent-empty footgun.)

## Fix

Harden `unwrapList` to accept **only** a plain array or a paginated `{data: [...]}` envelope, and otherwise **throw** with an actionable hint:

> Expected a list response but got: `<!doctype html><html>…`. Check that your context URL points at the Spica API (e.g. ".../api"), not the panel.

Route the `function` module through `unwrapList` too, so every list module shares one consistent, honest failure mode instead of crashing cryptically or swallowing the misconfiguration.

## Tests

- `unwrapList`: throws on a non-list body (HTML) and on an object without a `data` array; still passes arrays and `{data: [...]}` through.
- `functionModule.readRemote`: surfaces the helpful error on a panel-HTML response; still handles arrays and `{data: [...]}`.
- Full `sync` suite green (102/102).

🤖 Generated with [Claude Code](https://claude.com/claude-code)