### PR TITLE
fix(cli): surface meaningful error message instead of [object Object]

### DIFF
--- a/apps/cli/src/http.ts
+++ b/apps/cli/src/http.ts
@@ -27,7 +27,15 @@ export namespace httpService {
         if (!error.response) {
           return Promise.reject(error);
         }
-        return Promise.reject(error.response.data || error.response);
+        const data = error.response.data || error.response;
+        if (data instanceof Error) {
+          return Promise.reject(data);
+        }
+        const message =
+          typeof data === "string"
+            ? data
+            : data?.message || data?.error || JSON.stringify(data);
+        return Promise.reject(new Error(message));
       }
     );
     instance.defaults.headers.common["Authorization"] = authorization;


### PR DESCRIPTION
## Summary

- The axios response interceptor in `apps/cli/src/http.ts` was rejecting with the raw `error.response.data` plain object
- Sync commands (`plan`, `apply`, `fetch`) catch this and call `String(err)`, which produces `[object Object]` for plain objects
- Now the interceptor wraps the data in a proper `Error`, extracting `message` or `error` fields first and falling back to `JSON.stringify` — so users always get a readable error

## Repro

```
spica plan
✖ Fetching remote Environment Variable
[object Object]
```

## Test plan

- [ ] Run `spica plan` against an instance where the `env-var` endpoint returns an error (e.g. 403/404) — confirm a readable message is shown instead of `[object Object]`
- [ ] Verify `spica apply` and `spica fetch` similarly surface readable errors on API failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)