### PR TITLE
fix(panel): remove redundant paginate:true from bucket search query

### DIFF
--- a/apps/panel/src/hooks/useBucketSearch.ts
+++ b/apps/panel/src/hooks/useBucketSearch.ts
@@ -5,7 +5,6 @@ const escapeForRegex = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 const buildBucketQuery = (searchText: string, searchableColumns: string[]) =>
   ({
-    paginate: true,
     relation: true,
     limit: 25,
     filter: {


### PR DESCRIPTION
The search query built in `useBucketSearch` already inherits `paginate:true` from `useBucketData`, which always sets it before spreading the search query. Having it duplicated in the search query object was misleading and unnecessary.

**Note:** The `paginate: true` in `useBucketData.ts` is intentional — the bucket data list has an infinite scroll (load-more) feature that requires `meta.total` from the paginated backend response to know when all rows are loaded.

Fixes #1871

Generated with [Claude Code](https://claude.ai/code)