### PR TITLE
fix(panel): separate console.log/console.info filters and add multi-select

### DIFF
--- a/apps/panel/src/hooks/useFunctionLogFilterState.ts
+++ b/apps/panel/src/hooks/useFunctionLogFilterState.ts
@@ -15,12 +15,25 @@ const useFunctionLogFilterState = ({onSyncDrafts, onReset}: UseFunctionLogFilter
   const [searchQuery, setSearchQuery] = useState("");
   const [handlerFilter, setHandlerFilter] = useState("");
   const [draftHandlerFilter, setDraftHandlerFilter] = useState("");
-  const [severityFilter, setSeverityFilter] = useState<SeverityFilter>("all");
+  const [severityFilters, setSeverityFilters] = useState<SeverityFilter[]>([]);
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [expandedLogIds, setExpandedLogIds] = useState<string[]>([]);
   const [sortDirection, setSortDirection] = useState<"asc" | "desc">("desc");
 
-  const selectedLevels = severityFilter === "all" ? undefined : SEVERITY_LEVEL_MAP[severityFilter];
+  const toggleSeverityFilter = useCallback((key: SeverityFilter) => {
+    if (key === "all") {
+      setSeverityFilters([]);
+    } else {
+      setSeverityFilters(current =>
+        current.includes(key) ? current.filter(f => f !== key) : [...current, key]
+      );
+    }
+  }, []);
+
+  const selectedLevels =
+    severityFilters.length === 0
+      ? undefined
+      : severityFilters.flatMap(f => SEVERITY_LEVEL_MAP[f]);
 
   const syncFilterDrafts = useCallback(() => {
     setDraftBegin(formatDateTimeLocal(queryRange.begin));
@@ -45,7 +58,7 @@ const useFunctionLogFilterState = ({onSyncDrafts, onReset}: UseFunctionLogFilter
     setSearchQuery("");
     setHandlerFilter("");
     setDraftHandlerFilter("");
-    setSeverityFilter("all");
+    setSeverityFilters([]);
     setSortDirection("desc");
     setExpandedLogIds([]);
     setIsFilterOpen(false);
@@ -53,8 +66,8 @@ const useFunctionLogFilterState = ({onSyncDrafts, onReset}: UseFunctionLogFilter
   }, [onReset]);
 
   const isFilterApplied = useMemo(
-    () => severityFilter !== "all" || handlerFilter.trim() !== "" || !isSameDayRange(queryRange, defaultRange),
-    [defaultRange, handlerFilter, queryRange, severityFilter]
+    () => severityFilters.length > 0 || handlerFilter.trim() !== "" || !isSameDayRange(queryRange, defaultRange),
+    [defaultRange, handlerFilter, queryRange, severityFilters]
   );
 
   const toggleRow = useCallback((logId: string) => {
@@ -77,8 +90,8 @@ const useFunctionLogFilterState = ({onSyncDrafts, onReset}: UseFunctionLogFilter
     setHandlerFilter,
     draftHandlerFilter,
     setDraftHandlerFilter,
-    severityFilter,
-    setSeverityFilter,
+    severityFilters,
+    toggleSeverityFilter,
     selectedLevels,
     isFilterOpen,
     setIsFilterOpen,

--- a/apps/panel/src/pages/function-log/FunctionLogPage.module.scss
+++ b/apps/panel/src/pages/function-log/FunctionLogPage.module.scss
@@ -463,6 +463,17 @@
   color: var(--color-accent);
 }
 
+.severityLog .severityDot {
+  background: var(--color-teal, #14b8a6);
+}
+
+.severityLog.severityChipSelected,
+.severityLog.severityBadge {
+  border-color: var(--color-teal, #14b8a6);
+  background: rgba(20, 184, 166, 0.08);
+  color: var(--color-teal, #14b8a6);
+}
+
 .severityInfo .severityDot {
   background: var(--color-blue);
 }

--- a/apps/panel/src/pages/function-log/FunctionLogPage.tsx
+++ b/apps/panel/src/pages/function-log/FunctionLogPage.tsx
@@ -35,6 +35,7 @@ type FunctionDescriptor = {
 
 const SEVERITY_CLASS: Record<SeverityFilter, string> = {
   all: styles.severityAll,
+  log: styles.severityLog,
   info: styles.severityInfo,
   warning: styles.severityWarning,
   error: styles.severityError,
@@ -104,8 +105,8 @@ const FunctionLogPage = () => {
     setDraftEnd,
     searchQuery,
     setSearchQuery,
-    severityFilter,
-    setSeverityFilter,
+    severityFilters,
+    toggleSeverityFilter,
     selectedLevels,
     isFilterOpen,
     setIsFilterOpen,
@@ -372,13 +373,15 @@ const FunctionLogPage = () => {
           </label>
           <div className={styles.severityChips}>
             {SEVERITY_CHIPS.map(chip => {
-              const selected = severityFilter === chip.key;
+              const selected = chip.key === "all"
+                ? severityFilters.length === 0
+                : severityFilters.includes(chip.key);
               return (
                 <button
                   key={chip.key}
                   type="button"
                   className={`${styles.severityChip} ${SEVERITY_CLASS[chip.key]} ${selected ? styles.severityChipSelected : ""}`}
-                  onClick={() => setSeverityFilter(chip.key)}
+                  onClick={() => toggleSeverityFilter(chip.key)}
                 >
                   {chip.dotLabel && <span className={styles.severityDot}>{chip.dotLabel}</span>}
                   {chip.label}

--- a/apps/panel/src/pages/function/components/FunctionLogTable.tsx
+++ b/apps/panel/src/pages/function/components/FunctionLogTable.tsx
@@ -12,6 +12,7 @@ import styles from "./FunctionLogView.module.scss";
 
 const ROW_SEVERITY_CLASS: Record<SeverityFilter, string> = {
   all: styles.severityAll,
+  log: styles.severityLog,
   info: styles.severityInfo,
   warning: styles.severityWarning,
   error: styles.severityError,
@@ -24,7 +25,7 @@ type FunctionLogTableProps = {
   functionName: string;
   defaultHandlerName: string;
   searchQuery: string;
-  severityFilter: SeverityFilter;
+  severityFilters: SeverityFilter[];
   sortDirection: "asc" | "desc";
   expandedLogIds: string[];
   onSearchChange: (value: string) => void;
@@ -39,7 +40,7 @@ const FunctionLogTable = ({
   functionName,
   defaultHandlerName,
   searchQuery,
-  severityFilter,
+  severityFilters,
   sortDirection,
   expandedLogIds,
   onSearchChange,
@@ -65,8 +66,10 @@ const FunctionLogTable = ({
 
         <div className={styles.severityChips}>
           {SEVERITY_CHIPS.map(chip => {
-            const selected = severityFilter === chip.key;
-            const chipClassName = chip.key === "all" ? styles.severityAll : ROW_SEVERITY_CLASS[chip.key];
+            const selected = chip.key === "all"
+              ? severityFilters.length === 0
+              : severityFilters.includes(chip.key);
+            const chipClassName = ROW_SEVERITY_CLASS[chip.key];
 
             return (
               <button

--- a/apps/panel/src/pages/function/components/FunctionLogView.module.scss
+++ b/apps/panel/src/pages/function/components/FunctionLogView.module.scss
@@ -344,6 +344,20 @@
   }
 }
 
+.severityLog {
+  .severityDot {
+    background: var(--log-teal, #14b8a6);
+    color: #fff;
+  }
+
+  &.severityChipSelected,
+  &.severityBadge {
+    color: var(--log-teal, #14b8a6);
+    border-color: rgba(20, 184, 166, 0.22);
+    background: var(--log-teal-bg, rgba(20, 184, 166, 0.08));
+  }
+}
+
 .severityInfo {
   .severityDot {
     background: var(--log-blue);

--- a/apps/panel/src/pages/function/components/FunctionLogView.tsx
+++ b/apps/panel/src/pages/function/components/FunctionLogView.tsx
@@ -8,7 +8,6 @@ import {useClearFunctionLogsMutation, useGetFunctionLogsQuery} from "../../../st
 import useFunctionLogFilterState from "../../../hooks/useFunctionLogFilterState";
 import {
   LOG_LEVEL_LABELS,
-  type SeverityFilter,
 } from "../../../utils/functionLogLevels";
 import {
   formatRowTimestamp,
@@ -45,8 +44,8 @@ const FunctionLogView = ({
     searchQuery,
     setSearchQuery,
     handlerFilter,
-    severityFilter,
-    setSeverityFilter,
+    severityFilters,
+    toggleSeverityFilter,
     selectedLevels,
     isFilterOpen,
     setIsFilterOpen,
@@ -173,11 +172,11 @@ const FunctionLogView = ({
             functionName={functionName}
             defaultHandlerName={defaultHandlerName}
             searchQuery={searchQuery}
-            severityFilter={severityFilter}
+            severityFilters={severityFilters}
             sortDirection={sortDirection}
             expandedLogIds={expandedLogIds}
             onSearchChange={setSearchQuery}
-            onSeverityChange={setSeverityFilter}
+            onSeverityChange={toggleSeverityFilter}
             onSortDirectionChange={setSortDirection}
             onToggleRow={toggleRow}
           />

--- a/apps/panel/src/utils/functionLogLevels.ts
+++ b/apps/panel/src/utils/functionLogLevels.ts
@@ -3,7 +3,7 @@
  * Single source of truth — import from here instead of defining locally.
  */
 
-export type SeverityFilter = "all" | "info" | "warning" | "error" | "debug";
+export type SeverityFilter = "all" | "log" | "info" | "warning" | "error" | "debug";
 
 export const LOG_LEVEL_LABELS: Record<number, string> = {
   0: "Debug",
@@ -23,6 +23,7 @@ export const LOG_LEVEL_OPTIONS = [
 
 export const SEVERITY_CHIPS: Array<{key: SeverityFilter; label: string; dotLabel?: string}> = [
   {key: "all", label: "All"},
+  {key: "log", label: "Log", dotLabel: "L"},
   {key: "info", label: "Info", dotLabel: "I"},
   {key: "warning", label: "Warning", dotLabel: "W"},
   {key: "error", label: "Error", dotLabel: "E"},
@@ -30,7 +31,8 @@ export const SEVERITY_CHIPS: Array<{key: SeverityFilter; label: string; dotLabel
 ];
 
 export const SEVERITY_LEVEL_MAP: Record<Exclude<SeverityFilter, "all">, number[]> = {
-  info: [1, 2],
+  log: [1],
+  info: [2],
   warning: [3],
   error: [4],
   debug: [0],
@@ -42,6 +44,9 @@ export function getSeverityFilter(level: number): SeverityFilter {
   }
   if (level === 3) {
     return "warning";
+  }
+  if (level === 1) {
+    return "log";
   }
   if (level === 0) {
     return "debug";
@@ -60,6 +65,9 @@ export function getSeverityBadge(level: number) {
   }
   if (severity === "debug") {
     return "D";
+  }
+  if (severity === "log") {
+    return "L";
   }
   return "I";
 }


### PR DESCRIPTION
Fixes #1870

## Changes

- Added "Log" as a separate filter chip for `console.log` (level 1), distinct from "Info" (`console.info`, level 2)
- Filter chips now support multi-select: click any combination of Log, Info, Warning, Error, Debug
- Clicking "All" clears all active filters
- Added teal color for the new "Log" chip/badge

Generated with [Claude Code](https://claude.ai/code)