### PR TITLE
fix(passport): prevent startup crash from null persisted authFactor

### DIFF
--- a/packages/api/passport/authfactor/jest.config.ts
+++ b/packages/api/passport/authfactor/jest.config.ts
@@ -1,0 +1,8 @@
+export default {
+  projects: [
+    {
+      preset: "../../../../jest.preset.js",
+      testMatch: ["<rootDir>/test/**/*.spec.ts"]
+    }
+  ]
+};

--- a/packages/api/passport/authfactor/src/authfactor.ts
+++ b/packages/api/passport/authfactor/src/authfactor.ts
@@ -54,6 +54,10 @@ export class AuthFactor {
   }
 
   getFactor(meta: FactorMeta): Factor {
+    if (!meta) {
+      throw Error("Factor meta is missing.");
+    }
+
     const factor = this.factorsMap.get(meta.type);
 
     if (!factor) {

--- a/packages/api/passport/authfactor/test/authfactor.spec.ts
+++ b/packages/api/passport/authfactor/test/authfactor.spec.ts
@@ -1,0 +1,64 @@
+import {AuthFactor} from "@spica-server/passport-authfactor";
+import {Factor, FactorMeta} from "@spica-server/interface-passport-authfactor";
+
+describe("AuthFactor", () => {
+  let authFactor: AuthFactor;
+
+  const totpMeta: FactorMeta = {type: "totp", config: {}, secret: "shh"};
+
+  beforeEach(() => {
+    const factorsMap = new Map<string, any>([
+      [
+        "totp",
+        {
+          instanceFactory: (meta: FactorMeta) =>
+            ({
+              meta,
+              name: "totp",
+              start: () => Promise.resolve("challenge"),
+              authenticate: () => Promise.resolve(true),
+              getMeta: () => meta,
+              getSecretFields: () => ["secret"]
+            }) as Factor,
+          schemaProvider: () => Promise.resolve({type: "totp"} as any)
+        }
+      ]
+    ]);
+
+    authFactor = new AuthFactor(factorsMap, undefined);
+  });
+
+  describe("getFactor", () => {
+    it("should resolve a registered factor", () => {
+      expect(() => authFactor.getFactor(totpMeta)).not.toThrow();
+    });
+
+    it("should throw a clear error when meta is null instead of a TypeError", () => {
+      expect(() => authFactor.getFactor(null)).toThrowError("Factor meta is missing.");
+    });
+
+    it("should throw a clear error when meta is undefined", () => {
+      expect(() => authFactor.getFactor(undefined)).toThrowError("Factor meta is missing.");
+    });
+
+    it("should throw for an unknown factor type", () => {
+      expect(() => authFactor.getFactor({type: "unknown", config: {}})).toThrowError(
+        "Unknown factor named 'unknown'."
+      );
+    });
+  });
+
+  describe("register", () => {
+    it("should not crash with a null meta, surfacing a clear error instead", () => {
+      expect(() => authFactor.register("identity-id", null)).toThrowError(
+        "Factor meta is missing."
+      );
+      expect(authFactor.hasFactor("identity-id")).toEqual(false);
+    });
+
+    it("should register a factor from a valid meta", () => {
+      authFactor.register("identity-id", totpMeta);
+      expect(authFactor.hasFactor("identity-id")).toEqual(true);
+    });
+  });
+});

--- a/packages/api/passport/identity/src/identity.controller.ts
+++ b/packages/api/passport/identity/src/identity.controller.ts
@@ -18,7 +18,8 @@ import {
   UnauthorizedException,
   InternalServerErrorException,
   Optional,
-  NotFoundException
+  NotFoundException,
+  Logger
 } from "@nestjs/common";
 import {activity} from "@spica-server/activity-services";
 import {DEFAULT, NUMBER, JSONP, BOOLEAN} from "@spica-server/core";
@@ -79,12 +80,21 @@ export class IdentityController {
     }
     this.identityService
       .find({
-        authFactor: {$exists: true}
+        authFactor: {$exists: true, $ne: null}
       })
       .then(identities => {
         for (const identity of identities) {
+          if (!identity.authFactor) {
+            continue;
+          }
           this.authFactor.register(identity._id.toHexString(), identity.authFactor);
         }
+      })
+      .catch(error => {
+        Logger.error(
+          `Failed to register persisted auth factors on startup: ${error}`,
+          IdentityController.name
+        );
       });
   }
 

--- a/packages/api/passport/user/src/user.controller.ts
+++ b/packages/api/passport/user/src/user.controller.ts
@@ -18,7 +18,8 @@ import {
   UnauthorizedException,
   InternalServerErrorException,
   Optional,
-  NotFoundException
+  NotFoundException,
+  Logger
 } from "@nestjs/common";
 import {activity} from "@spica-server/activity-services";
 import {DEFAULT, NUMBER, JSONP, BOOLEAN} from "@spica-server/core";
@@ -85,12 +86,21 @@ export class UserController {
     }
     this.userService
       .find({
-        authFactor: {$exists: true}
+        authFactor: {$exists: true, $ne: null}
       })
       .then(users => {
         for (const user of users) {
+          if (!user.authFactor) {
+            continue;
+          }
           this.authFactor.register(user._id.toHexString(), user.authFactor);
         }
+      })
+      .catch(error => {
+        Logger.error(
+          `Failed to register persisted auth factors on startup: ${error}`,
+          UserController.name
+        );
       });
   }
 


### PR DESCRIPTION
## Problem

A reported crash on `0.18.45`:

```
TypeError: Cannot read properties of null (reading 'type')
    at AuthFactor.getFactor (.../authfactor/dist/src/authfactor.js:39:49)
    at AuthFactor.register (.../authfactor/dist/src/authfactor.js:32:29)
    at .../passport-user/dist/src/user.controller.js:68:33
    at process.processTicksAndRejections
```

The `IdentityController`/`UserController` constructors re-register persisted auth factors on boot:

```ts
this.userService
  .find({ authFactor: {$exists: true} })
  .then(users => {
    for (const user of users) {
      this.authFactor.register(user._id.toHexString(), user.authFactor);
    }
  });
```

`{$exists: true}` **also matches documents whose `authFactor` is explicitly `null`**, so `register(id, null)` reaches `getFactor`, which dereferences `meta.type` and throws. Unlike the request path (`setUserFactor`), this call is **not** wrapped in `try/catch`, and the `.then(...)` has **no `.catch`** — so the throw becomes an unhandled promise rejection that **crash-loops the process on startup**.

A document with `authFactor: null` isn't produced by the normal flows (`deleteFactor` does `$unset`; activation does `$set: {authFactor: meta}`), but can arise from an aborted/partial activation, a manual DB edit, or an import/migration that wrote an explicit `null`. Once present, every replica fails to boot.

This path is unchanged on current `master`, so the bug is still live.

## Fix

Applied symmetrically to identity and user:

- Exclude null in the query: `{authFactor: {$exists: true, $ne: null}}`.
- Skip null defensively inside the loop (`if (!doc.authFactor) continue;`).
- Add a `.catch` on the startup `.then(...)` so one bad record can never crash boot — it logs instead.
- Guard `AuthFactor.getFactor` against a missing `meta` with a clear `Error("Factor meta is missing.")` rather than a `TypeError`.

## Tests

Added a focused unit spec for `AuthFactor` (`getFactor`/`register`) covering the null/undefined meta cases and the existing unknown-type and happy paths.

```
Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)