### PR TITLE
Simplify S3 delete to remove prefix-based batch deletion

### DIFF
--- a/packages/api/storage/src/storage.service.ts
+++ b/packages/api/storage/src/storage.service.ts
@@ -231,9 +231,12 @@ export class StorageService extends BaseCollection<StorageObjectMeta>("storage")
 
       const folderDeletionPromises = objects.map(async object => {
         const escapedName = this.escapeRegex(object.name);
-        await this._coll.deleteMany({
-          name: {$regex: new RegExp(`^${escapedName}`)}
-        });
+        const childFilter = {name: {$regex: new RegExp(`^${escapedName}`)}};
+
+        const children = await this._coll.find(childFilter).toArray();
+        await Promise.allSettled(children.map(child => this.service.delete(child.name)));
+
+        await this._coll.deleteMany(childFilter);
       });
 
       await Promise.all(folderDeletionPromises);

--- a/packages/api/storage/src/storage.service.ts
+++ b/packages/api/storage/src/storage.service.ts
@@ -202,13 +202,14 @@ export class StorageService extends BaseCollection<StorageObjectMeta>("storage")
     // rollback will cost much, in fact api could crash, best-effort deletion is enough, so we do not use transaction here
     try {
       await this.service.delete(result.name);
-      const folderName = result.name;
 
-      const escapedName = this.escapeRegex(folderName);
+      const escapedName = this.escapeRegex(result.name);
+      const childFilter = {name: {$regex: new RegExp(`^${escapedName}`)}};
 
-      await this._coll.deleteMany({
-        name: {$regex: new RegExp(`^${escapedName}`)}
-      });
+      const children = await this._coll.find(childFilter).toArray();
+      await Promise.allSettled(children.map(child => this.service.delete(child.name)));
+
+      await this._coll.deleteMany(childFilter);
     } catch (error) {
       this.logger.error(
         `Failed to delete storage object ${result.name} from storage:`,

--- a/packages/api/storage/src/strategy/aws.s3.ts
+++ b/packages/api/storage/src/strategy/aws.s3.ts
@@ -6,7 +6,6 @@ import {
   GetObjectCommandInput,
   PutObjectCommand,
   DeleteObjectCommand,
-  DeleteObjectsCommand,
   CopyObjectCommand,
   ListObjectsV2Command
 } from "@aws-sdk/client-s3";
@@ -99,31 +98,12 @@ export class AWSS3 extends BaseStrategy {
   }
 
   async delete(id: string): Promise<void> {
-    let continuationToken: string | undefined = undefined;
-    do {
-      const listResponse = await this.s3.send(
-        new ListObjectsV2Command({
-          Bucket: this.bucketName,
-          Prefix: id,
-          ContinuationToken: continuationToken
-        })
-      );
-
-      const objects = listResponse.Contents ?? [];
-
-      if (objects.length > 0) {
-        await this.s3.send(
-          new DeleteObjectsCommand({
-            Bucket: this.bucketName,
-            Delete: {
-              Objects: objects.map(obj => ({Key: obj.Key!}))
-            }
-          })
-        );
-      }
-
-      continuationToken = listResponse.IsTruncated ? listResponse.NextContinuationToken : undefined;
-    } while (continuationToken);
+    await this.s3.send(
+      new DeleteObjectCommand({
+        Bucket: this.bucketName,
+        Key: id
+      })
+    );
   }
 
   async url(id: string): Promise<string> {

--- a/packages/api/storage/test/strategy/aws.s3.spec.ts
+++ b/packages/api/storage/test/strategy/aws.s3.spec.ts
@@ -140,62 +140,24 @@ describe("AWSS3", () => {
   });
 
   describe("delete", () => {
-    it("should list and delete all objects matching prefix", async () => {
-      sendMock
-        .mockResolvedValueOnce({
-          Contents: [{Key: "folder/file1.txt"}, {Key: "folder/file2.txt"}],
-          IsTruncated: false
-        })
-        .mockResolvedValueOnce({});
+    it("should delete object directly by its exact key", async () => {
+      sendMock.mockResolvedValueOnce({});
+
+      await service.delete("folder/file.txt");
+
+      expect(sendMock).toHaveBeenCalledTimes(1);
+      const command = sendMock.mock.calls[0][0];
+      expect(command.input).toEqual({Bucket: "test-bucket", Key: "folder/file.txt"});
+    });
+
+    it("should delete folder marker by its exact key without listing", async () => {
+      sendMock.mockResolvedValueOnce({});
 
       await service.delete("folder/");
 
-      expect(sendMock).toHaveBeenCalledTimes(2);
-
-      const listCommand = sendMock.mock.calls[0][0];
-      expect(listCommand.input).toEqual({
-        Bucket: "test-bucket",
-        Prefix: "folder/",
-        ContinuationToken: undefined
-      });
-
-      const deleteCommand = sendMock.mock.calls[1][0];
-      expect(deleteCommand.input.Bucket).toEqual("test-bucket");
-      expect(deleteCommand.input.Delete.Objects).toEqual([
-        {Key: "folder/file1.txt"},
-        {Key: "folder/file2.txt"}
-      ]);
-    });
-
-    it("should handle paginated deletion with continuation token", async () => {
-      sendMock
-        .mockResolvedValueOnce({
-          Contents: [{Key: "a.txt"}],
-          IsTruncated: true,
-          NextContinuationToken: "token2"
-        })
-        .mockResolvedValueOnce({}) // delete batch 1
-        .mockResolvedValueOnce({
-          Contents: [{Key: "b.txt"}],
-          IsTruncated: false
-        })
-        .mockResolvedValueOnce({}); // delete batch 2
-
-      await service.delete("prefix");
-
-      expect(sendMock).toHaveBeenCalledTimes(4);
-    });
-
-    it("should handle empty contents gracefully", async () => {
-      sendMock.mockResolvedValueOnce({
-        Contents: undefined,
-        IsTruncated: false
-      });
-
-      await service.delete("empty/");
-
-      // Only the list call, no delete call
       expect(sendMock).toHaveBeenCalledTimes(1);
+      const command = sendMock.mock.calls[0][0];
+      expect(command.input).toEqual({Bucket: "test-bucket", Key: "folder/"});
     });
   });
 


### PR DESCRIPTION
## Summary
Changes the S3 storage deletion strategy from listing and batch-deleting all objects matching a prefix to directly deleting individual objects by their exact key. This simplifies the delete operation and aligns with how the storage service now manages folder hierarchies.

## Key Changes

- **AWS S3 Strategy (`aws.s3.ts`)**:
  - Removed `ListObjectsV2Command` and `DeleteObjectsCommand` logic that iterated through paginated results
  - Replaced with single `DeleteObjectCommand` call using the exact key provided
  - Removed `DeleteObjectsCommand` import (no longer needed)
  - Simplified from a loop handling continuation tokens to a straightforward single delete operation

- **Storage Service (`storage.service.ts`)**:
  - Updated folder deletion to explicitly fetch all child objects from the database before deleting them individually
  - Changed from relying on S3's prefix-based batch deletion to calling `service.delete()` for each child object separately
  - Applied same pattern in both single folder deletion and bulk folder deletion paths
  - Used `Promise.allSettled()` for child deletions to ensure best-effort cleanup even if individual deletes fail

- **Test Updates (`aws.s3.spec.ts`)**:
  - Removed tests for prefix-based listing and batch deletion scenarios
  - Removed test for paginated deletion with continuation tokens
  - Removed test for empty contents handling
  - Added simpler tests verifying direct deletion by exact key for both files and folder markers

## Implementation Details

The change shifts responsibility for managing object hierarchies from S3 to the storage service layer. Instead of S3 handling prefix-based deletion of all matching objects, the storage service now:
1. Queries the database for all child objects matching a folder prefix
2. Explicitly deletes each child object via S3
3. Cleans up database records

This approach provides better control over deletion semantics and error handling at the application level.

https://claude.ai/code/session_01JYoH1TNXua1eqGPALsRECu