### PR TITLE
fix(passport): enforce 2FA from persisted record to fix multi-replica bypass

### DIFF
--- a/packages/api/passport/identity/src/identity.controller.ts
+++ b/packages/api/passport/identity/src/identity.controller.ts
@@ -219,14 +219,19 @@ export class IdentityController {
     )
   )
   async deleteFactor(@Param("id", OBJECT_ID) id: ObjectId) {
-    const res = this.deleteIdentityFactor(id.toHexString());
+    // deleteIdentityFactor only clears any in-progress activation; an already-activated factor is
+    // no longer in that transient map, so existence must be derived from the persisted record.
+    this.deleteIdentityFactor(id.toHexString());
     this.authFactor.unregister(id.toHexString());
 
-    if (!res) {
+    const identity = await this.identityService.findOneAndUpdate(
+      {_id: id},
+      {$unset: {authFactor: ""}}
+    );
+
+    if (!identity) {
       throw new NotFoundException(`Identity with ID ${id} not found`);
     }
-
-    await this.identityService.findOneAndUpdate({_id: id}, {$unset: {authFactor: ""}});
   }
 
   @Get(":id")

--- a/packages/api/passport/src/passport.identity.controller.ts
+++ b/packages/api/passport/src/passport.identity.controller.ts
@@ -179,7 +179,14 @@ export class PassportIdentityController {
     const refreshTokenSchema = await this.identityService.signRefreshToken(identity);
 
     const id = identity._id.toHexString();
-    if (this.authFactor.hasFactor(id)) {
+    // Enforce 2FA from the persisted record, not the in-memory AuthFactor map: that map is
+    // per-replica and only synced opportunistically, so a replica that missed the registration
+    // broadcast would otherwise skip the challenge and let the user bypass 2FA.
+    if (identity.authFactor) {
+      if (!this.authFactor.hasFactor(id)) {
+        this.authFactor.register(id, identity.authFactor);
+      }
+
       this.setIdentityToken(id, tokenSchema);
       this.setRefreshToken(id, refreshTokenSchema);
 

--- a/packages/api/passport/src/passport.identity.controller.ts
+++ b/packages/api/passport/src/passport.identity.controller.ts
@@ -169,7 +169,12 @@ export class PassportIdentityController {
       return;
     }
 
-    const {tokenSchema, refreshTokenSchema} = await this.signIdentity(identity, expires);
+    const {tokenSchema, refreshTokenSchema, factorRes} = await this.signIdentity(identity, expires);
+
+    if (factorRes) {
+      return res.status(200).json(factorRes);
+    }
+
     this.setRefreshTokenCookie(res, refreshTokenSchema.token);
     res.status(200).json(tokenSchema);
   }

--- a/packages/api/passport/src/passport.user.controller.ts
+++ b/packages/api/passport/src/passport.user.controller.ts
@@ -182,7 +182,14 @@ export class PassportUserController {
     const refreshTokenSchema = await this.userService.signRefreshToken(user);
 
     const id = user._id.toHexString();
-    if (this.authFactor.hasFactor(id)) {
+    // Enforce 2FA from the persisted record, not the in-memory AuthFactor map: that map is
+    // per-replica and only synced opportunistically, so a replica that missed the registration
+    // broadcast would otherwise skip the challenge and let the user bypass 2FA.
+    if (user.authFactor) {
+      if (!this.authFactor.hasFactor(id)) {
+        this.authFactor.register(id, user.authFactor);
+      }
+
       this.setUserToken(id, tokenSchema);
       this.setRefreshToken(id, refreshTokenSchema);
 

--- a/packages/api/passport/src/passport.user.controller.ts
+++ b/packages/api/passport/src/passport.user.controller.ts
@@ -168,11 +168,16 @@ export class PassportUserController {
   async completeLoginWithState(state: string, user: User, expires: number) {
     const res = this.stateReqs.get(state);
     this.stateReqs.delete(state);
-    if (!res || res.headerSent) {
+    if (!res || res.headersSent) {
       return;
     }
 
-    const {tokenSchema, refreshTokenSchema} = await this.signUser(user, expires);
+    const {tokenSchema, refreshTokenSchema, factorRes} = await this.signUser(user, expires);
+
+    if (factorRes) {
+      return res.status(200).json(factorRes);
+    }
+
     this.setRefreshTokenCookie(res, refreshTokenSchema.token);
     res.status(200).json(tokenSchema);
   }

--- a/packages/api/passport/src/passport.user.controller.ts
+++ b/packages/api/passport/src/passport.user.controller.ts
@@ -216,7 +216,7 @@ export class PassportUserController {
 
   async _login(username: string, password: string, state: string, expires: number, res) {
     const catchError = e => {
-      if (!res.headerSent) {
+      if (!res.headersSent) {
         res.status(e.status || 500).json(e.response || e);
       }
     };

--- a/packages/api/passport/test/e2e.spec.ts
+++ b/packages/api/passport/test/e2e.spec.ts
@@ -4,6 +4,7 @@ import {SchemaModule, hash} from "@spica-server/core-schema";
 import {CoreTestingModule, Request} from "@spica-server/core-testing";
 import {DatabaseTestingModule} from "@spica-server/database-testing";
 import {PassportModule} from "@spica-server/passport";
+import {AuthFactor} from "@spica-server/passport-authfactor";
 import {REQUEST_SERVICE} from "@spica-server/interface-passport";
 import {PreferenceTestingModule} from "@spica-server/preference-testing";
 
@@ -896,9 +897,10 @@ describe("E2E Tests", () => {
 
   describe("2FA", () => {
     let identity;
+    let module;
 
     beforeEach(async () => {
-      const module = await Test.createTestingModule(moduleMetaData).compile();
+      module = await Test.createTestingModule(moduleMetaData).compile();
 
       req = module.get(Request);
       app = module.createNestApplication();
@@ -994,6 +996,32 @@ describe("E2E Tests", () => {
           expect(res.body.token).toBeDefined();
         });
 
+        it("should still enforce 2fa when the replica is missing the in-memory factor state", async () => {
+          const challenge = await activate2fa(identity);
+
+          // Reproduce a second replica that never received the registration broadcast:
+          // the factor is persisted in the database but absent from this instance's in-memory map.
+          const authFactor = module.get(AuthFactor);
+          authFactor.unregister(identity._id);
+          expect(authFactor.hasFactor(identity._id)).toEqual(false);
+
+          let res = await req.post("/passport/identify", {
+            identifier: "identityWith2fa",
+            password: "password"
+          });
+
+          expect(res.body).toEqual({
+            challenge: "Please enter the 6 digit code",
+            answerUrl: `passport/identify/${identity._id}/factor-authentication`
+          });
+          expect(res.body.token).not.toBeDefined();
+
+          const totp = generateTotp(challenge);
+          res = await req.post(res.body.answerUrl, {answer: totp});
+          expect(res.statusCode).toEqual(200);
+          expect(res.body.token).toBeDefined();
+        });
+
         it("should not login if 2fa code is incorrect", async () => {
           await activate2fa(identity);
 
@@ -1019,6 +1047,10 @@ describe("E2E Tests", () => {
             {},
             {Authorization: `IDENTITY ${token}`}
           );
+
+          // Prove deactivation is persisted, not just cleared from this instance's in-memory map:
+          // a replica without that state must also see 2fa as deactivated.
+          module.get(AuthFactor).unregister(identity._id);
 
           const res = await req.post("/passport/identify", {
             identifier: "identityWith2fa",

--- a/packages/api/passport/test/e2e.spec.ts
+++ b/packages/api/passport/test/e2e.spec.ts
@@ -1,6 +1,6 @@
 import {Controller, Get, INestApplication, ModuleMetadata, Req, Res} from "@nestjs/common";
 import {Test} from "@nestjs/testing";
-import {SchemaModule, hash} from "@spica-server/core-schema";
+import {SchemaModule, hash, OBJECT_ID, DATE_TIME} from "@spica-server/core-schema";
 import {CoreTestingModule, Request} from "@spica-server/core-testing";
 import {DatabaseTestingModule} from "@spica-server/database-testing";
 import {PassportModule} from "@spica-server/passport";
@@ -219,7 +219,7 @@ describe("E2E Tests", () => {
   const moduleMetaData: ModuleMetadata = {
     controllers: [SAMLController, OAuthController],
     imports: [
-      SchemaModule.forRoot(),
+      SchemaModule.forRoot({formats: [OBJECT_ID, DATE_TIME]}),
       DatabaseTestingModule.replicaSet(),
       ConfigModule.forRoot(),
       PassportModule.forRoot({
@@ -1017,6 +1017,51 @@ describe("E2E Tests", () => {
           expect(res.body.token).not.toBeDefined();
 
           const totp = generateTotp(challenge);
+          res = await req.post(res.body.answerUrl, {answer: totp});
+          expect(res.statusCode).toEqual(200);
+          expect(res.body.token).toBeDefined();
+        });
+
+        it("should still enforce 2fa on user login when the replica is missing the in-memory factor state", async () => {
+          const user = await req
+            .post(
+              "/passport/user",
+              {username: "userWith2fa", password: "password"},
+              {Authorization: `IDENTITY ${token}`}
+            )
+            .then(r => r.body);
+
+          const totpSchema = await req
+            .get(`/passport/user/factors`, {}, {Authorization: `IDENTITY ${token}`})
+            .then(r => r.body.find(f => f.type == "totp"));
+
+          const {answerUrl: activationAnswerUrl, challenge} = await req
+            .post(`/passport/user/${user._id}/start-factor-verification`, totpSchema, {
+              Authorization: `IDENTITY ${token}`
+            })
+            .then(r => r.body as {challenge: string; answerUrl: string});
+
+          let totp = generateTotp(challenge);
+          await req.post(activationAnswerUrl, {answer: totp}, {Authorization: `IDENTITY ${token}`});
+
+          // Reproduce a second replica that never received the registration broadcast:
+          // the factor is persisted in the database but absent from this instance's in-memory map.
+          const authFactor = module.get(AuthFactor);
+          authFactor.unregister(user._id);
+          expect(authFactor.hasFactor(user._id)).toEqual(false);
+
+          let res = await req.post("/passport/login", {
+            username: "userWith2fa",
+            password: "password"
+          });
+
+          expect(res.body).toEqual({
+            challenge: "Please enter the 6 digit code",
+            answerUrl: `passport/login/${user._id}/factor-authentication`
+          });
+          expect(res.body.token).not.toBeDefined();
+
+          totp = generateTotp(challenge);
           res = await req.post(res.body.answerUrl, {answer: totp});
           expect(res.statusCode).toEqual(200);
           expect(res.body.token).toBeDefined();

--- a/packages/api/passport/user/src/user.controller.ts
+++ b/packages/api/passport/user/src/user.controller.ts
@@ -217,14 +217,16 @@ export class UserController {
     )
   )
   async deleteFactor(@Param("id", OBJECT_ID) id: ObjectId) {
-    const res = this.deleteUserFactor(id.toHexString());
+    // deleteUserFactor only clears any in-progress activation; an already-activated factor is
+    // no longer in that transient map, so existence must be derived from the persisted record.
+    this.deleteUserFactor(id.toHexString());
     this.authFactor.unregister(id.toHexString());
 
-    if (!res) {
+    const user = await this.userService.findOneAndUpdate({_id: id}, {$unset: {authFactor: ""}});
+
+    if (!user) {
       throw new NotFoundException(`User with ID ${id} not found`);
     }
-
-    await this.userService.findOneAndUpdate({_id: id}, {$unset: {authFactor: ""}});
   }
 
   @Get(":id")


### PR DESCRIPTION
## Problem

TOTP/2FA was inconsistent across replicas. When the API runs with two or more replicas, activating 2FA on one replica and then logging in against **another** replica would let the user log straight in **without** a challenge — a 2FA bypass.

### Root cause

`PassportIdentityController.signIdentity` / `PassportUserController.signUser` decided whether to enforce 2FA from the in-memory `AuthFactor.userFactor` map via `hasFactor(id)`:

```ts
if (this.authFactor.hasFactor(id)) { /* challenge */ } else { /* log in */ }
```

That map is **per-replica**. It is populated by a one-time startup load and by live `register()`/`start()` calls propagated to other replicas only via best-effort `ClassCommander` SYNC broadcasts over a MongoDB change-stream bus — which is **live-only (no replay), has a 5-minute TTL, and is a no-op when replication is disabled or the change stream wasn't active**.

So a replica that was already running when 2FA got activated elsewhere — and missed the `register` broadcast — has `hasFactor(id) === false` and skips the challenge entirely. The persisted source of truth (`identity.authFactor` / `user.authFactor`) is already on the loaded document but was ignored.

## Fix

- **Login enforcement** (`signIdentity`, `signUser`): decide based on the persisted `authFactor` field, and lazily `register()` it into the local map if missing so `start()`/`authenticate()` work on the handling replica. Every replica now self-heals from the database. Identity and user are fixed symmetrically.

- **Deactivation** (`deleteFactor`, identity + user): `deleteIdentityFactor`/`deleteUserFactor` only clear the *in-progress activation* map, which is empty once activation has completed. The old code threw `NotFound` based on that map and **skipped the DB `$unset` entirely**, so deactivation never persisted (it only appeared to work because the in-memory map was cleared first — which doesn't propagate across replicas either). Existence is now derived from the persisted `findOneAndUpdate` result, and the `$unset` always runs.

## Tests

- New regression test: after activating 2FA, the instance's in-memory factor state is cleared (reproducing a replica that missed the broadcast); login must still return a challenge — and the subsequent TOTP answer must succeed.
- Strengthened the deactivation test to clear in-memory state after deactivation, proving the removal is persisted rather than only cleared from one instance's map.
- Full `api/passport` suite: 85 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)