### PR TITLE
fix(panel): prevent n.map crash when closing bucket drawer via backdrop

### DIFF
--- a/apps/panel/src/components/organisms/BucketEntryDrawer/BucketEntryDrawer.tsx
+++ b/apps/panel/src/components/organisms/BucketEntryDrawer/BucketEntryDrawer.tsx
@@ -124,7 +124,9 @@ const BucketEntryDrawer = ({
     for (const [key, p] of relationEntries) {
       const formatted = (p as any).relationState?.initialFormattedValues;
       if (formatted !== undefined) {
-        overrides[key] = formatted;
+        const relationType = (p as any).relationType;
+        // initialFormattedValues is always an array; onetoone form value should be a single object
+        overrides[key] = relationType === "onetomany" ? formatted : (formatted[0] ?? formatted);
       }
     }
 

--- a/apps/panel/src/domain/fields/registry.ts
+++ b/apps/panel/src/domain/fields/registry.ts
@@ -461,11 +461,12 @@ const RELATION_DEFINITION: FieldDefinition = {
     const getLabel = (v: {[key: string]: string}) =>
       v[primaryKey] ??
       v.label ??
-      initialFormattedValues?.label ??
-      initialFormattedValues?.find(
-        (i: {value: string; _id: string}) =>
-          i.value === v.value || i.value === v._id || (typeof v === "string" && i.value === v)
-      )?.label;
+      (Array.isArray(initialFormattedValues)
+        ? initialFormattedValues.find(
+            (i: {value: string; _id: string}) =>
+              i.value === v.value || i.value === v._id || (typeof v === "string" && i.value === v)
+          )?.label
+        : (initialFormattedValues as any)?.label);
 
     if (property?.relationType === "onetomany") {
       const values = Array.isArray(value)

--- a/apps/panel/src/hooks/useRelationInputHandlers.tsx
+++ b/apps/panel/src/hooks/useRelationInputHandlers.tsx
@@ -24,7 +24,7 @@ export type RelationState = {
   total: number;
   lastSearch: string;
   primaryKey: string;
-  initialFormattedValues?: FormattedInitialValue | FormattedInitialValue[];
+  initialFormattedValues?: FormattedInitialValue[];
   stateInitialized: boolean;
 };
 
@@ -245,7 +245,7 @@ export const useRelationInputHandlers = (): RelationInputHandlers => {
         return initialValue;
       }
 
-      let formattedValue: {label: string; value: string} | Array<{label: string; value: string}> | undefined = undefined;
+      let formattedValue: Array<{label: string; value: string}> | undefined = undefined;
       const primaryKey = relationStatesRef.current[key]?.primaryKey;
       if (Array.isArray(initialValue)) {
         const formattedValues: Array<{label: string; value: string}> = [];
@@ -265,10 +265,10 @@ export const useRelationInputHandlers = (): RelationInputHandlers => {
       } else {
         try {
           const row = await getBucketEntry({bucketId, entryId: initialValue as string}).unwrap();
-          formattedValue = {
+          formattedValue = [{
             value: (row as any)?._id || "",
             label: primaryKey ? (row as any)?.[primaryKey] || "" : ""
-          };
+          }];
         } catch (error) {
           console.error("Failed to fetch row data:", error);
           formattedValue = undefined;
@@ -316,7 +316,7 @@ export const useRelationInputHandlers = (): RelationInputHandlers => {
           if (formatted) {
             setRelationStates(prev => ({
               ...prev,
-              [key]: {...prev[key], initialFormattedValues: formatted, stateInitialized: true}
+              [key]: {...prev[key], initialFormattedValues: [formatted], stateInitialized: true}
             }));
             return;
           }


### PR DESCRIPTION
Fixes #1865

## Summary

- Normalize `initialFormattedValues` in `useRelationInputHandlers.tsx` to always be an array (was inconsistently a single object for `onetoone` relations, an array for `onetomany`)
- Guard `getLabel` in `registry.ts` with `Array.isArray()` before calling `.find()`, preventing the crash when a plain object is encountered
- Update `BucketEntryDrawer.tsx` override logic to extract `formatted[0]` for `onetoone` fields so the form state keeps the expected single-object shape

## Test plan

- [ ] Open any bucket data page on fresh page load
- [ ] Click a table row to open the edit drawer
- [ ] Click outside the drawer (backdrop) to close → should close without error
- [ ] Verify relation field labels display correctly in the drawer for both `onetomany` and `onetoone` fields
- [ ] Verify Cancel button still works

Generated with [Claude Code](https://claude.ai/code)