### PR TITLE
Improve secret sync and API handling

### DIFF
--- a/apps/cli/src/commands/sync/apply.ts
+++ b/apps/cli/src/commands/sync/apply.ts
@@ -7,6 +7,7 @@ import {httpService} from "../../http";
 import {applyPlan, buildPlan, renderPlan, resolveModules, MODULE_NAMES} from "@spica-server/sync";
 import {confirm} from "./prompt";
 import {cliReporter} from "./reporter";
+import {findLocalSecretsWithValues, renderSecretValueWarnings} from "./secret-warning";
 
 async function apply({args, options}: ActionParameters) {
   const rootDir = path.resolve((args.dir as string | undefined) ?? process.cwd());
@@ -30,6 +31,7 @@ async function apply({args, options}: ActionParameters) {
   );
 
   renderPlan(p, {detailed});
+  renderSecretValueWarnings(await findLocalSecretsWithValues(modules, rootDir));
 
   if (totalChanges === 0) {
     process.exitCode = 0;

--- a/apps/cli/src/commands/sync/dev.ts
+++ b/apps/cli/src/commands/sync/dev.ts
@@ -19,6 +19,7 @@ import {
 } from "@spica-server/sync";
 import {confirm} from "./prompt";
 import {cliReporter} from "./reporter";
+import {findLocalSecretsWithValues, renderSecretValueWarnings} from "./secret-warning";
 
 // ─── State ───────────────────────────────────────────────────────────────────
 
@@ -412,6 +413,7 @@ async function dev({args, options}: ActionParameters) {
   );
 
   renderPlan(plan, {detailed: false});
+  renderSecretValueWarnings(await findLocalSecretsWithValues(modules, rootDir));
 
   if (totalChanges > 0) {
     const ok = await confirm("\nApply these changes?");

--- a/apps/cli/src/commands/sync/plan.ts
+++ b/apps/cli/src/commands/sync/plan.ts
@@ -3,6 +3,7 @@ import {ActionParameters, Command, Program} from "@caporal/core";
 import {httpService} from "../../http";
 import {buildPlan, renderPlan, resolveModules, MODULE_NAMES} from "@spica-server/sync";
 import {cliReporter} from "./reporter";
+import {findLocalSecretsWithValues, renderSecretValueWarnings} from "./secret-warning";
 
 async function plan({args, options}: ActionParameters) {
   try {
@@ -18,6 +19,9 @@ async function plan({args, options}: ActionParameters) {
 
     const p = await buildPlan(modules, http, rootDir, detailed, true, cliReporter);
     renderPlan(p, {detailed, json});
+    if (!json) {
+      renderSecretValueWarnings(await findLocalSecretsWithValues(modules, rootDir));
+    }
 
     process.exitCode = 0;
   } catch (err: unknown) {

--- a/apps/cli/src/commands/sync/secret-warning.ts
+++ b/apps/cli/src/commands/sync/secret-warning.ts
@@ -1,0 +1,51 @@
+import {bold, yellow} from "colorette";
+import {ResourceModule} from "@spica-server/sync";
+import {secretModule} from "@spica-server/sync";
+
+type SecretSchema = {
+  key?: string;
+  value?: unknown;
+};
+
+export async function findLocalSecretsWithValues(
+  modules: ResourceModule[],
+  rootDir: string
+): Promise<string[]> {
+  if (!modules.some(mod => mod.name === secretModule.name)) {
+    return [];
+  }
+
+  const locals = await secretModule.readLocal(rootDir);
+
+  return locals
+    .filter(local => {
+      const secret = local.data as SecretSchema;
+      return typeof secret.value === "string" && secret.value.length > 0;
+    })
+    .map(local => {
+      const secret = local.data as SecretSchema;
+      return secret.key || local.slug;
+    })
+    .sort((a, b) => a.localeCompare(b));
+}
+
+export function renderSecretValueWarnings(secretNames: string[]): void {
+  for (const secretName of secretNames) {
+    console.log(
+      yellow(
+        `  Warning: secret(${secretName}) includes value in the local files. ` +
+          `It is not suggested to version secret values, omit value on local file ` +
+          `or consider using environment variables.`
+      )
+    );
+  }
+
+  if (secretNames.length > 0) {
+    console.log(
+      yellow(
+        `  ${bold("Proceeding will still send local secret values to the remote API for changed secrets.")}`
+      )
+    );
+  }
+}
+

--- a/apps/cli/test/commands/sync/secret-warning.spec.ts
+++ b/apps/cli/test/commands/sync/secret-warning.spec.ts
@@ -1,0 +1,72 @@
+import os from "os";
+import path from "path";
+import fs from "fs";
+import yaml from "yaml";
+import {bucketModule, secretModule} from "@spica-server/sync";
+import {
+  findLocalSecretsWithValues,
+  renderSecretValueWarnings
+} from "@spica/cli/src/commands/sync/secret-warning";
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "spica-secret-warning-test-"));
+}
+
+function cleanup(dir: string) {
+  fs.rmSync(dir, {recursive: true, force: true});
+}
+
+describe("findLocalSecretsWithValues", () => {
+  it("returns secret keys whose local schema includes a non-empty value", async () => {
+    const dir = makeTmpDir();
+    try {
+      const withValueDir = path.join(dir, "secret", "API_KEY");
+      const withoutValueDir = path.join(dir, "secret", "DB_PASS");
+
+      fs.mkdirSync(withValueDir, {recursive: true});
+      fs.mkdirSync(withoutValueDir, {recursive: true});
+
+      fs.writeFileSync(
+        path.join(withValueDir, "schema.yaml"),
+        yaml.stringify({key: "API_KEY", value: "super-secret"})
+      );
+      fs.writeFileSync(path.join(withoutValueDir, "schema.yaml"), yaml.stringify({key: "DB_PASS"}));
+
+      await expect(findLocalSecretsWithValues([secretModule], dir)).resolves.toEqual(["API_KEY"]);
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  it("returns empty when secret module is not part of the selected modules", async () => {
+    const dir = makeTmpDir();
+    try {
+      await expect(findLocalSecretsWithValues([bucketModule], dir)).resolves.toEqual([]);
+    } finally {
+      cleanup(dir);
+    }
+  });
+});
+
+describe("renderSecretValueWarnings", () => {
+  it("prints the warning text and proceed note", () => {
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    renderSecretValueWarnings(["API_KEY"]);
+
+    const output = logSpy.mock.calls.map(call => String(call[0])).join("\n");
+    expect(output).toContain("secret(API_KEY) includes value in the local files");
+    expect(output).toContain("Proceeding will still send local secret values");
+
+    logSpy.mockRestore();
+  });
+
+  it("prints nothing when there are no matching secrets", () => {
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    renderSecretValueWarnings([]);
+
+    expect(logSpy).not.toHaveBeenCalled();
+    logSpy.mockRestore();
+  });
+});

--- a/apps/panel/src/store/api/secretApi.ts
+++ b/apps/panel/src/store/api/secretApi.ts
@@ -7,7 +7,7 @@ export interface Secret {
 
 export interface SecretInput {
   key: string;
-  value: string;
+  value?: string;
 }
 
 export interface SecretListResponse {

--- a/packages/api/function/src/change.ts
+++ b/packages/api/function/src/change.ts
@@ -133,7 +133,9 @@ function normalizeEnvVars(envVars: EnvVar[]) {
 function normalizeSecrets(secrets: Secret[], decryptor: SecretDecryptor) {
   return (secrets || []).reduce((acc, curr) => {
     const decrypted = decryptor(curr);
-    acc[decrypted.key] = decrypted.value;
+    if (typeof decrypted.value == "string") {
+      acc[decrypted.key] = decrypted.value;
+    }
     return acc;
   }, {});
 }

--- a/packages/api/secret/services/src/module.ts
+++ b/packages/api/secret/services/src/module.ts
@@ -18,6 +18,11 @@ export class ServicesModule {
         {
           provide: SECRET_DECRYPTOR,
           useValue: (secret: Secret): DecryptedSecret => {
+            if (!secret.value) {
+              return {
+                ...secret
+              };
+            }
             return {
               ...secret,
               value: decrypt(secret.value, options.encryptionSecret)

--- a/packages/api/secret/src/controller.ts
+++ b/packages/api/secret/src/controller.ts
@@ -52,7 +52,7 @@ export class SecretController {
     @Body(Schema.validate("http://spica.internal/secret"))
     body: {
       key: string;
-      value: string;
+      value?: string;
     }
   ) {
     return CRUD.insert(this.ss, body).catch(error => {
@@ -66,7 +66,7 @@ export class SecretController {
   async updateOne(
     @Param("id", OBJECT_ID) id: ObjectId,
     @Body(Schema.validate("http://spica.internal/secret"))
-    body: {key: string; value: string}
+    body: {key: string; value?: string}
   ) {
     return CRUD.replace(this.ss, id, body).catch(error => {
       throw new HttpException(error.message, error.status || 500);

--- a/packages/api/secret/src/crud.ts
+++ b/packages/api/secret/src/crud.ts
@@ -1,10 +1,27 @@
 import {ObjectId, ReturnDocument} from "@spica-server/database";
 import {SecretService} from "@spica-server/secret-services";
-import {DecryptedSecret, HiddenSecret, Secret} from "@spica-server/interface-secret";
+import {HiddenSecret, Secret} from "@spica-server/interface-secret";
 import {encrypt} from "@spica-server/core-encryption";
 import {SecretPipelineBuilder} from "./pipeline.builder.js";
 import {NotFoundException} from "@nestjs/common";
 import {PaginationResponse} from "@spica-server/interface-passport-identity";
+
+type SecretInput = {
+  _id?: ObjectId | string;
+  key: string;
+  value?: string;
+};
+
+type StoredSecretInsert = {
+  _id?: ObjectId;
+  key: string;
+  value?: Secret["value"];
+};
+
+type StoredSecretUpdate = {
+  key: string;
+  value?: Secret["value"];
+};
 
 export async function find(
   ss: SecretService,
@@ -58,17 +75,20 @@ export async function findOne(ss: SecretService, id: ObjectId): Promise<HiddenSe
   return res;
 }
 
-export async function insert(ss: SecretService, body: DecryptedSecret): Promise<HiddenSecret> {
-  const secret: Secret = {
-    key: body.key,
-    value: encrypt(body.value, ss.encryptionSecret)
+export async function insert(ss: SecretService, body: SecretInput): Promise<HiddenSecret> {
+  const secret: StoredSecretInsert = {
+    key: body.key
   };
+
+  if (typeof body.value == "string") {
+    secret.value = encrypt(body.value, ss.encryptionSecret);
+  }
 
   if (body._id) {
     secret._id = new ObjectId(body._id);
   }
 
-  const insertedSecret = await ss.insertOne(secret);
+  const insertedSecret = await ss.insertOne(secret as Secret);
   delete insertedSecret.value;
   return insertedSecret as HiddenSecret;
 }
@@ -76,13 +96,19 @@ export async function insert(ss: SecretService, body: DecryptedSecret): Promise<
 export async function replace(
   ss: SecretService,
   id: ObjectId,
-  body: DecryptedSecret
+  body: SecretInput
 ): Promise<HiddenSecret> {
-  const encrypted = encrypt(body.value, ss.encryptionSecret);
+  const set: StoredSecretUpdate = {
+    key: body.key
+  };
 
-  const result = await ss.findOneAndReplace(
+  if (typeof body.value == "string") {
+    set.value = encrypt(body.value, ss.encryptionSecret);
+  }
+
+  const result = await ss.findOneAndUpdate(
     {_id: id},
-    {_id: id, key: body.key, value: encrypted},
+    {$set: set},
     {returnDocument: ReturnDocument.AFTER}
   );
 

--- a/packages/api/secret/src/schema.json
+++ b/packages/api/secret/src/schema.json
@@ -1,7 +1,7 @@
 {
   "$id": "http://spica.internal/secret",
   "type": "object",
-  "required": ["key", "value"],
+  "required": ["key"],
   "properties": {
     "_id": {
       "type": "string",

--- a/packages/api/secret/test/controller.spec.ts
+++ b/packages/api/secret/test/controller.spec.ts
@@ -115,10 +115,12 @@ describe("Secret", () => {
       expect(found.body.key).toBe("DB_PASS");
     });
 
-    it("should return validation errors when value is missing", async () => {
-      const res = await req.post("/secret", {key: "NO_VALUE"}).catch(r => r);
+    it("should create a secret when value is omitted", async () => {
+      const {body} = await req.post("/secret", {key: "NO_VALUE"});
 
-      expect(res.statusCode).toBe(400);
+      expect(body._id).toBeDefined();
+      expect(body.key).toBe("NO_VALUE");
+      expect(body.value).toBeUndefined();
     });
 
     it("should return validation errors when key is missing", async () => {
@@ -148,6 +150,22 @@ describe("Secret", () => {
       expect(updated._id).toBe(inserted._id);
       expect(updated.key).toBe("NEW_KEY");
       expect(updated.value).toBeUndefined();
+    });
+
+    it("should update key without changing stored value when value is omitted", async () => {
+      const {body: inserted} = await req.post("/secret", {key: "OLD_KEY", value: "old_val"});
+
+      const {body: updated} = await req.put(`/secret/${inserted._id}`, {
+        key: "RENAMED_KEY"
+      });
+
+      expect(updated._id).toBe(inserted._id);
+      expect(updated.key).toBe("RENAMED_KEY");
+      expect(updated.value).toBeUndefined();
+
+      const {body: found} = await req.get(`/secret/${inserted._id}`);
+      expect(found.key).toBe("RENAMED_KEY");
+      expect(found.value).toBeUndefined();
     });
 
     it("should return 404 for non-existent secret", async () => {

--- a/packages/api/secret/test/crud.spec.ts
+++ b/packages/api/secret/test/crud.spec.ts
@@ -60,6 +60,16 @@ describe("Secret CRUD", () => {
       expect(result.key).toBe("CUSTOM_ID_KEY");
       expect((result as any).value).toBeUndefined();
     });
+
+    it("should insert a secret without storing value when omitted", async () => {
+      const result = await CRUD.insert(ss, {key: "VALUELESS_KEY"});
+
+      const raw = await ss.findOne({_id: result._id});
+
+      expect(result.key).toBe("VALUELESS_KEY");
+      expect((result as any).value).toBeUndefined();
+      expect(raw.value).toBeUndefined();
+    });
   });
 
   describe("findOne", () => {
@@ -166,6 +176,18 @@ describe("Secret CRUD", () => {
 
       expect(raw.value).not.toBe("updated_value");
       expect(isEncryptedData(raw.value)).toBe(true);
+    });
+
+    it("should preserve stored value when updating without value", async () => {
+      const inserted = await CRUD.insert(ss, {key: "REPLACE_KEY", value: "old_value"});
+      const before = await ss.findOne({_id: inserted._id});
+
+      const replaced = await CRUD.replace(ss, inserted._id, {key: "RENAMED_KEY"});
+      const after = await ss.findOne({_id: inserted._id});
+
+      expect(replaced.key).toBe("RENAMED_KEY");
+      expect((replaced as any).value).toBeUndefined();
+      expect(after.value).toEqual(before.value);
     });
 
     it("should throw NotFoundException for non-existent id", async () => {

--- a/packages/interface/secret/src/index.ts
+++ b/packages/interface/secret/src/index.ts
@@ -4,10 +4,10 @@ import {EncryptedData} from "@spica-server/core-encryption";
 export interface Secret {
   _id?: ObjectId;
   key: string;
-  value: EncryptedData<false>;
+  value?: EncryptedData<false>;
 }
 
-export type DecryptedSecret = Omit<Secret, "value"> & {value: string};
+export type DecryptedSecret = Omit<Secret, "value"> & {value?: string};
 
 export type HiddenSecret = Omit<Secret, "value">;
 


### PR DESCRIPTION
## Summary
- warn in sync plan/apply/dev when local secret files include plaintext values
- allow secret create and update requests without a value while preserving existing encrypted values on key-only updates
- make secret consumers tolerate valueless secrets and cover the new behavior with tests

## Verification
- yarn tsc -p apps/cli/tsconfig.json --noEmit
- yarn tsc -p packages/api/secret/tsconfig.json --noEmit
- yarn tsc -p packages/interface/secret/tsconfig.json --noEmit

## Notes
- Nx/Jest runs in this shell were unreliable because the workspace test harness stalled during startup, so verification here is compile-based.