### PR TITLE
fix(function): dedup shifted schedule events across replicas

### DIFF
--- a/packages/api/function/enqueuer/src/schedule.ts
+++ b/packages/api/function/enqueuer/src/schedule.ts
@@ -72,8 +72,14 @@ export class ScheduleEnqueuer implements Enqueuer<ScheduleOptions> {
       this.queue.enqueue(ev);
     };
 
+    // A scheduled tick is identified by its planned fire time, which node-schedule reports
+    // identically on every replica. A shifted (re-dispatched) event instead carries an
+    // eventId that is broadcast to every surviving replica, while each one recomputes
+    // firedAt from its own clock — so only the shared eventId can dedup the handoff.
+    const discriminator = eventId || firedAt;
+
     const meta = {
-      _id: `${target.cwd}-${target.handler}-${options.frequency}-${options.timezone}-${firedAt}`,
+      _id: `${target.cwd}-${target.handler}-${options.frequency}-${options.timezone}-${discriminator}`,
       cwd: target.cwd,
       handler: target.handler,
       frequency: options.frequency,
@@ -82,9 +88,9 @@ export class ScheduleEnqueuer implements Enqueuer<ScheduleOptions> {
     };
 
     if (this.jobReducer) {
-      this.jobReducer.do(meta, enqueue);
+      return this.jobReducer.do(meta, enqueue);
     } else {
-      enqueue();
+      return enqueue();
     }
   }
 

--- a/packages/api/function/enqueuer/test/schedule.spec.ts
+++ b/packages/api/function/enqueuer/test/schedule.spec.ts
@@ -2,6 +2,10 @@ import {Test} from "@nestjs/testing";
 import {ScheduleEnqueuer} from "@spica-server/function-enqueuer";
 import {EventQueue} from "@spica-server/function-queue";
 import {event} from "@spica-server/function-queue-proto";
+import {DatabaseTestingModule} from "@spica-server/database-testing";
+import {JobReducer, JobService} from "@spica-server/replication";
+import {REPLICATION_SERVICE_OPTIONS} from "@spica-server/interface-replication";
+import {replicationServiceOptions} from "@spica-server/replication/testing";
 
 function createTarget(cwd?: string, handler?: string) {
   const target = new event.Target();
@@ -95,5 +99,72 @@ describe("ScheduleEnqueuer", () => {
     });
     jest.advanceTimersByTime(1000 * 60 * 2);
     expect(eventQueue.enqueue).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("ScheduleEnqueuer multi-replica", () => {
+  let module;
+  let jobReducer: JobReducer;
+
+  // Two enqueuers standing in for two API replicas that share the same MongoDB
+  // "jobs" collection (the cross-replica dedup lock used by JobReducer).
+  let replicaA: ScheduleEnqueuer;
+  let replicaB: ScheduleEnqueuer;
+  let queueA: {enqueue: jest.Mock};
+  let queueB: {enqueue: jest.Mock};
+
+  const target = createTarget("/tmp/fn1", "default");
+  const options = {timezone: undefined, frequency: "* * * * *"};
+
+  function totalEnqueues() {
+    return queueA.enqueue.mock.calls.length + queueB.enqueue.mock.calls.length;
+  }
+
+  beforeEach(async () => {
+    module = await Test.createTestingModule({
+      imports: [DatabaseTestingModule.standalone()],
+      providers: [
+        {provide: REPLICATION_SERVICE_OPTIONS, useValue: replicationServiceOptions},
+        JobService,
+        JobReducer
+      ]
+    }).compile();
+
+    jobReducer = module.get(JobReducer);
+
+    queueA = {enqueue: jest.fn()};
+    queueB = {enqueue: jest.fn()};
+
+    replicaA = new ScheduleEnqueuer(queueA as any, jest.fn(), jobReducer);
+    replicaB = new ScheduleEnqueuer(queueB as any, jest.fn(), jobReducer);
+  });
+
+  afterEach(async () => {
+    await module.close();
+  });
+
+  it("should enqueue a scheduled tick on only one replica", async () => {
+    // node-schedule hands every replica the same planned fireDate, so firedAt is
+    // identical across replicas and the JobReducer key matches.
+    const firedAt = 1000;
+    await replicaA.onTickHandler(target, options, firedAt);
+    await replicaB.onTickHandler(target, options, firedAt);
+
+    expect(totalEnqueues()).toEqual(1);
+  });
+
+  it("should re-dispatch a shifted event on only one replica even when replicas disagree on the wall clock", async () => {
+    // When a draining replica shifts an in-flight event, the SHIFT command is broadcast
+    // to every surviving replica and each recomputes `firedAt` from its own clock
+    // (ScheduleEnqueuer.shift -> `new Date(...)`). Two replicas crossing a second boundary
+    // therefore produce different firedAt values for the SAME event id.
+    const eventId = "shifted-event-id";
+    const firedAtOnReplicaA = 1000;
+    const firedAtOnReplicaB = 2000;
+
+    await replicaA.onTickHandler(target, options, firedAtOnReplicaA, eventId);
+    await replicaB.onTickHandler(target, options, firedAtOnReplicaB, eventId);
+
+    expect(totalEnqueues()).toEqual(1);
   });
 });


### PR DESCRIPTION
## Problem

Scheduled (cron) function triggers could execute **more than once per fire** in multi-replica deployments, despite the existing `JobReducer` dedup. Reported symptom: "some triggers execute per-replica; they seem deduped while replicas are steadily running, but a newly started / restarting api can double-execute."

## Root cause

Steady-state is actually correct: `node-schedule` (2.1.1) reports the **planned** `fireDate` identically to every replica, so the `JobReducer` key (`cwd-handler-freq-tz-firedAt`) matches and exactly one replica enqueues.

The bug is in the **shutdown handoff**. When a replica drains in-flight scheduled events (`onEventsAreDrained` → `shift`), `shift` is registered as a `CommandType.SHIFT` command, so the commander **broadcasts it to every surviving replica** (not one). Each surviving replica re-runs `shift`, which recomputes `const now = new Date(...)` from **its own clock** and uses that as the dedup key. Two replicas crossing a one-second boundary produce **different keys for the same event** → both win the Mongo upsert → the function runs multiple times. This surfaces mainly during rolling restarts/deploys.

A secondary latent issue: `onTickHandler` didn't `return` the `JobReducer.do()` promise, so `onEventsAreDrained`'s `Promise.all` never actually awaited the handoff (process could exit before the re-dispatch persisted).

## Fix

- Use the constant, broadcast `eventId` as the dedup discriminator on the re-dispatch (shift) path; keep the deterministic planned `firedAt` for normal scheduled ticks (`discriminator = eventId || firedAt`). All replicas receiving a shift now compute the same key → exactly one re-enqueues.
- Return the `JobReducer.do()` / `enqueue()` result from `onTickHandler` so the drain awaits the handoff.

## Tests

Added a `ScheduleEnqueuer multi-replica` suite with two enqueuers sharing a real Mongo-backed `JobReducer`:
- Normal tick (same `firedAt`) → 1 enqueue (passes pre- and post-fix; proves steady-state dedup).
- Shifted event with divergent per-replica clocks → **2 enqueues before the fix, 1 after**.

All 84 enqueuer tests and 15 scheduler tests pass.

## Note

This fix covers the replication-enabled path. Running multiple replicas **without** `--replication` leaves `jobReducer` undefined and every trigger fires once per replica by design — a separate config-level concern. The Helm chart already sets `--replication` when `replicas > 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)