### PR TITLE
fix(bucket): cache schemas in memory to stop per-document query storm

### DIFF
--- a/packages/api/bucket/common/src/crud.ts
+++ b/packages/api/bucket/common/src/crud.ts
@@ -173,7 +173,7 @@ export async function findDocuments<T>(
 async function buildAclProjection(
   schema: Bucket,
   user: any,
-  schemaResolver: (id: string | ObjectId) => Promise<Bucket>,
+  schemaResolver: (id: string | ObjectId) => Promise<Bucket> | Bucket,
   hashSecret?: string
 ) {
   const properties = schema.properties as Record<string, {acl?: string}>;
@@ -223,7 +223,7 @@ export async function insertDocument(
   },
   factories: {
     collection: (schema: Bucket) => BaseCollection<any>;
-    schema: (id: string | ObjectId) => Promise<Bucket>;
+    schema: (id: string | ObjectId) => Promise<Bucket> | Bucket;
     deleteOne: (documentId: ObjectId) => Promise<void>;
   },
   hashSecret?: string,
@@ -275,7 +275,7 @@ export async function replaceDocument(
   },
   factories: {
     collection: (schema: Bucket) => BaseCollection<any>;
-    schema: (id: string | ObjectId) => Promise<Bucket>;
+    schema: (id: string | ObjectId) => Promise<Bucket> | Bucket;
   },
   options: {
     returnDocument: ReturnDocument;
@@ -322,7 +322,7 @@ export async function patchDocument(
   },
   factories: {
     collection: (schema: Bucket) => BaseCollection<any>;
-    schema: (id: string | ObjectId) => Promise<Bucket>;
+    schema: (id: string | ObjectId) => Promise<Bucket> | Bucket;
   },
   options: {
     returnDocument: ReturnDocument;
@@ -368,7 +368,7 @@ export async function deleteDocument(
   },
   factories: {
     collection: (schema: Bucket) => BaseCollection<BucketDocument>;
-    schema: (schema: string | ObjectId) => Promise<Bucket>;
+    schema: (schema: string | ObjectId) => Promise<Bucket> | Bucket;
   },
   hashSecret?: string,
   encryptionSecret?: string
@@ -404,7 +404,7 @@ export async function deleteDocument(
 
 async function executeWriteRule(
   schema: Bucket,
-  resolve: (id: string) => Promise<Bucket>,
+  resolve: (id: string) => Promise<Bucket> | Bucket,
   document: BucketDocument,
   collection: BaseCollection<unknown>,
   auth: object,

--- a/packages/api/bucket/graphql/src/graphql.ts
+++ b/packages/api/bucket/graphql/src/graphql.ts
@@ -278,7 +278,7 @@ export class GraphqlController implements OnModuleInit {
         {
           collection: (schema: Bucket) => this.bds.children(schema),
           preference: () => this.bs.getPreferences(),
-          schema: (bucketId: string) => this.bs.findOne({_id: new ObjectId(bucketId)})
+          schema: this.bs.resolveSchema
         },
         this.hashSecret,
         this.encryptionSecret
@@ -351,7 +351,7 @@ export class GraphqlController implements OnModuleInit {
         {req: context, applyAcl: this.shouldApplyAcl(context)},
         {
           collection: bucketId => this.bds.children(bucketId),
-          schema: (bucketId: string) => this.bs.findOne({_id: new ObjectId(bucketId)}),
+          schema: this.bs.resolveSchema,
           deleteOne: async documentId => {
             const deleteFn = this.delete(bucket, false);
             await deleteFn(root, {_id: documentId}, context, info);
@@ -389,7 +389,7 @@ export class GraphqlController implements OnModuleInit {
         {
           collection: (schema: Bucket) => this.bds.children(schema),
           preference: () => this.bs.getPreferences(),
-          schema: (bucketId: string) => this.bs.findOne({_id: new ObjectId(bucketId)})
+          schema: this.bs.resolveSchema
         },
         this.hashSecret,
         this.encryptionSecret
@@ -434,7 +434,7 @@ export class GraphqlController implements OnModuleInit {
         {req: context, applyAcl: this.shouldApplyAcl(context)},
         {
           collection: bucketId => this.bds.children(bucketId),
-          schema: (bucketId: string) => this.bs.findOne({_id: new ObjectId(bucketId)})
+          schema: this.bs.resolveSchema
         },
         undefined,
         this.hashSecret,
@@ -476,7 +476,7 @@ export class GraphqlController implements OnModuleInit {
         {
           collection: (schema: Bucket) => this.bds.children(schema),
           preference: () => this.bs.getPreferences(),
-          schema: (bucketId: string) => this.bs.findOne({_id: new ObjectId(bucketId)})
+          schema: this.bs.resolveSchema
         },
         this.hashSecret,
         this.encryptionSecret
@@ -519,7 +519,7 @@ export class GraphqlController implements OnModuleInit {
           previousDocument,
           bucket,
           this.encryptionSecret,
-          bucketId => this.bs.findOne({_id: new ObjectId(bucketId)})
+          this.bs.resolveSchema
         );
       }
 
@@ -536,7 +536,7 @@ export class GraphqlController implements OnModuleInit {
         {req: context, applyAcl: this.shouldApplyAcl(context)},
         {
           collection: bucketId => this.bds.children(bucketId),
-          schema: (bucketId: string) => this.bs.findOne({_id: new ObjectId(bucketId)})
+          schema: this.bs.resolveSchema
         },
         {returnDocument: ReturnDocument.AFTER},
         this.hashSecret,
@@ -576,7 +576,7 @@ export class GraphqlController implements OnModuleInit {
         {
           collection: (schema: Bucket) => this.bds.children(schema),
           preference: () => this.bs.getPreferences(),
-          schema: (bucketId: string) => this.bs.findOne({_id: new ObjectId(bucketId)})
+          schema: this.bs.resolveSchema
         },
         this.hashSecret,
         this.encryptionSecret
@@ -621,7 +621,7 @@ export class GraphqlController implements OnModuleInit {
         {req: context, applyAcl: this.shouldApplyAcl(context)},
         {
           collection: schema => this.bds.children(schema),
-          schema: (bucketId: string) => this.bs.findOne({_id: new ObjectId(bucketId)})
+          schema: this.bs.resolveSchema
         },
         this.hashSecret,
         this.encryptionSecret

--- a/packages/api/bucket/realtime/src/bucket-data-options.builder.ts
+++ b/packages/api/bucket/realtime/src/bucket-data-options.builder.ts
@@ -1,11 +1,7 @@
 import {RealtimeOptionsBuilder} from "@spica-server/realtime";
 import * as expression from "@spica-server/bucket-expression";
 import {aggregate} from "@spica-server/bucket-expression";
-import {
-  authIdToString,
-  filterReviver,
-  constructFilterValues
-} from "@spica-server/bucket-common";
+import {authIdToString, filterReviver, constructFilterValues} from "@spica-server/bucket-common";
 import {Bucket} from "@spica-server/interface-bucket";
 
 export class BucketDataOptionsBuilder extends RealtimeOptionsBuilder {
@@ -19,14 +15,11 @@ export class BucketDataOptionsBuilder extends RealtimeOptionsBuilder {
   async applyBucketFilter(
     rawFilter: string,
     schema: Bucket,
-    bucketResolver: (id: string) => Promise<Bucket>
+    bucketResolver: (id: string) => Promise<Bucket> | Bucket
   ): Promise<this> {
     this.ensureAndFilter();
 
-    let parsedFilter = parseFilter(
-      (value: string) => JSON.parse(value, filterReviver),
-      rawFilter
-    );
+    let parsedFilter = parseFilter((value: string) => JSON.parse(value, filterReviver), rawFilter);
 
     if (parsedFilter) {
       parsedFilter = await constructFilterValues(parsedFilter, schema, bucketResolver);
@@ -57,7 +50,7 @@ export class BucketDataOptionsBuilder extends RealtimeOptionsBuilder {
   static async fromBucketQuery(
     req: any,
     schema: Bucket,
-    bucketResolver: (id: string) => Promise<Bucket>,
+    bucketResolver: (id: string) => Promise<Bucket> | Bucket,
     shouldApplyAcl: boolean
   ): Promise<any> {
     const builder = new BucketDataOptionsBuilder();
@@ -69,11 +62,7 @@ export class BucketDataOptionsBuilder extends RealtimeOptionsBuilder {
     }
 
     if (normalizedReq.query.has("filter")) {
-      await builder.applyBucketFilter(
-        normalizedReq.query.get("filter"),
-        schema,
-        bucketResolver
-      );
+      await builder.applyBucketFilter(normalizedReq.query.get("filter"), schema, bucketResolver);
     }
 
     if (normalizedReq.query.has("sort")) {

--- a/packages/api/bucket/realtime/src/realtime.gateway.ts
+++ b/packages/api/bucket/realtime/src/realtime.gateway.ts
@@ -563,7 +563,7 @@ export class RealtimeGateway implements OnGatewayConnection, OnGatewayDisconnect
       return document;
     }
 
-    const schema = await this.bucketService.findOne({_id: new ObjectId(req.params.id)});
+    const schema = await this.getBucketResolver()(new ObjectId(req.params.id));
     if (!schema?.properties) {
       return document;
     }
@@ -573,7 +573,7 @@ export class RealtimeGateway implements OnGatewayConnection, OnGatewayDisconnect
 
   private async decryptDocuments(_client: any, req: any) {
     const bucketId = req.params.id;
-    const schema = await this.bucketService.findOne({_id: new ObjectId(bucketId)});
+    const schema = await this.getBucketResolver()(new ObjectId(bucketId));
     if (!schema) return undefined;
     return (document: any) => {
       if (!document) return document;

--- a/packages/api/bucket/realtime/src/realtime.gateway.ts
+++ b/packages/api/bucket/realtime/src/realtime.gateway.ts
@@ -546,7 +546,7 @@ export class RealtimeGateway implements OnGatewayConnection, OnGatewayDisconnect
   }
 
   getBucketResolver() {
-    return (id: string | ObjectId) => this.bucketService.findOne({_id: new ObjectId(id)});
+    return this.bucketService.resolveSchema;
   }
 
   send(client, kind: ChunkKind, status: number, message: string) {

--- a/packages/api/bucket/services/package.json
+++ b/packages/api/bucket/services/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@nestjs/common": "^10.4.15",
+    "@spica-server/core-patch": "workspace:*",
     "@spica-server/core-schema": "workspace:*",
     "@spica-server/database": "workspace:*",
     "@spica-server/interface-bucket": "workspace:*",

--- a/packages/api/bucket/services/src/bucket.service.ts
+++ b/packages/api/bucket/services/src/bucket.service.ts
@@ -91,8 +91,6 @@ export class BucketService
           this.schemaCache.set(id, change.fullDocument);
         }
       },
-      // observer.error terminates the stream; a non-resumable error would otherwise
-      // leave the cache silently stale, so reload and re-open the watcher.
       error: async error => {
         if (this.destroyed) {
           return;
@@ -112,9 +110,6 @@ export class BucketService
     });
   }
 
-  // Returns a copy: callers (relation/ACL resolution) alias and mutate the schema,
-  // and findOne historically handed out a fresh object each call. The cold-miss
-  // findOne is already fresh, so only the cache hit needs copying.
   resolveSchema = (id: string | ObjectId): Bucket | Promise<Bucket> => {
     const cached = this.schemaCache.get(id.toString());
     return cached ? deepCopy(cached) : this.findOne({_id: new ObjectId(id)});

--- a/packages/api/bucket/services/src/bucket.service.ts
+++ b/packages/api/bucket/services/src/bucket.service.ts
@@ -1,4 +1,12 @@
-import {Inject, Injectable, NotFoundException, Optional} from "@nestjs/common";
+import {
+  Inject,
+  Injectable,
+  Logger,
+  NotFoundException,
+  OnModuleDestroy,
+  OnModuleInit,
+  Optional
+} from "@nestjs/common";
 import {Validator} from "@spica-server/core-schema";
 import {Default} from "@spica-server/interface-core";
 import {
@@ -11,7 +19,8 @@ import {
   WithId
 } from "@spica-server/database";
 import {PreferenceService} from "@spica-server/preference-services";
-import {BehaviorSubject, Observable} from "rxjs";
+import {deepCopy} from "@spica-server/core-patch";
+import {BehaviorSubject, Observable, Subscription} from "rxjs";
 import {getBucketDataCollection} from "./index.js";
 import {
   IndexDefinition,
@@ -23,8 +32,16 @@ import {
 import * as crypto from "crypto";
 
 @Injectable()
-export class BucketService extends BaseCollection<Bucket>("buckets") {
+export class BucketService
+  extends BaseCollection<Bucket>("buckets")
+  implements OnModuleInit, OnModuleDestroy
+{
   schemaChangeEmitter: BehaviorSubject<any> = new BehaviorSubject<any>(undefined);
+
+  private readonly logger = new Logger(BucketService.name);
+  private schemaCache = new Map<string, Bucket>();
+  private cacheSub?: Subscription;
+  private destroyed = false;
 
   constructor(
     db: DatabaseService,
@@ -36,6 +53,72 @@ export class BucketService extends BaseCollection<Bucket>("buckets") {
       collectionOptions: {changeStreamPreAndPostImages: {enabled: true}}
     });
   }
+
+  async onModuleInit() {
+    await this.warmSchemaCache();
+    this.startSchemaCacheWatch();
+  }
+
+  onModuleDestroy() {
+    this.destroyed = true;
+    this.cacheSub?.unsubscribe();
+  }
+
+  private async warmSchemaCache() {
+    const all = await super.find();
+    this.schemaCache = new Map(all.map(bucket => [bucket._id.toString(), bucket]));
+  }
+
+  private startSchemaCacheWatch() {
+    if (this.destroyed) {
+      return;
+    }
+    this.cacheSub = this.watch(
+      [{$match: {operationType: {$in: ["insert", "update", "replace", "delete"]}}}],
+      {fullDocument: "updateLookup"}
+    ).subscribe({
+      next: change => {
+        if (!("documentKey" in change)) {
+          return;
+        }
+        const id = (change.documentKey._id as ObjectId)?.toString();
+        if (!id) {
+          return;
+        }
+        if (change.operationType === "delete") {
+          this.schemaCache.delete(id);
+        } else if ("fullDocument" in change && change.fullDocument) {
+          this.schemaCache.set(id, change.fullDocument);
+        }
+      },
+      // observer.error terminates the stream; a non-resumable error would otherwise
+      // leave the cache silently stale, so reload and re-open the watcher.
+      error: async error => {
+        if (this.destroyed) {
+          return;
+        }
+        this.logger.error(
+          `bucket schema cache watch error: ${error instanceof Error ? error.message : error}`
+        );
+        try {
+          await this.warmSchemaCache();
+        } catch (e) {
+          this.logger.error(
+            `bucket schema cache re-warm failed: ${e instanceof Error ? e.message : e}`
+          );
+        }
+        this.startSchemaCacheWatch();
+      }
+    });
+  }
+
+  // Returns a copy: callers (relation/ACL resolution) alias and mutate the schema,
+  // and findOne historically handed out a fresh object each call. The cold-miss
+  // findOne is already fresh, so only the cache hit needs copying.
+  resolveSchema = (id: string | ObjectId): Bucket | Promise<Bucket> => {
+    const cached = this.schemaCache.get(id.toString());
+    return cached ? deepCopy(cached) : this.findOne({_id: new ObjectId(id)});
+  };
 
   getPreferences() {
     return this.pref.get<BucketPreferences>("bucket");
@@ -81,6 +164,8 @@ export class BucketService extends BaseCollection<Bucket>("buckets") {
 
     const insertedBucket = await super.insertOne(bucket);
 
+    this.schemaCache.set(insertedBucket._id.toString(), deepCopy(insertedBucket));
+
     await this.db.createCollection(getBucketDataCollection(insertedBucket._id));
 
     await this.updateIndexes(bucket);
@@ -93,9 +178,11 @@ export class BucketService extends BaseCollection<Bucket>("buckets") {
     doc: Bucket,
     options?: FindOneAndReplaceOptions
   ): Promise<WithId<Bucket>> {
-    return super
-      .findOneAndReplace(filter, doc, options)
-      .then(r => this.updateIndexes({...doc, _id: filter._id as ObjectId}).then(() => r));
+    return super.findOneAndReplace(filter, doc, options).then(r => {
+      const replaced = {...doc, _id: filter._id as ObjectId} as WithId<Bucket>;
+      this.schemaCache.set(replaced._id.toString(), deepCopy(replaced));
+      return this.updateIndexes(replaced).then(() => r);
+    });
   }
 
   async drop(id: string | ObjectId) {
@@ -103,6 +190,7 @@ export class BucketService extends BaseCollection<Bucket>("buckets") {
     if (!schema) {
       throw new NotFoundException(`Bucket with ID ${id} does not exist.`);
     }
+    this.schemaCache.delete(id.toString());
     await this.db.dropCollection(getBucketDataCollection(id));
     return schema;
   }

--- a/packages/api/bucket/services/tsconfig.json
+++ b/packages/api/bucket/services/tsconfig.json
@@ -7,6 +7,9 @@
   "include": ["src/**/*.ts", "index.ts"],
   "references": [
     {
+      "path": "../../../core/patch"
+    },
+    {
       "path": "../../preference/services"
     },
     {

--- a/packages/api/bucket/src/bucket-data.controller.ts
+++ b/packages/api/bucket/src/bucket-data.controller.ts
@@ -149,7 +149,7 @@ export class BucketDataController {
       {
         collection: schema => this.bds.children(schema),
         preference: () => this.bs.getPreferences(),
-        schema: (bucketId: string) => this.bs.findOne({_id: new ObjectId(bucketId)})
+        schema: this.bs.resolveSchema
       },
       this.hashSecret,
       this.encryptionSecret
@@ -245,7 +245,7 @@ export class BucketDataController {
       {
         collection: schema => this.bds.children(schema),
         preference: () => this.bs.getPreferences(),
-        schema: (bucketId: string) => this.bs.findOne({_id: new ObjectId(bucketId)})
+        schema: this.bs.resolveSchema
       },
       this.hashSecret,
       this.encryptionSecret
@@ -304,7 +304,7 @@ export class BucketDataController {
       {req: req, applyAcl: strategyType === ReqAuthStrategy.USER},
       {
         collection: schema => this.bds.children(schema),
-        schema: (bucketId: string) => this.bs.findOne({_id: new ObjectId(bucketId)}),
+        schema: this.bs.resolveSchema,
         deleteOne: documentId => this.deleteOne(strategyType, req, bucketId, documentId)
       },
       this.hashSecret,
@@ -365,7 +365,7 @@ export class BucketDataController {
       throw new NotFoundException(`Could not find the schema with id ${bucketId}`);
     }
 
-    const schemaResolver = (bucketId: string) => this.bs.findOne({_id: new ObjectId(bucketId)});
+    const schemaResolver = this.bs.resolveSchema;
     const previousDocument = await replaceDocument(
       schema,
       {...document, _id: documentId},
@@ -461,7 +461,7 @@ export class BucketDataController {
       {req: req, applyAcl: strategyType === ReqAuthStrategy.USER},
       {
         collection: schema => this.bds.children(schema),
-        schema: (bucketId: string) => this.bs.findOne({_id: new ObjectId(bucketId)})
+        schema: this.bs.resolveSchema
       },
       {returnDocument: ReturnDocument.AFTER},
       this.hashSecret,
@@ -523,7 +523,7 @@ export class BucketDataController {
       {req: req, applyAcl: strategyType === ReqAuthStrategy.USER},
       {
         collection: schema => this.bds.children(schema),
-        schema: (bucketId: string) => this.bs.findOne({_id: new ObjectId(bucketId)})
+        schema: this.bs.resolveSchema
       },
       this.hashSecret,
       this.encryptionSecret

--- a/packages/interface/bucket/common/src/crud.ts
+++ b/packages/interface/bucket/common/src/crud.ts
@@ -23,7 +23,7 @@ export interface CrudParams {
 export interface CrudFactories<T> {
   collection: (schema: Bucket) => BaseCollection<T>;
   preference: () => Promise<BucketPreferences>;
-  schema: (id: string | ObjectId) => Promise<Bucket>;
+  schema: (id: string | ObjectId) => Promise<Bucket> | Bucket;
 }
 
 export interface CrudPagination<T> {

--- a/packages/interface/bucket/common/src/relation.ts
+++ b/packages/interface/bucket/common/src/relation.ts
@@ -38,4 +38,4 @@ export type RelationDefinition = {
   dependent: boolean;
 };
 
-export type RelationResolver = (id: string) => Promise<Bucket>;
+export type RelationResolver = (id: string) => Promise<Bucket> | Bucket;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8674,6 +8674,7 @@ __metadata:
   resolution: "@spica-server/bucket-services@workspace:packages/api/bucket/services"
   dependencies:
     "@nestjs/common": "npm:^10.4.15"
+    "@spica-server/core-patch": "workspace:*"
     "@spica-server/core-schema": "workspace:*"
     "@spica-server/database": "workspace:*"
     "@spica-server/database-testing": "workspace:*"


### PR DESCRIPTION
## Problem

Bucket data requests issue a large number of `buckets._id` point-lookups against MongoDB. In production, a single `GET /bucket/:id/data?relation=true` list response fired **hundreds of identical schema lookups** — the same ~32 bucket-schema documents re-read **~1000×/s** (vs ~110×/s on the previous release) for the same external workload — driving CPU on both the API and mongod.

## Root cause

Every relational operation resolves the target bucket *schema* through one uncached callback:

```ts
schema: (bucketId) => this.bs.findOne({_id: new ObjectId(bucketId)})
```

used by relation-map building, ACL/filter resolution, and — critically — the **per-document** `decryptDocumentFields` loop, which calls it once **per returned document × per relation field**. With no memoization, query volume scales with `documents × relations`.

A latent bug compounded it: `decrypt.ts:resolveRelatedSchema` does `resolved instanceof Promise ? undefined : resolved`. The resolver was `async`, so it **always** returned `undefined` — nested-relation decryption silently no-op'd while still firing the (wasted) query.

## Fix

- Add an in-memory schema cache to `BucketService`, warmed in `onModuleInit` and kept fresh by a **collection-wide change stream** (resync + resubscribe on error, `destroyed` guard for clean teardown) plus local write-through in `insertOne`/`findOneAndReplace`/`drop`.
- Introduce `resolveSchema`, which returns the cached schema **synchronously on a hit** (so the decrypt path works *and* costs nothing) and falls back to `findOne` on a miss. Route every relational resolver — REST data controller, GraphQL, realtime — through it.
- `resolveSchema` returns a `deepCopy` on a hit because relation/ACL resolution **aliases and mutates** the schema object (something `findOne` used to isolate by returning a fresh document each call). A local clone is far cheaper than the old network round-trip + BSON deserialize, and removes the mongod work entirely.
- `findOne`/`find` are left **uncached** so the schema read-before-write flows (PATCH/replace diffing) stay fresh.

Resolver types widened to `(...) => Promise<Bucket> | Bucket` so a single resolver satisfies both the `await`-ing relation/ACL paths and the sync-expecting decrypt path.

## Effect

- `buckets` schema reads driven toward ~0 for the same workload; API and mongod CPU drop accordingly.
- Nested-relation field decryption now actually runs (previously a silent no-op).

## Tests

All bucket suites pass (320 tests): `services` 13, `common` 101, `bucket` acceptance 137, `graphql` 54, `realtime` 15. Build + format checks clean. One acceptance test (`filter statistics by user wallet`) surfaced the schema-aliasing hazard during development and is green after the copy-on-hit fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)