### PR TITLE
fix(panel): use full absolute URL when copying HTTP trigger

### DIFF
--- a/apps/panel/src/components/prefabs/navigations/function/FunctionModal.tsx
+++ b/apps/panel/src/components/prefabs/navigations/function/FunctionModal.tsx
@@ -315,7 +315,7 @@ const FunctionModal = ({isOpen, onClose, functionToEdit, onSaved}: FunctionModal
     );
   };
 
-  const baseUrl = (import.meta.env.VITE_BASE_URL as string) || "";
+  const baseUrl = (import.meta.env.VITE_BASE_URL as string) || `${window.location.origin}/api`;
 
   return (
     <Drawer

--- a/apps/panel/src/pages/function/components/TriggerPanel.tsx
+++ b/apps/panel/src/pages/function/components/TriggerPanel.tsx
@@ -30,7 +30,7 @@ const DB_OPERATIONS = ["INSERT", "UPDATE", "REPLACE", "DELETE"];
 const BUCKET_OPERATIONS = ["ALL", "INSERT", "UPDATE", "DELETE"];
 const SYSTEM_EVENTS = ["READY"];
 
-const BASE_URL = (import.meta.env.VITE_BASE_URL as string) || "";
+const BASE_URL = (import.meta.env.VITE_BASE_URL as string) || `${window.location.origin}/api`;
 
 const TriggerPanel = ({triggers, enqueuers, handlers, onChange}: TriggerPanelProps) => {
   const handleAddTrigger = useCallback(() => {


### PR DESCRIPTION
When VITE_BASE_URL is not configured (production behind nginx gateway), the HTTP trigger URL was built with an empty base, producing a relative path like `/fn-execute/path` instead of a full absolute URL.

Fall back to `window.location.origin + "/api"` so the copied URL always includes the host and the /api gateway prefix.

Fixes #1868

Generated with [Claude Code](https://claude.ai/code)