### PR TITLE
refactor(config): drive watchConfig via in-process RxJS dispatcher instead of change streams

### DIFF
--- a/packages/api/config/package.json
+++ b/packages/api/config/package.json
@@ -10,7 +10,8 @@
     "@spica-server/interface-config": "workspace:*",
     "@spica-server/interface-replication": "workspace:*",
     "@spica-server/passport-guard": "workspace:*",
-    "@spica-server/replication": "workspace:*"
+    "@spica-server/replication": "workspace:*",
+    "rxjs": "^7.8.1"
   },
   "devDependencies": {
     "@nestjs/testing": "^10.4.15",

--- a/packages/api/config/package.json
+++ b/packages/api/config/package.json
@@ -8,7 +8,9 @@
     "@spica-server/core-schema": "workspace:*",
     "@spica-server/database": "workspace:*",
     "@spica-server/interface-config": "workspace:*",
-    "@spica-server/passport-guard": "workspace:*"
+    "@spica-server/interface-replication": "workspace:*",
+    "@spica-server/passport-guard": "workspace:*",
+    "@spica-server/replication": "workspace:*"
   },
   "devDependencies": {
     "@nestjs/testing": "^10.4.15",

--- a/packages/api/config/src/config.change-dispatcher.ts
+++ b/packages/api/config/src/config.change-dispatcher.ts
@@ -1,0 +1,35 @@
+import {Injectable, OnModuleDestroy, Optional} from "@nestjs/common";
+import {Observable, Subject} from "rxjs";
+import {filter} from "rxjs/operators";
+import {BaseConfig} from "@spica-server/interface-config";
+import {ClassCommander} from "@spica-server/replication";
+import {CommandType} from "@spica-server/interface-replication";
+
+@Injectable()
+export class ConfigChangeDispatcher implements OnModuleDestroy {
+  private readonly changes = new Subject<BaseConfig>();
+  private commanderSubscription?: {unsubscribe: () => void};
+
+  // ClassCommander rebroadcasts dispatch() to every replica so a config write on one
+  // instance reaches the watchers on all instances, replacing the previous change-stream watch.
+  constructor(@Optional() commander?: ClassCommander) {
+    if (commander) {
+      this.commanderSubscription = commander.register(this, [this.dispatch], CommandType.SYNC);
+    }
+  }
+
+  dispatch(config: BaseConfig) {
+    this.changes.next(config);
+  }
+
+  watch(module: string): Observable<BaseConfig> {
+    return this.changes.pipe(filter(change => !!change && change.module === module));
+  }
+
+  onModuleDestroy() {
+    if (this.commanderSubscription) {
+      this.commanderSubscription.unsubscribe();
+    }
+    this.changes.complete();
+  }
+}

--- a/packages/api/config/src/config.module.ts
+++ b/packages/api/config/src/config.module.ts
@@ -1,5 +1,6 @@
 import {Global, Module} from "@nestjs/common";
 import {ConfigService} from "./config.service.js";
+import {ConfigChangeDispatcher} from "./config.change-dispatcher.js";
 import {ConfigController} from "./config.controller.js";
 import {ConfigSchemaRegistry} from "./config.schema.registry.js";
 import {REGISTER_CONFIG_SCHEMA} from "@spica-server/interface-config";
@@ -14,6 +15,7 @@ export class ConfigModule {
       imports: [SchemaModule.forChild({})],
       controllers: [ConfigController],
       providers: [
+        ConfigChangeDispatcher,
         ConfigService,
         ConfigSchemaRegistry,
         {
@@ -26,7 +28,7 @@ export class ConfigModule {
           inject: [ConfigSchemaRegistry]
         }
       ],
-      exports: [ConfigService, ConfigSchemaRegistry, REGISTER_CONFIG_SCHEMA]
+      exports: [ConfigChangeDispatcher, ConfigService, ConfigSchemaRegistry, REGISTER_CONFIG_SCHEMA]
     };
   }
 }

--- a/packages/api/config/src/config.service.ts
+++ b/packages/api/config/src/config.service.ts
@@ -4,6 +4,7 @@ import {
   DatabaseService,
   Filter,
   FindOneAndReplaceOptions,
+  ReturnDocument,
   UpdateFilter,
   UpdateOptions,
   WithId
@@ -37,7 +38,13 @@ export class ConfigService extends BaseCollection<BaseConfig>("config") {
     options?: FindOneAndReplaceOptions
   ): Promise<WithId<BaseConfig>> {
     const result = await super.findOneAndReplace(filter, doc, options);
-    await this.dispatchChange(filter);
+    // When the caller asks for the post-write document (the controller does), dispatch it
+    // directly; otherwise re-read. Avoids an extra round-trip on the common update path.
+    if (result && options?.returnDocument === ReturnDocument.AFTER) {
+      this.changeDispatcher.dispatch({module: result.module, options: result.options});
+    } else {
+      await this.dispatchChange(filter);
+    }
     return result;
   }
 
@@ -45,6 +52,10 @@ export class ConfigService extends BaseCollection<BaseConfig>("config") {
     return this.changeDispatcher.watch(module);
   }
 
+  // Read-after-write so the dispatched snapshot reflects the persisted document. A concurrent
+  // write to the same module could be reflected instead, but config writes are rare admin
+  // actions where that race is acceptable, and reconstructing the payload from update operators
+  // would be far more fragile.
   private async dispatchChange(filter: Filter<BaseConfig>): Promise<void> {
     const config = await this.findOne(filter);
     if (config) {

--- a/packages/api/config/src/config.service.ts
+++ b/packages/api/config/src/config.service.ts
@@ -1,10 +1,54 @@
 import {Injectable} from "@nestjs/common";
-import {BaseCollection, DatabaseService} from "@spica-server/database";
+import {
+  BaseCollection,
+  DatabaseService,
+  Filter,
+  FindOneAndReplaceOptions,
+  UpdateFilter,
+  UpdateOptions,
+  WithId
+} from "@spica-server/database";
 import {BaseConfig} from "@spica-server/interface-config";
+import {Observable} from "rxjs";
+import {ConfigChangeDispatcher} from "./config.change-dispatcher.js";
 
 @Injectable()
 export class ConfigService extends BaseCollection<BaseConfig>("config") {
-  constructor(db: DatabaseService) {
+  constructor(
+    db: DatabaseService,
+    private readonly changeDispatcher: ConfigChangeDispatcher
+  ) {
     super(db);
+  }
+
+  async updateOne(
+    filter: Filter<BaseConfig>,
+    update: UpdateFilter<BaseConfig> | BaseConfig,
+    options?: UpdateOptions
+  ): Promise<number> {
+    const result = await super.updateOne(filter, update, options);
+    await this.dispatchChange(filter);
+    return result;
+  }
+
+  async findOneAndReplace(
+    filter: Filter<BaseConfig>,
+    doc: BaseConfig,
+    options?: FindOneAndReplaceOptions
+  ): Promise<WithId<BaseConfig>> {
+    const result = await super.findOneAndReplace(filter, doc, options);
+    await this.dispatchChange(filter);
+    return result;
+  }
+
+  protected watchModule(module: string): Observable<BaseConfig> {
+    return this.changeDispatcher.watch(module);
+  }
+
+  private async dispatchChange(filter: Filter<BaseConfig>): Promise<void> {
+    const config = await this.findOne(filter);
+    if (config) {
+      this.changeDispatcher.dispatch({module: config.module, options: config.options});
+    }
   }
 }

--- a/packages/api/config/src/index.ts
+++ b/packages/api/config/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./config.service.js";
+export * from "./config.change-dispatcher.js";
 export * from "./config.module.js";
 export * from "./config.controller.js";
 export * from "./config.schema.registry.js";

--- a/packages/api/config/tsconfig.json
+++ b/packages/api/config/tsconfig.json
@@ -7,7 +7,13 @@
   "include": ["src/**/*.ts", "index.ts", "src/**/*.json"],
   "references": [
     {
+      "path": "../replication"
+    },
+    {
       "path": "../passport/guard"
+    },
+    {
+      "path": "../../interface/replication"
     },
     {
       "path": "../../interface/config"

--- a/packages/api/passport/identity/src/config.service.ts
+++ b/packages/api/passport/identity/src/config.service.ts
@@ -1,16 +1,15 @@
 import {Injectable} from "@nestjs/common";
-import {ConfigService} from "@spica-server/config";
+import {ConfigChangeDispatcher, ConfigService} from "@spica-server/config";
 import {DatabaseService} from "@spica-server/database";
-import {BaseConfig} from "@spica-server/interface-config";
 import {IdentityConfigSettings} from "@spica-server/interface-passport-identity";
-import {filter, map} from "rxjs/operators";
+import {map} from "rxjs/operators";
 
 @Injectable()
 export class IdentityConfigService extends ConfigService {
   private readonly MODULE_NAME = "identity";
 
-  constructor(db: DatabaseService) {
-    super(db);
+  constructor(db: DatabaseService, changeDispatcher: ConfigChangeDispatcher) {
+    super(db, changeDispatcher);
   }
 
   async set(config: IdentityConfigSettings): Promise<void> {
@@ -35,9 +34,8 @@ export class IdentityConfigService extends ConfigService {
   }
 
   watchConfig() {
-    return this.watch([], {fullDocument: "updateLookup"}).pipe(
-      filter(change => (change as any).fullDocument?.module === this.MODULE_NAME),
-      map(change => ((change as any).fullDocument?.options as IdentityConfigSettings) || {})
+    return this.watchModule(this.MODULE_NAME).pipe(
+      map(change => (change.options as IdentityConfigSettings) || {})
     );
   }
 }

--- a/packages/api/passport/test/password-policy-identity.spec.ts
+++ b/packages/api/passport/test/password-policy-identity.spec.ts
@@ -127,7 +127,6 @@ describe("Password Policy - Identity", () => {
     afterAll(async () => {
       await database.collection("config").deleteMany({module: "identity"});
       await database.collection("identity").deleteMany({identifier: {$ne: "spica"}});
-      await new Promise(resolve => setTimeout(resolve, 1000));
     });
 
     it("should reject password shorter than minLength", async () => {
@@ -231,7 +230,6 @@ describe("Password Policy - Identity", () => {
     afterAll(async () => {
       await database.collection("config").deleteMany({module: "identity"});
       await database.collection("identity").deleteMany({identifier: {$ne: "spica"}});
-      await new Promise(resolve => setTimeout(resolve, 1000));
     });
 
     it("should reject password shorter than minLength", async () => {
@@ -266,7 +264,6 @@ describe("Password Policy - Identity", () => {
     afterAll(async () => {
       await database.collection("config").deleteMany({module: "identity"});
       await database.collection("identity").deleteMany({identifier: {$ne: "spica"}});
-      await new Promise(resolve => setTimeout(resolve, 1000));
     });
 
     it("should start validating passwords with the new policy without restart", async () => {

--- a/packages/api/passport/test/password-policy-identity.spec.ts
+++ b/packages/api/passport/test/password-policy-identity.spec.ts
@@ -6,13 +6,22 @@ import {PassportModule} from "@spica-server/passport";
 import {SchemaModule} from "@spica-server/core-schema";
 import {OBJECT_ID, DATE_TIME} from "@spica-server/core-schema";
 import {PreferenceTestingModule} from "@spica-server/preference-testing";
-import {ConfigModule} from "@spica-server/config";
+import {ConfigModule, ConfigService} from "@spica-server/config";
 
 describe("Password Policy - Identity", () => {
   let app: INestApplication;
   let req: Request;
   let database: DatabaseService;
+  let configService: ConfigService;
   let adminToken: string;
+
+  function setIdentityConfig(options: object) {
+    return configService.findOneAndReplace(
+      {module: "identity"},
+      {module: "identity", options},
+      {upsert: true}
+    );
+  }
 
   beforeAll(async () => {
     const module = await Test.createTestingModule({
@@ -71,6 +80,7 @@ describe("Password Policy - Identity", () => {
     app = module.createNestApplication();
     req = module.get(Request);
     database = module.get(DatabaseService);
+    configService = module.get(ConfigService);
 
     await app.listen(req.socket);
 
@@ -103,21 +113,15 @@ describe("Password Policy - Identity", () => {
 
   describe("with password policy config", () => {
     beforeAll(async () => {
-      await database.collection("config").insertOne({
-        module: "identity",
-        options: {
-          password: {
-            minLength: 8,
-            minLowercase: 1,
-            minUppercase: 1,
-            minNumber: 1,
-            minSpecialCharacter: 1
-          }
+      await setIdentityConfig({
+        password: {
+          minLength: 8,
+          minLowercase: 1,
+          minUppercase: 1,
+          minNumber: 1,
+          minSpecialCharacter: 1
         }
       });
-
-      // Wait for change stream to propagate
-      await new Promise(resolve => setTimeout(resolve, 2000));
     });
 
     afterAll(async () => {
@@ -217,16 +221,11 @@ describe("Password Policy - Identity", () => {
 
   describe("with partial password policy (only minLength)", () => {
     beforeAll(async () => {
-      await database.collection("config").deleteMany({module: "identity"});
-      await database.collection("config").insertOne({
-        module: "identity",
-        options: {
-          password: {
-            minLength: 6
-          }
+      await setIdentityConfig({
+        password: {
+          minLength: 6
         }
       });
-      await new Promise(resolve => setTimeout(resolve, 2000));
     });
 
     afterAll(async () => {
@@ -257,15 +256,11 @@ describe("Password Policy - Identity", () => {
   describe("when password policy config is updated at runtime", () => {
     beforeAll(async () => {
       await database.collection("config").deleteMany({module: "identity"});
-      await database.collection("config").insertOne({
-        module: "identity",
-        options: {
-          password: {
-            minLength: 3
-          }
+      await setIdentityConfig({
+        password: {
+          minLength: 3
         }
       });
-      await new Promise(resolve => setTimeout(resolve, 2000));
     });
 
     afterAll(async () => {
@@ -284,16 +279,11 @@ describe("Password Policy - Identity", () => {
       expect(initialRes.statusCode).toEqual(201);
 
       // Update the password policy to a stricter minLength while the app is running.
-      await database.collection("config").updateOne(
-        {module: "identity"},
-        {
-          $set: {
-            "options.password.minLength": 6
-          }
-        },
-        {upsert: true}
-      );
-      await new Promise(resolve => setTimeout(resolve, 2000));
+      await setIdentityConfig({
+        password: {
+          minLength: 6
+        }
+      });
 
       // This password met the old policy but should now be rejected by the new one.
       const resShort = await req.post(

--- a/packages/api/passport/test/password-policy-user.spec.ts
+++ b/packages/api/passport/test/password-policy-user.spec.ts
@@ -123,7 +123,6 @@ describe("Password Policy - User", () => {
     afterAll(async () => {
       await database.collection("config").deleteMany({module: "user"});
       await database.collection("user").deleteMany({});
-      await new Promise(resolve => setTimeout(resolve, 1000));
     });
 
     it("should reject password shorter than minLength on user create", async () => {
@@ -282,7 +281,6 @@ describe("Password Policy - User", () => {
       await database.collection("config").deleteMany({module: "identity"});
       await database.collection("config").deleteMany({module: "user"});
       await database.collection("user").deleteMany({});
-      await new Promise(resolve => setTimeout(resolve, 1000));
     });
 
     it("should enforce user policy (minLength 6), not identity policy", async () => {

--- a/packages/api/passport/test/password-policy-user.spec.ts
+++ b/packages/api/passport/test/password-policy-user.spec.ts
@@ -6,13 +6,18 @@ import {PassportModule} from "@spica-server/passport";
 import {SchemaModule} from "@spica-server/core-schema";
 import {OBJECT_ID, DATE_TIME} from "@spica-server/core-schema";
 import {PreferenceTestingModule} from "@spica-server/preference-testing";
-import {ConfigModule} from "@spica-server/config";
+import {ConfigModule, ConfigService} from "@spica-server/config";
 
 describe("Password Policy - User", () => {
   let app: INestApplication;
   let req: Request;
   let database: DatabaseService;
+  let configService: ConfigService;
   let adminToken: string;
+
+  function setConfig(module: string, options: object) {
+    return configService.findOneAndReplace({module}, {module, options}, {upsert: true});
+  }
 
   beforeAll(async () => {
     const module = await Test.createTestingModule({
@@ -71,6 +76,7 @@ describe("Password Policy - User", () => {
     app = module.createNestApplication();
     req = module.get(Request);
     database = module.get(DatabaseService);
+    configService = module.get(ConfigService);
 
     await app.listen(req.socket);
 
@@ -103,19 +109,15 @@ describe("Password Policy - User", () => {
 
   describe("with user password policy config", () => {
     beforeAll(async () => {
-      await database.collection("config").insertOne({
-        module: "user",
-        options: {
-          password: {
-            minLength: 8,
-            minLowercase: 1,
-            minUppercase: 1,
-            minNumber: 1,
-            minSpecialCharacter: 1
-          }
+      await setConfig("user", {
+        password: {
+          minLength: 8,
+          minLowercase: 1,
+          minUppercase: 1,
+          minNumber: 1,
+          minSpecialCharacter: 1
         }
       });
-      await new Promise(resolve => setTimeout(resolve, 2000));
     });
 
     afterAll(async () => {
@@ -263,24 +265,17 @@ describe("Password Policy - User", () => {
     beforeAll(async () => {
       await database.collection("config").deleteMany({module: "identity"});
       await database.collection("config").deleteMany({module: "user"});
-      await database.collection("config").insertOne({
-        module: "identity",
-        options: {
-          password: {
-            minLength: 12,
-            minUppercase: 3
-          }
+      await setConfig("identity", {
+        password: {
+          minLength: 12,
+          minUppercase: 3
         }
       });
-      await database.collection("config").insertOne({
-        module: "user",
-        options: {
-          password: {
-            minLength: 6
-          }
+      await setConfig("user", {
+        password: {
+          minLength: 6
         }
       });
-      await new Promise(resolve => setTimeout(resolve, 2000));
     });
 
     afterAll(async () => {

--- a/packages/api/passport/user/src/config.service.ts
+++ b/packages/api/passport/user/src/config.service.ts
@@ -1,15 +1,15 @@
 import {Injectable} from "@nestjs/common";
-import {ConfigService} from "@spica-server/config";
+import {ConfigChangeDispatcher, ConfigService} from "@spica-server/config";
 import {DatabaseService} from "@spica-server/database";
 import {BaseConfig} from "@spica-server/interface-config";
 import {UserConfigSettings, RateLimitConfig} from "@spica-server/interface-passport-user";
-import {filter, map} from "rxjs/operators";
+import {map} from "rxjs/operators";
 
 @Injectable()
 export class UserConfigService extends ConfigService {
   private readonly MODULE_NAME = "user";
-  constructor(db: DatabaseService) {
-    super(db);
+  constructor(db: DatabaseService, changeDispatcher: ConfigChangeDispatcher) {
+    super(db, changeDispatcher);
   }
 
   async set(config: UserConfigSettings): Promise<void> {
@@ -107,12 +107,10 @@ export class UserConfigService extends ConfigService {
   }
 
   watchConfig() {
-    return this.watch([], {fullDocument: "updateLookup"}).pipe(
-      filter(change => (change as any).fullDocument?.module === this.MODULE_NAME),
+    return this.watchModule(this.MODULE_NAME).pipe(
       map(
         change =>
-          ((change as any).fullDocument?.options as UserConfigSettings) ||
-          ({} as Partial<UserConfigSettings>)
+          (change.options as UserConfigSettings) || ({} as Partial<UserConfigSettings>)
       )
     );
   }

--- a/packages/api/passport/user/test/user.controller.spec.ts
+++ b/packages/api/passport/user/test/user.controller.spec.ts
@@ -6,6 +6,7 @@ import {SchemaModule} from "@spica-server/core-schema";
 import {DATE_TIME, OBJECT_ID} from "@spica-server/core-schema";
 import {PreferenceTestingModule} from "@spica-server/preference-testing";
 import {PassportModule} from "@spica-server/passport";
+import {ConfigModule} from "@spica-server/config";
 
 describe("User Controller CRUD Operations", () => {
   let module: TestingModule;
@@ -23,6 +24,7 @@ describe("User Controller CRUD Operations", () => {
         DatabaseTestingModule.replicaSet(),
         PreferenceTestingModule,
         CoreTestingModule,
+        ConfigModule.forRoot(),
         PassportModule.forRoot({
           publicUrl: "http://localhost:3000",
           samlCertificateTTL: 604800,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8745,9 +8745,12 @@ __metadata:
     "@spica-server/database": "workspace:*"
     "@spica-server/database-testing": "workspace:*"
     "@spica-server/interface-config": "workspace:*"
+    "@spica-server/interface-replication": "workspace:*"
     "@spica-server/passport-guard": "workspace:*"
     "@spica-server/passport-testing": "workspace:*"
+    "@spica-server/replication": "workspace:*"
     "@types/json-schema": "npm:^7.0.15"
+    rxjs: "npm:^7.8.1"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

`IdentityConfigService.watchConfig()` and `UserConfigService.watchConfig()` previously opened a **MongoDB change stream per subscription** (`this.watch([], {fullDocument: "updateLookup"})`) to notify consumers of config changes. This PR replaces that with an **in-process RxJS `Subject`** that emits whenever a config write method (`set`/`update*`/`findOneAndReplace`) is called, with cross-replica propagation riding on **`ClassCommander`** — the same broadcast mechanism the rest of the API already uses for replica state sync (auth factors, function triggers, etc.).

The consumer-facing contract is unchanged: `watchConfig()` still returns `Observable<options>` and emits on every config change. No consumer was modified.

## How it works

- **`ConfigChangeDispatcher`** (new, provided + exported by the global `ConfigModule`) owns the `Subject<BaseConfig>`. It registers `dispatch()` with `ClassCommander` in `SYNC` mode so a write on one replica is rebroadcast to the watchers on every replica (including itself), reproducing the old change-stream "all replicas observe the write" behavior.
- **`ConfigService`** overrides `updateOne` / `findOneAndReplace` to dispatch the resulting document after the write. `watchModule(module)` exposes the filtered per-module stream to subclasses. Because the dispatcher is a **shared singleton**, writes through the generic `ConfigController` (which operates on the base `ConfigService`) reach the identity/user watchers too — exactly the production write path for password-policy config.
- **`watchConfig()`** in the subclasses now maps `watchModule(MODULE_NAME)` to `options`, same shape as before.

## Hot/cold & consumer behavior

The old `watch()` was a *cold* observable (a new change stream per subscribe). The new stream is a *hot* multicast `Subject`, which matches what the consumers actually need: they subscribe once at module init and seed the current value separately via `merge(initial$, changes$)`. A plain `Subject` (not `ReplaySubject`) preserves the "only future changes, no replay" semantics of the previous change stream, so the `merge(initial$, …)` consumers behave identically.

## Optionality

Per review: the **dispatcher is a required dependency** (emission must always work within a single API instance), and only the **commander is optional** (a single-replica deployment has no peer to broadcast to → `@Optional()`, local-only emission).

## Behavioral note

Change detection is now scoped to writes that go **through a config service** (the documented `set`/`update`/controller path). Out-of-band writes made *directly to the `config` collection*, bypassing the service, no longer trigger `watchConfig`. Cross-replica propagation is preserved via `ClassCommander` (which is itself change-stream-backed under the hood, when `--replication` is enabled).

## Tests

`don't add new tests` was honored. Existing tests that wrote config **directly to MongoDB** and relied on change-stream propagation were updated to write **through the service** (aligned with the new contract); `user.controller.spec` gained `ConfigModule` for the now-required dispatcher dependency.

Passing locally:
- `api/config` — 29 ✓
- `password-policy-identity` — 12 ✓ · `password-policy-user` — 13 ✓
- `rate-limit.guard` — 19 ✓ · `rate-limit_e2e` — 6 ✓
- `user.controller` — 39 ✓

`reset-password` / `passwordless-login` / `verification` e2e suites fail in this environment due to unavailable MailHog/SMS Docker testcontainers — verified to fail **identically on the clean baseline** (pre-existing, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)