### PR TITLE
fix(panel): isolate undo history per function

### DIFF
--- a/apps/panel/src/pages/function/components/CodeEditor.tsx
+++ b/apps/panel/src/pages/function/components/CodeEditor.tsx
@@ -141,7 +141,7 @@ const CodeEditor = ({value, language, onChange, onSave, readOnly, functionId, ex
     <Editor
       height="100%"
       language={language}
-      path="file:///main.tsx"
+      path={`file:///${functionId || "default"}/index.tsx`}
       value={value}
       onChange={handleChange}
       beforeMount={handleBeforeMount}


### PR DESCRIPTION
Fixes #1861

## Problem

Monaco Editor used a static `path="file:///main.tsx"` for all functions, causing all functions to share a single Monaco model and undo stack. Pressing Cmd+Z after switching functions would undo changes from the previously edited function.

## Fix

Changed the path to `file:///{functionId}/index.tsx` so each function gets its own Monaco model with an isolated undo history.

Generated with [Claude Code](https://claude.ai/code)