### PR TITLE
fix(bucket): guard findRelations against null/undefined schema

### DIFF
--- a/packages/api/bucket/common/src/relation.ts
+++ b/packages/api/bucket/common/src/relation.ts
@@ -20,6 +20,9 @@ export function findRelations(
   path: string = "",
   targets: Map<string, RelationType>
 ) {
+  if (!schema) {
+    return targets;
+  }
   path = path ? `${path}.` : ``;
   for (const field of Object.keys(schema)) {
     if (isObject(schema[field])) {

--- a/packages/api/bucket/common/test/relation.spec.ts
+++ b/packages/api/bucket/common/test/relation.spec.ts
@@ -45,6 +45,12 @@ describe("Relation", () => {
     expect(isArray(schema)).toBe(false);
   });
 
+  it("should return targets without throwing when schema is null or undefined", () => {
+    const targets = new Map();
+    expect(findRelations(null, "id1", "", targets)).toBe(targets);
+    expect(findRelations(undefined, "id1", "", targets)).toBe(targets);
+  });
+
   it("should find relations", () => {
     const schema = {
       nested_relation: {


### PR DESCRIPTION
## Summary

- `findRelations` in `bucket-common` recurses into `schema[field].properties` for object-type fields, which can be `undefined` when the field has no nested properties defined
- This caused `Object.keys(undefined)` → `TypeError: Cannot convert undefined or null to object` whenever a document with such a field was deleted (`BucketDataController.deleteOne` → `clearRelations` → `findRelations`)
- Fix: return early if `schema` is falsy at the top of `findRelations`

## Test plan

- [ ] New unit test `should return targets without throwing when schema is null or undefined` covers both `null` and `undefined` inputs
- [ ] All 102 existing `api/bucket/common/test` tests still pass
- [ ] Reproduce by creating a bucket with an object field that has no `properties`, insert a document, then delete it — previously 500'd, now succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)