### PR TITLE
feat(devkit/bucket): accept USER auth strategy in initialize

### DIFF
--- a/packages/devkit/bucket/src/bucket.ts
+++ b/packages/devkit/bucket/src/bucket.ts
@@ -9,6 +9,7 @@ import {getWsObs} from "./operators";
 import {
   ApikeyInitialization,
   IdentityInitialization,
+  UserInitialization,
   IndexResult,
   HttpService
 } from "@spica-server/interface-function-packages";
@@ -24,7 +25,7 @@ let wsUrl;
 
 let service: HttpService;
 
-export function initialize(options: ApikeyInitialization | IdentityInitialization) {
+export function initialize(options: ApikeyInitialization | IdentityInitialization | UserInitialization) {
   const {authorization: _authorization, publicUrl, service: _service} = _initialize(options);
 
   authorization = _authorization;

--- a/packages/devkit/bucket/test/bucket.spec.ts
+++ b/packages/devkit/bucket/test/bucket.spec.ts
@@ -36,6 +36,18 @@ describe("@spica-devkit/bucket", () => {
     });
   });
 
+  describe("initialize", () => {
+    it("should initialize with user token", () => {
+      Bucket.initialize({user: "TEST_USER_TOKEN"});
+      const connection = Bucket.data.realtime.getAll("bucket_id");
+
+      const url = new URL("ws://test/bucket/bucket_id/data");
+      url.searchParams.append("Authorization", "USER TEST_USER_TOKEN");
+
+      expect(connection["_config"].url).toEqual(url.toString());
+    });
+  });
+
   describe("bucket", () => {
     const bucket: Bucket.Bucket = {
       title: "User Bucket",


### PR DESCRIPTION
## Summary

- `bucket-data.controller.ts` already accepts all auth strategies via `AuthGuard()` (no args) on its CRUD endpoints — USER tokens work server-side today
- `@spica-devkit/bucket`'s `initialize` was typed to only accept `ApikeyInitialization | IdentityInitialization`, which blocked USER callers at the TypeScript level
- Added `UserInitialization` to the union type and its import; no runtime changes needed since `internal_common`'s `initialize` already handles the `user` property

**Why only bucket?**
- `storage.controller.ts` and `passport/identity.controller.ts` use `AuthGuard(["IDENTITY", "APIKEY"])` explicitly — USER is not accepted there, so their devkit `initialize` signatures are correct as-is

## Test plan

- [x] Added unit test: `initialize({user: "..."})` sets `USER <token>` in the WS URL (verifies the authorization string flows through correctly)
- [x] All 33 existing bucket devkit tests pass (`yarn nx test devkit/bucket`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)