### PR TITLE
fix(devkit/auth): allow public auth methods to bypass axios auth interceptor

### DIFF
--- a/packages/devkit/auth/src/auth.ts
+++ b/packages/devkit/auth/src/auth.ts
@@ -90,7 +90,7 @@ export async function signIn(
       password,
       expires: tokenLifeSpan
     },
-    {headers}
+    {headers, skipAuthCheck: true}
   );
 
   const verified = await service.get<VerifiedToken>(`${userSegment}/verify`, {
@@ -235,7 +235,7 @@ export function remove(id: string, headers?: object): Promise<any> {
  * @returns Promise resolving to the new access token
  */
 export async function refreshAccessToken(accessToken: string, headers?: object): Promise<string> {
-  checkInitialized(authorization, service);
+  checkInitialized(authorization, service, {skipAuthCheck: true});
 
   const response = await service.post<TokenScheme>(
     `${userSegment}/session/refresh`,
@@ -449,7 +449,7 @@ export function requestPasswordReset(
   return service.post<PasswordResetStartResponse>(
     `${userSegment}/forgot-password/start`,
     {username, provider},
-    {headers}
+    {headers, skipAuthCheck: true}
   );
 }
 
@@ -475,7 +475,7 @@ export function completePasswordReset(
   return service.post<PasswordResetCompleteResponse>(
     `${userSegment}/forgot-password/verify`,
     {username, code, newPassword, provider},
-    {headers}
+    {headers, skipAuthCheck: true}
   );
 }
 
@@ -498,7 +498,7 @@ export function passwordlessLogin(
   return service.post<PasswordlessLoginStartResponse>(
     `${userSegment}/passwordless-login/start`,
     {username, provider},
-    {headers}
+    {headers, skipAuthCheck: true}
   );
 }
 
@@ -524,7 +524,7 @@ export async function completePasswordlessLogin(
   const response = await service.post<PasswordlessLoginCompleteResponse>(
     `${userSegment}/passwordless-login/verify`,
     {username, code, provider},
-    {headers}
+    {headers, skipAuthCheck: true}
   );
 
   const verified = await service.get<VerifiedToken>(`${userSegment}/verify`, {

--- a/packages/devkit/auth/test/auth.spec.ts
+++ b/packages/devkit/auth/test/auth.spec.ts
@@ -204,7 +204,7 @@ describe("@spica-devkit/auth", () => {
       expect(postSpy).toHaveBeenCalledWith(
         "passport/user/forgot-password/start",
         {username: "testuser", provider: "email"},
-        {headers: undefined}
+        {headers: undefined, skipAuthCheck: true}
       );
     });
 
@@ -215,7 +215,7 @@ describe("@spica-devkit/auth", () => {
       expect(postSpy).toHaveBeenCalledWith(
         "passport/user/forgot-password/verify",
         {username: "testuser", code: "123456", newPassword: "newpass", provider: "email"},
-        {headers: undefined}
+        {headers: undefined, skipAuthCheck: true}
       );
     });
 
@@ -226,7 +226,7 @@ describe("@spica-devkit/auth", () => {
       expect(postSpy).toHaveBeenCalledWith(
         "passport/user/passwordless-login/start",
         {username: "testuser", provider: "email"},
-        {headers: undefined}
+        {headers: undefined, skipAuthCheck: true}
       );
     });
 
@@ -237,7 +237,7 @@ describe("@spica-devkit/auth", () => {
       expect(postSpy).toHaveBeenCalledWith(
         "passport/user/passwordless-login/verify",
         {username: "testuser", code: "123456", provider: "email"},
-        {headers: undefined}
+        {headers: undefined, skipAuthCheck: true}
       );
 
       expect(getSpy).toHaveBeenCalledTimes(1);
@@ -255,7 +255,7 @@ describe("@spica-devkit/auth", () => {
       expect(postSpy).toHaveBeenCalledWith(
         "passport/user/passwordless-login/verify",
         {username: "testuser", code: "123456", provider: "phone"},
-        {headers: {Accept: "application/json"}}
+        {headers: {Accept: "application/json"}, skipAuthCheck: true}
       );
     });
   });

--- a/packages/devkit/auth/test/user-session.spec.ts
+++ b/packages/devkit/auth/test/user-session.spec.ts
@@ -96,7 +96,7 @@ describe("UserSession", () => {
       expect(postSpy).toHaveBeenCalledWith(
         "/passport/login",
         {username: "testuser", password: "testpass", expires: undefined},
-        {headers: undefined}
+        {headers: undefined, skipAuthCheck: true}
       );
 
       expect(getSpy).toHaveBeenCalledTimes(1);
@@ -112,7 +112,7 @@ describe("UserSession", () => {
       expect(postSpy).toHaveBeenCalledWith(
         "/passport/login",
         {username: "testuser", password: "testpass", expires: 3600},
-        {headers: undefined}
+        {headers: undefined, skipAuthCheck: true}
       );
     });
 
@@ -123,7 +123,7 @@ describe("UserSession", () => {
       expect(postSpy).toHaveBeenCalledWith(
         "/passport/login",
         {username: "testuser", password: "testpass", expires: undefined},
-        {headers: {"X-Custom": "value"}}
+        {headers: {"X-Custom": "value"}, skipAuthCheck: true}
       );
     });
   });
@@ -155,7 +155,7 @@ describe("UserSession", () => {
       expect(postSpy).toHaveBeenCalledWith(
         "passport/user/passwordless-login/verify",
         {username: "testuser", code: "123456", provider: "phone"},
-        {headers: undefined}
+        {headers: undefined, skipAuthCheck: true}
       );
 
       expect(getSpy).toHaveBeenCalledTimes(1);
@@ -171,7 +171,7 @@ describe("UserSession", () => {
       expect(postSpy).toHaveBeenCalledWith(
         "passport/user/passwordless-login/verify",
         {username: "testuser", code: "123456", provider: "email"},
-        {headers: {"X-Custom": "value"}}
+        {headers: {"X-Custom": "value"}, skipAuthCheck: true}
       );
     });
   });
@@ -504,7 +504,7 @@ describe("UserSession", () => {
       expect(postSpy).toHaveBeenCalledWith(
         "passport/user/forgot-password/start",
         {username: "someuser", provider: "email"},
-        {headers: undefined}
+        {headers: undefined, skipAuthCheck: true}
       );
     });
   });

--- a/packages/devkit/internal_common/src/request.ts
+++ b/packages/devkit/internal_common/src/request.ts
@@ -22,7 +22,7 @@ export class Axios implements HttpService {
         request.maxBodyLength = Number.MAX_SAFE_INTEGER;
         request.maxContentLength = Number.MAX_SAFE_INTEGER;
 
-        if (!request.skipAuthCheck && !request.headers["Authorization"]) {
+        if (!(request as any).skipAuthCheck && !request.headers["Authorization"]) {
           throw new Error(
             "You should call initialize method with a valid apikey, identity or user token."
           );

--- a/packages/devkit/internal_common/src/request.ts
+++ b/packages/devkit/internal_common/src/request.ts
@@ -22,9 +22,9 @@ export class Axios implements HttpService {
         request.maxBodyLength = Number.MAX_SAFE_INTEGER;
         request.maxContentLength = Number.MAX_SAFE_INTEGER;
 
-        if (!request.headers["Authorization"]) {
+        if (!request.skipAuthCheck && !request.headers["Authorization"]) {
           throw new Error(
-            "You should call initialize method with a valid apikey or identity token."
+            "You should call initialize method with a valid apikey, identity or user token."
           );
         }
         return request;


### PR DESCRIPTION
## Summary

- The axios request interceptor in `internal_common` blocked every HTTP call that lacked an `Authorization` header, including calls to public endpoints like `/passport/login` that don't need prior credentials
- Public methods (`signIn`, `requestPasswordReset`, `completePasswordReset`, `passwordlessLogin`, `completePasswordlessLogin`) already called `checkInitialized(..., {skipAuthCheck: true})` to skip the module-level guard, but the interceptor independently re-checked and threw the same kind of error before the request reached the server
- `refreshAccessToken` provides its own `Authorization` header per-request but its `checkInitialized` call incorrectly required module-level credentials

## Changes

- `internal_common/src/request.ts`: interceptor now respects a `skipAuthCheck` property on the request config; also fixes the error message to include **user** token (was missing alongside apikey and identity)
- `auth/src/auth.ts`: pass `skipAuthCheck: true` in the axios config for each public-endpoint POST; change `refreshAccessToken`'s `checkInitialized` to use `{skipAuthCheck: true}` since it supplies its own token

## Test plan

- [ ] `signIn(username, password)` succeeds after `initialize({publicUrl})` with no apikey/identity/user token
- [ ] `requestPasswordReset`, `completePasswordReset`, `passwordlessLogin`, `completePasswordlessLogin` succeed after `initialize({publicUrl})` with no credentials
- [ ] `refreshAccessToken(token)` succeeds after `initialize({publicUrl})` with no credentials
- [ ] All above methods still work when called after a full `initialize({apikey, publicUrl})`
- [ ] Methods that legitimately require auth (signUp, getAll, get, ban, etc.) still throw if no credentials are set

🤖 Generated with [Claude Code](https://claude.com/claude-code)