### PR TITLE
refactor(env_var,secret): drive function watch via in-process RxJS dispatcher instead of change streams

### DIFF
--- a/packages/api/env_var/services/index.ts
+++ b/packages/api/env_var/services/index.ts
@@ -1,2 +1,3 @@
 export * from "./src/service.js";
+export * from "./src/change-dispatcher.js";
 export {ServicesModule} from "./src/module.js";

--- a/packages/api/env_var/services/package.json
+++ b/packages/api/env_var/services/package.json
@@ -13,7 +13,6 @@
     "@nestjs/common": "^10.4.15",
     "@spica-server/database": "workspace:*",
     "@spica-server/interface-env_var": "workspace:*",
-    "@spica-server/interface-replication": "workspace:*",
     "@spica-server/replication": "workspace:*",
     "rxjs": "^7.8.1"
   }

--- a/packages/api/env_var/services/package.json
+++ b/packages/api/env_var/services/package.json
@@ -12,6 +12,9 @@
   "dependencies": {
     "@nestjs/common": "^10.4.15",
     "@spica-server/database": "workspace:*",
-    "@spica-server/interface-env_var": "workspace:*"
+    "@spica-server/interface-env_var": "workspace:*",
+    "@spica-server/interface-replication": "workspace:*",
+    "@spica-server/replication": "workspace:*",
+    "rxjs": "^7.8.1"
   }
 }

--- a/packages/api/env_var/services/src/change-dispatcher.ts
+++ b/packages/api/env_var/services/src/change-dispatcher.ts
@@ -1,0 +1,41 @@
+import {Injectable, OnModuleDestroy, Optional} from "@nestjs/common";
+import {Observable, Subject} from "rxjs";
+import {ObjectId} from "@spica-server/database";
+import {ClassCommander} from "@spica-server/replication";
+import {CommandType} from "@spica-server/interface-replication";
+
+export interface CollectionChangeEvent {
+  operationType: "insert" | "update" | "replace" | "delete";
+  documentKey: {_id: ObjectId};
+}
+
+@Injectable()
+export class EnvVarChangeDispatcher implements OnModuleDestroy {
+  private readonly changes = new Subject<CollectionChangeEvent>();
+  private commanderSubscription?: {unsubscribe: () => void};
+
+  // ClassCommander rebroadcasts dispatch() to every replica so an env-var write on one instance
+  // reaches the watchers on all instances, replacing the previous change-stream watch. A distinct
+  // class name per collection keeps env-var and secret broadcasts isolated (ClassCommander routes
+  // by ctx.constructor.name).
+  constructor(@Optional() commander?: ClassCommander) {
+    if (commander) {
+      this.commanderSubscription = commander.register(this, [this.dispatch], CommandType.SYNC);
+    }
+  }
+
+  dispatch(change: CollectionChangeEvent) {
+    this.changes.next(change);
+  }
+
+  watch(): Observable<CollectionChangeEvent> {
+    return this.changes.asObservable();
+  }
+
+  onModuleDestroy() {
+    if (this.commanderSubscription) {
+      this.commanderSubscription.unsubscribe();
+    }
+    this.changes.complete();
+  }
+}

--- a/packages/api/env_var/services/src/change-dispatcher.ts
+++ b/packages/api/env_var/services/src/change-dispatcher.ts
@@ -1,41 +1,9 @@
-import {Injectable, OnModuleDestroy, Optional} from "@nestjs/common";
-import {Observable, Subject} from "rxjs";
-import {ObjectId} from "@spica-server/database";
-import {ClassCommander} from "@spica-server/replication";
-import {CommandType} from "@spica-server/interface-replication";
-
-export interface CollectionChangeEvent {
-  operationType: "insert" | "update" | "replace" | "delete";
-  documentKey: {_id: ObjectId};
-}
+import {Injectable, Optional} from "@nestjs/common";
+import {ClassCommander, CollectionChangeDispatcher} from "@spica-server/replication";
 
 @Injectable()
-export class EnvVarChangeDispatcher implements OnModuleDestroy {
-  private readonly changes = new Subject<CollectionChangeEvent>();
-  private commanderSubscription?: {unsubscribe: () => void};
-
-  // ClassCommander rebroadcasts dispatch() to every replica so an env-var write on one instance
-  // reaches the watchers on all instances, replacing the previous change-stream watch. A distinct
-  // class name per collection keeps env-var and secret broadcasts isolated (ClassCommander routes
-  // by ctx.constructor.name).
+export class EnvVarChangeDispatcher extends CollectionChangeDispatcher {
   constructor(@Optional() commander?: ClassCommander) {
-    if (commander) {
-      this.commanderSubscription = commander.register(this, [this.dispatch], CommandType.SYNC);
-    }
-  }
-
-  dispatch(change: CollectionChangeEvent) {
-    this.changes.next(change);
-  }
-
-  watch(): Observable<CollectionChangeEvent> {
-    return this.changes.asObservable();
-  }
-
-  onModuleDestroy() {
-    if (this.commanderSubscription) {
-      this.commanderSubscription.unsubscribe();
-    }
-    this.changes.complete();
+    super(commander);
   }
 }

--- a/packages/api/env_var/services/src/module.ts
+++ b/packages/api/env_var/services/src/module.ts
@@ -1,14 +1,21 @@
 import {Global, Module} from "@nestjs/common";
 import {EnvVarService} from "./service.js";
+import {EnvVarChangeDispatcher} from "./change-dispatcher.js";
 
+// EnvVarService is re-provided by every module that needs it (EnvVarModule, function services),
+// so the dispatcher lives on the static @Global module — imported by class reference and therefore
+// registered once — to stay a single shared bus those instances all dispatch to and watch.
 @Global()
-@Module({})
+@Module({
+  providers: [EnvVarChangeDispatcher],
+  exports: [EnvVarChangeDispatcher]
+})
 export class ServicesModule {
   static forRoot() {
     return {
       module: ServicesModule,
-      providers: [EnvVarService],
-      exports: [EnvVarService]
+      providers: [EnvVarChangeDispatcher, EnvVarService],
+      exports: [EnvVarChangeDispatcher, EnvVarService]
     };
   }
 }

--- a/packages/api/env_var/services/src/module.ts
+++ b/packages/api/env_var/services/src/module.ts
@@ -1,5 +1,4 @@
 import {Global, Module} from "@nestjs/common";
-import {EnvVarService} from "./service.js";
 import {EnvVarChangeDispatcher} from "./change-dispatcher.js";
 
 // EnvVarService is re-provided by every module that needs it (EnvVarModule, function services),
@@ -10,12 +9,4 @@ import {EnvVarChangeDispatcher} from "./change-dispatcher.js";
   providers: [EnvVarChangeDispatcher],
   exports: [EnvVarChangeDispatcher]
 })
-export class ServicesModule {
-  static forRoot() {
-    return {
-      module: ServicesModule,
-      providers: [EnvVarChangeDispatcher, EnvVarService],
-      exports: [EnvVarChangeDispatcher, EnvVarService]
-    };
-  }
-}
+export class ServicesModule {}

--- a/packages/api/env_var/services/src/service.ts
+++ b/packages/api/env_var/services/src/service.ts
@@ -11,8 +11,9 @@ import {
   WithId
 } from "@spica-server/database";
 import {EnvVar} from "@spica-server/interface-env_var";
+import {CollectionChangeEvent} from "@spica-server/replication";
 import {Observable} from "rxjs";
-import {CollectionChangeEvent, EnvVarChangeDispatcher} from "./change-dispatcher.js";
+import {EnvVarChangeDispatcher} from "./change-dispatcher.js";
 
 @Injectable()
 export class EnvVarService extends BaseCollection<EnvVar>("env_var") {

--- a/packages/api/env_var/services/src/service.ts
+++ b/packages/api/env_var/services/src/service.ts
@@ -1,13 +1,73 @@
 import {Injectable} from "@nestjs/common";
-import {BaseCollection, DatabaseService} from "@spica-server/database";
+import {
+  BaseCollection,
+  DatabaseService,
+  Filter,
+  FindOneAndDeleteOptions,
+  FindOneAndReplaceOptions,
+  FindOneAndUpdateOptions,
+  OptionalUnlessRequiredId,
+  UpdateFilter,
+  WithId
+} from "@spica-server/database";
 import {EnvVar} from "@spica-server/interface-env_var";
+import {Observable} from "rxjs";
+import {CollectionChangeEvent, EnvVarChangeDispatcher} from "./change-dispatcher.js";
 
 @Injectable()
 export class EnvVarService extends BaseCollection<EnvVar>("env_var") {
-  constructor(db: DatabaseService) {
+  constructor(
+    db: DatabaseService,
+    private readonly changeDispatcher: EnvVarChangeDispatcher
+  ) {
     super(db, {
       afterInit: () => this._coll.createIndex({key: 1}, {unique: true}),
       collectionOptions: {changeStreamPreAndPostImages: {enabled: true}}
     });
+  }
+
+  async insertOne(doc: OptionalUnlessRequiredId<EnvVar>): Promise<WithId<EnvVar>> {
+    const result = await super.insertOne(doc);
+    this.changeDispatcher.dispatch({operationType: "insert", documentKey: {_id: result._id}});
+    return result;
+  }
+
+  async findOneAndUpdate(
+    filter: Filter<EnvVar>,
+    update: UpdateFilter<EnvVar> | EnvVar,
+    options?: FindOneAndUpdateOptions
+  ): Promise<WithId<EnvVar>> {
+    const result = await super.findOneAndUpdate(filter, update, options);
+    if (result) {
+      this.changeDispatcher.dispatch({operationType: "update", documentKey: {_id: result._id}});
+    }
+    return result;
+  }
+
+  async findOneAndReplace(
+    filter: Filter<EnvVar>,
+    doc: EnvVar,
+    options?: FindOneAndReplaceOptions
+  ): Promise<WithId<EnvVar>> {
+    const result = await super.findOneAndReplace(filter, doc, options);
+    if (result) {
+      this.changeDispatcher.dispatch({operationType: "replace", documentKey: {_id: result._id}});
+    }
+    return result;
+  }
+
+  async findOneAndDelete(
+    filter: Filter<EnvVar>,
+    options?: FindOneAndDeleteOptions
+  ): Promise<WithId<EnvVar>> {
+    const result = await super.findOneAndDelete(filter, options);
+    if (result) {
+      this.changeDispatcher.dispatch({operationType: "delete", documentKey: {_id: result._id}});
+    }
+    return result;
+  }
+
+  watchChanges(): Observable<CollectionChangeEvent> {
+    return this.changeDispatcher.watch();
   }
 }

--- a/packages/api/env_var/services/tsconfig.json
+++ b/packages/api/env_var/services/tsconfig.json
@@ -1,10 +1,13 @@
 {
   "extends": "../../../../tsconfig.base.json",
-  "include": [
-    "src/**/*.ts",
-    "index.ts"
-  ],
+  "include": ["src/**/*.ts", "index.ts"],
   "references": [
+    {
+      "path": "../../replication"
+    },
+    {
+      "path": "../../../interface/replication"
+    },
     {
       "path": "../../../interface/env_var"
     },

--- a/packages/api/env_var/services/tsconfig.json
+++ b/packages/api/env_var/services/tsconfig.json
@@ -6,9 +6,6 @@
       "path": "../../replication"
     },
     {
-      "path": "../../../interface/replication"
-    },
-    {
       "path": "../../../interface/env_var"
     },
     {

--- a/packages/api/function/services/package.json
+++ b/packages/api/function/services/package.json
@@ -14,6 +14,7 @@
     "@spica-server/env_var-services": "workspace:*",
     "@spica-server/interface-function": "workspace:*",
     "@spica-server/interface-function-asset-storage": "workspace:*",
+    "@spica-server/replication": "workspace:*",
     "@spica-server/secret-services": "workspace:*",
     "rxjs": "^7.8.1"
   }

--- a/packages/api/function/services/src/service.ts
+++ b/packages/api/function/services/src/service.ts
@@ -16,6 +16,10 @@ import {Function, FunctionOptions, FUNCTION_OPTIONS} from "@spica-server/interfa
 
 const collectionName = "function";
 
+// An env-var/secret insert has no functions referencing it yet, so only these operations
+// can affect an existing function's resolved environment.
+const relevantOperations = ["update", "replace", "delete"];
+
 @Injectable()
 export class FunctionService extends BaseCollection<Function>(collectionName) {
   constructor(
@@ -41,15 +45,7 @@ export class FunctionService extends BaseCollection<Function>(collectionName) {
     envVarId: ObjectId;
     operationType: "replace" | "update" | "delete";
   }> {
-    const watchPipeline = [
-      {
-        $match: {
-          operationType: {
-            $in: ["update", "replace", "delete"]
-          }
-        }
-      }
-    ];
+    const isRelevantOperation = change => relevantOperations.includes(change.operationType);
     const filterOnlyDocumentIds = change => !!change.documentKey?._id;
     const mapChangeToUpdate = change => {
       return {
@@ -72,8 +68,13 @@ export class FunctionService extends BaseCollection<Function>(collectionName) {
       });
 
     return this.evs
-      .watch(watchPipeline)
-      .pipe(filter(filterOnlyDocumentIds), map(mapChangeToUpdate), switchMap(getFunctionsOfEnv));
+      .watchChanges()
+      .pipe(
+        filter(isRelevantOperation),
+        filter(filterOnlyDocumentIds),
+        map(mapChangeToUpdate),
+        switchMap(getFunctionsOfEnv)
+      );
   }
 
   watchFunctionsForSecretChanges(): Observable<{
@@ -81,15 +82,7 @@ export class FunctionService extends BaseCollection<Function>(collectionName) {
     secretId: ObjectId;
     operationType: "replace" | "update" | "delete";
   }> {
-    const watchPipeline = [
-      {
-        $match: {
-          operationType: {
-            $in: ["update", "replace", "delete"]
-          }
-        }
-      }
-    ];
+    const isRelevantOperation = change => relevantOperations.includes(change.operationType);
     const filterOnlyDocumentIds = change => !!change.documentKey?._id;
     const mapChangeToUpdate = change => {
       return {
@@ -112,7 +105,12 @@ export class FunctionService extends BaseCollection<Function>(collectionName) {
       });
 
     return this.ss
-      .watch(watchPipeline)
-      .pipe(filter(filterOnlyDocumentIds), map(mapChangeToUpdate), switchMap(getFunctionsOfSecret));
+      .watchChanges()
+      .pipe(
+        filter(isRelevantOperation),
+        filter(filterOnlyDocumentIds),
+        map(mapChangeToUpdate),
+        switchMap(getFunctionsOfSecret)
+      );
   }
 }

--- a/packages/api/function/services/src/service.ts
+++ b/packages/api/function/services/src/service.ts
@@ -11,6 +11,7 @@ import {
 } from "@spica-server/database";
 import {EnvVarService} from "@spica-server/env_var-services";
 import {SecretService} from "@spica-server/secret-services";
+import {CollectionChangeEvent} from "@spica-server/replication";
 import {filter, map, Observable, switchMap} from "rxjs";
 import {Function, FunctionOptions, FUNCTION_OPTIONS} from "@spica-server/interface-function";
 
@@ -19,6 +20,8 @@ const collectionName = "function";
 // An env-var/secret insert has no functions referencing it yet, so only these operations
 // can affect an existing function's resolved environment.
 const relevantOperations = ["update", "replace", "delete"];
+const isRelevantOperation = (change: CollectionChangeEvent) =>
+  relevantOperations.includes(change.operationType);
 
 @Injectable()
 export class FunctionService extends BaseCollection<Function>(collectionName) {
@@ -40,41 +43,34 @@ export class FunctionService extends BaseCollection<Function>(collectionName) {
     });
   }
 
+  private watchFunctionsForResource(
+    changes: Observable<CollectionChangeEvent>,
+    resourceField: "env_vars" | "secrets"
+  ): Observable<{
+    fns: WithId<Function>[];
+    resourceId: ObjectId;
+    operationType: "replace" | "update" | "delete";
+  }> {
+    return changes.pipe(
+      filter(isRelevantOperation),
+      switchMap(change =>
+        this.find({[resourceField]: {$in: [change.documentKey._id]}}).then(fns => ({
+          fns,
+          resourceId: change.documentKey._id,
+          operationType: change.operationType as "replace" | "update" | "delete"
+        }))
+      )
+    );
+  }
+
   watchFunctionsForEnvChanges(): Observable<{
     fns: WithId<Function>[];
     envVarId: ObjectId;
     operationType: "replace" | "update" | "delete";
   }> {
-    const isRelevantOperation = change => relevantOperations.includes(change.operationType);
-    const filterOnlyDocumentIds = change => !!change.documentKey?._id;
-    const mapChangeToUpdate = change => {
-      return {
-        envVarId: change.documentKey?._id,
-        operationType: change.operationType
-      };
-    };
-
-    const getFunctionsOfEnv = ({envVarId, operationType}) =>
-      this.find({
-        env_vars: {
-          $in: [envVarId]
-        }
-      }).then(fns => {
-        return {
-          fns,
-          envVarId,
-          operationType
-        };
-      });
-
-    return this.evs
-      .watchChanges()
-      .pipe(
-        filter(isRelevantOperation),
-        filter(filterOnlyDocumentIds),
-        map(mapChangeToUpdate),
-        switchMap(getFunctionsOfEnv)
-      );
+    return this.watchFunctionsForResource(this.evs.watchChanges(), "env_vars").pipe(
+      map(({fns, resourceId, operationType}) => ({fns, envVarId: resourceId, operationType}))
+    );
   }
 
   watchFunctionsForSecretChanges(): Observable<{
@@ -82,35 +78,8 @@ export class FunctionService extends BaseCollection<Function>(collectionName) {
     secretId: ObjectId;
     operationType: "replace" | "update" | "delete";
   }> {
-    const isRelevantOperation = change => relevantOperations.includes(change.operationType);
-    const filterOnlyDocumentIds = change => !!change.documentKey?._id;
-    const mapChangeToUpdate = change => {
-      return {
-        secretId: change.documentKey?._id,
-        operationType: change.operationType
-      };
-    };
-
-    const getFunctionsOfSecret = ({secretId, operationType}) =>
-      this.find({
-        secrets: {
-          $in: [secretId]
-        }
-      }).then(fns => {
-        return {
-          fns,
-          secretId,
-          operationType
-        };
-      });
-
-    return this.ss
-      .watchChanges()
-      .pipe(
-        filter(isRelevantOperation),
-        filter(filterOnlyDocumentIds),
-        map(mapChangeToUpdate),
-        switchMap(getFunctionsOfSecret)
-      );
+    return this.watchFunctionsForResource(this.ss.watchChanges(), "secrets").pipe(
+      map(({fns, resourceId, operationType}) => ({fns, secretId: resourceId, operationType}))
+    );
   }
 }

--- a/packages/api/function/services/tsconfig.json
+++ b/packages/api/function/services/tsconfig.json
@@ -9,13 +9,16 @@
       "path": "../../secret/services"
     },
     {
-      "path": "../../env_var/services"
+      "path": "../../replication"
+    },
+    {
+      "path": "../../../interface/function/asset-storage"
     },
     {
       "path": "../../../interface/function"
     },
     {
-      "path": "../../../interface/function/asset-storage"
+      "path": "../../env_var/services"
     }
   ],
   "compilerOptions": {

--- a/packages/api/function/test/engine.spec.ts
+++ b/packages/api/function/test/engine.spec.ts
@@ -5,9 +5,9 @@ import {Scheduler, SchedulerModule} from "@spica-server/function-scheduler";
 import {FunctionEngine} from "@spica-server/function/src/engine";
 import {FunctionService} from "@spica-server/function-services";
 import {INestApplication} from "@nestjs/common";
-import {EnvVarService} from "@spica-server/env_var-services";
+import {EnvVarService, EnvVarChangeDispatcher} from "@spica-server/env_var-services";
 import {TargetChange, ChangeKind} from "@spica-server/interface-function";
-import {SecretService} from "@spica-server/secret-services";
+import {SecretService, SecretChangeDispatcher} from "@spica-server/secret-services";
 import {encrypt} from "@spica-server/core-encryption";
 process.env.FUNCTION_GRPC_ADDRESS = "0.0.0.0:4378";
 
@@ -58,8 +58,8 @@ describe("Engine", () => {
     scheduler = module.get(Scheduler);
     database = module.get(DatabaseService);
 
-    evs = new EnvVarService(database);
-    ss = new SecretService(database, "test-encryption-secret");
+    evs = new EnvVarService(database, new EnvVarChangeDispatcher());
+    ss = new SecretService(database, "test-encryption-secret", new SecretChangeDispatcher());
 
     fs = new FunctionService(database, evs, ss, {} as any);
     engine = new FunctionEngine(

--- a/packages/api/replication/src/change-dispatcher.ts
+++ b/packages/api/replication/src/change-dispatcher.ts
@@ -1,0 +1,41 @@
+import {Injectable, OnModuleDestroy, Optional} from "@nestjs/common";
+import {Observable, Subject} from "rxjs";
+import {ObjectId} from "@spica-server/database";
+import {CommandType} from "@spica-server/interface-replication";
+import {ClassCommander} from "./commander.js";
+
+export interface CollectionChangeEvent {
+  operationType: "insert" | "update" | "replace" | "delete";
+  documentKey: {_id: ObjectId};
+}
+
+// In-process pub/sub for collection writes that replaces a MongoDB change-stream watch.
+// ClassCommander rebroadcasts dispatch() to every replica so a write on one instance reaches
+// the watchers on all instances. Subclass per collection so ClassCommander, which routes by
+// ctx.constructor.name, keeps each collection's broadcasts isolated.
+@Injectable()
+export abstract class CollectionChangeDispatcher implements OnModuleDestroy {
+  private readonly changes = new Subject<CollectionChangeEvent>();
+  private commanderSubscription?: {unsubscribe: () => void};
+
+  constructor(@Optional() commander?: ClassCommander) {
+    if (commander) {
+      this.commanderSubscription = commander.register(this, [this.dispatch], CommandType.SYNC);
+    }
+  }
+
+  dispatch(change: CollectionChangeEvent) {
+    this.changes.next(change);
+  }
+
+  watch(): Observable<CollectionChangeEvent> {
+    return this.changes.asObservable();
+  }
+
+  onModuleDestroy() {
+    if (this.commanderSubscription) {
+      this.commanderSubscription.unsubscribe();
+    }
+    this.changes.complete();
+  }
+}

--- a/packages/api/replication/src/index.ts
+++ b/packages/api/replication/src/index.ts
@@ -4,4 +4,5 @@ export * from "./memory/index.js";
 export * from "./consts.js";
 export * from "./module.js";
 export * from "./commander.js";
+export * from "./change-dispatcher.js";
 export * from "./reducer.js";

--- a/packages/api/secret/services/index.ts
+++ b/packages/api/secret/services/index.ts
@@ -1,2 +1,3 @@
 export * from "./src/service.js";
+export * from "./src/change-dispatcher.js";
 export {ServicesModule} from "./src/module.js";

--- a/packages/api/secret/services/package.json
+++ b/packages/api/secret/services/package.json
@@ -18,6 +18,9 @@
     "@spica-server/core": "workspace:*",
     "@spica-server/core-encryption": "workspace:*",
     "@spica-server/database": "workspace:*",
-    "@spica-server/interface-secret": "workspace:*"
+    "@spica-server/interface-replication": "workspace:*",
+    "@spica-server/interface-secret": "workspace:*",
+    "@spica-server/replication": "workspace:*",
+    "rxjs": "^7.8.1"
   }
 }

--- a/packages/api/secret/services/package.json
+++ b/packages/api/secret/services/package.json
@@ -18,7 +18,6 @@
     "@spica-server/core": "workspace:*",
     "@spica-server/core-encryption": "workspace:*",
     "@spica-server/database": "workspace:*",
-    "@spica-server/interface-replication": "workspace:*",
     "@spica-server/interface-secret": "workspace:*",
     "@spica-server/replication": "workspace:*",
     "rxjs": "^7.8.1"

--- a/packages/api/secret/services/src/change-dispatcher.ts
+++ b/packages/api/secret/services/src/change-dispatcher.ts
@@ -1,0 +1,41 @@
+import {Injectable, OnModuleDestroy, Optional} from "@nestjs/common";
+import {Observable, Subject} from "rxjs";
+import {ObjectId} from "@spica-server/database";
+import {ClassCommander} from "@spica-server/replication";
+import {CommandType} from "@spica-server/interface-replication";
+
+export interface CollectionChangeEvent {
+  operationType: "insert" | "update" | "replace" | "delete";
+  documentKey: {_id: ObjectId};
+}
+
+@Injectable()
+export class SecretChangeDispatcher implements OnModuleDestroy {
+  private readonly changes = new Subject<CollectionChangeEvent>();
+  private commanderSubscription?: {unsubscribe: () => void};
+
+  // ClassCommander rebroadcasts dispatch() to every replica so a secret write on one instance
+  // reaches the watchers on all instances, replacing the previous change-stream watch. A distinct
+  // class name per collection keeps env-var and secret broadcasts isolated (ClassCommander routes
+  // by ctx.constructor.name).
+  constructor(@Optional() commander?: ClassCommander) {
+    if (commander) {
+      this.commanderSubscription = commander.register(this, [this.dispatch], CommandType.SYNC);
+    }
+  }
+
+  dispatch(change: CollectionChangeEvent) {
+    this.changes.next(change);
+  }
+
+  watch(): Observable<CollectionChangeEvent> {
+    return this.changes.asObservable();
+  }
+
+  onModuleDestroy() {
+    if (this.commanderSubscription) {
+      this.commanderSubscription.unsubscribe();
+    }
+    this.changes.complete();
+  }
+}

--- a/packages/api/secret/services/src/change-dispatcher.ts
+++ b/packages/api/secret/services/src/change-dispatcher.ts
@@ -1,41 +1,9 @@
-import {Injectable, OnModuleDestroy, Optional} from "@nestjs/common";
-import {Observable, Subject} from "rxjs";
-import {ObjectId} from "@spica-server/database";
-import {ClassCommander} from "@spica-server/replication";
-import {CommandType} from "@spica-server/interface-replication";
-
-export interface CollectionChangeEvent {
-  operationType: "insert" | "update" | "replace" | "delete";
-  documentKey: {_id: ObjectId};
-}
+import {Injectable, Optional} from "@nestjs/common";
+import {ClassCommander, CollectionChangeDispatcher} from "@spica-server/replication";
 
 @Injectable()
-export class SecretChangeDispatcher implements OnModuleDestroy {
-  private readonly changes = new Subject<CollectionChangeEvent>();
-  private commanderSubscription?: {unsubscribe: () => void};
-
-  // ClassCommander rebroadcasts dispatch() to every replica so a secret write on one instance
-  // reaches the watchers on all instances, replacing the previous change-stream watch. A distinct
-  // class name per collection keeps env-var and secret broadcasts isolated (ClassCommander routes
-  // by ctx.constructor.name).
+export class SecretChangeDispatcher extends CollectionChangeDispatcher {
   constructor(@Optional() commander?: ClassCommander) {
-    if (commander) {
-      this.commanderSubscription = commander.register(this, [this.dispatch], CommandType.SYNC);
-    }
-  }
-
-  dispatch(change: CollectionChangeEvent) {
-    this.changes.next(change);
-  }
-
-  watch(): Observable<CollectionChangeEvent> {
-    return this.changes.asObservable();
-  }
-
-  onModuleDestroy() {
-    if (this.commanderSubscription) {
-      this.commanderSubscription.unsubscribe();
-    }
-    this.changes.complete();
+    super(commander);
   }
 }

--- a/packages/api/secret/services/src/module.ts
+++ b/packages/api/secret/services/src/module.ts
@@ -1,5 +1,6 @@
 import {Global, Module} from "@nestjs/common";
 import {SecretService, SECRET_ENCRYPTION_SECRET} from "./service.js";
+import {SecretChangeDispatcher} from "./change-dispatcher.js";
 import {decrypt} from "@spica-server/core-encryption";
 import {Secret, DecryptedSecret, SECRET_DECRYPTOR} from "@spica-server/interface-secret";
 
@@ -10,6 +11,7 @@ export class ServicesModule {
     return {
       module: ServicesModule,
       providers: [
+        SecretChangeDispatcher,
         SecretService,
         {
           provide: SECRET_ENCRYPTION_SECRET,
@@ -25,7 +27,7 @@ export class ServicesModule {
           }
         }
       ],
-      exports: [SecretService, SECRET_DECRYPTOR]
+      exports: [SecretChangeDispatcher, SecretService, SECRET_DECRYPTOR]
     };
   }
 }

--- a/packages/api/secret/services/src/service.ts
+++ b/packages/api/secret/services/src/service.ts
@@ -1,6 +1,18 @@
 import {Inject, Injectable} from "@nestjs/common";
-import {BaseCollection, DatabaseService} from "@spica-server/database";
+import {
+  BaseCollection,
+  DatabaseService,
+  Filter,
+  FindOneAndDeleteOptions,
+  FindOneAndReplaceOptions,
+  FindOneAndUpdateOptions,
+  OptionalUnlessRequiredId,
+  UpdateFilter,
+  WithId
+} from "@spica-server/database";
 import {Secret} from "@spica-server/interface-secret";
+import {Observable} from "rxjs";
+import {CollectionChangeEvent, SecretChangeDispatcher} from "./change-dispatcher.js";
 
 export const SECRET_ENCRYPTION_SECRET = Symbol.for("SECRET_ENCRYPTION_SECRET");
 
@@ -8,11 +20,57 @@ export const SECRET_ENCRYPTION_SECRET = Symbol.for("SECRET_ENCRYPTION_SECRET");
 export class SecretService extends BaseCollection<Secret>("secret") {
   constructor(
     db: DatabaseService,
-    @Inject(SECRET_ENCRYPTION_SECRET) public readonly encryptionSecret: string
+    @Inject(SECRET_ENCRYPTION_SECRET) public readonly encryptionSecret: string,
+    private readonly changeDispatcher: SecretChangeDispatcher
   ) {
     super(db, {
       afterInit: () => this._coll.createIndex({key: 1}, {unique: true}),
       collectionOptions: {changeStreamPreAndPostImages: {enabled: true}}
     });
+  }
+
+  async insertOne(doc: OptionalUnlessRequiredId<Secret>): Promise<WithId<Secret>> {
+    const result = await super.insertOne(doc);
+    this.changeDispatcher.dispatch({operationType: "insert", documentKey: {_id: result._id}});
+    return result;
+  }
+
+  async findOneAndUpdate(
+    filter: Filter<Secret>,
+    update: UpdateFilter<Secret> | Secret,
+    options?: FindOneAndUpdateOptions
+  ): Promise<WithId<Secret>> {
+    const result = await super.findOneAndUpdate(filter, update, options);
+    if (result) {
+      this.changeDispatcher.dispatch({operationType: "update", documentKey: {_id: result._id}});
+    }
+    return result;
+  }
+
+  async findOneAndReplace(
+    filter: Filter<Secret>,
+    doc: Secret,
+    options?: FindOneAndReplaceOptions
+  ): Promise<WithId<Secret>> {
+    const result = await super.findOneAndReplace(filter, doc, options);
+    if (result) {
+      this.changeDispatcher.dispatch({operationType: "replace", documentKey: {_id: result._id}});
+    }
+    return result;
+  }
+
+  async findOneAndDelete(
+    filter: Filter<Secret>,
+    options?: FindOneAndDeleteOptions
+  ): Promise<WithId<Secret>> {
+    const result = await super.findOneAndDelete(filter, options);
+    if (result) {
+      this.changeDispatcher.dispatch({operationType: "delete", documentKey: {_id: result._id}});
+    }
+    return result;
+  }
+
+  watchChanges(): Observable<CollectionChangeEvent> {
+    return this.changeDispatcher.watch();
   }
 }

--- a/packages/api/secret/services/src/service.ts
+++ b/packages/api/secret/services/src/service.ts
@@ -11,8 +11,9 @@ import {
   WithId
 } from "@spica-server/database";
 import {Secret} from "@spica-server/interface-secret";
+import {CollectionChangeEvent} from "@spica-server/replication";
 import {Observable} from "rxjs";
-import {CollectionChangeEvent, SecretChangeDispatcher} from "./change-dispatcher.js";
+import {SecretChangeDispatcher} from "./change-dispatcher.js";
 
 export const SECRET_ENCRYPTION_SECRET = Symbol.for("SECRET_ENCRYPTION_SECRET");
 

--- a/packages/api/secret/services/tsconfig.json
+++ b/packages/api/secret/services/tsconfig.json
@@ -9,9 +9,6 @@
       "path": "../../../interface/secret"
     },
     {
-      "path": "../../../interface/replication"
-    },
-    {
       "path": "../../../database"
     },
     {

--- a/packages/api/secret/services/tsconfig.json
+++ b/packages/api/secret/services/tsconfig.json
@@ -3,7 +3,13 @@
   "include": ["src/**/*.ts", "index.ts"],
   "references": [
     {
+      "path": "../../replication"
+    },
+    {
       "path": "../../../interface/secret"
+    },
+    {
+      "path": "../../../interface/replication"
     },
     {
       "path": "../../../database"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8961,7 +8961,6 @@ __metadata:
     "@nestjs/common": "npm:^10.4.15"
     "@spica-server/database": "workspace:*"
     "@spica-server/interface-env_var": "workspace:*"
-    "@spica-server/interface-replication": "workspace:*"
     "@spica-server/replication": "workspace:*"
     rxjs: "npm:^7.8.1"
   languageName: unknown
@@ -9262,6 +9261,7 @@ __metadata:
     "@spica-server/env_var-services": "workspace:*"
     "@spica-server/interface-function": "workspace:*"
     "@spica-server/interface-function-asset-storage": "workspace:*"
+    "@spica-server/replication": "workspace:*"
     "@spica-server/secret-services": "workspace:*"
     rxjs: "npm:^7.8.1"
   languageName: unknown
@@ -10176,7 +10176,6 @@ __metadata:
     "@spica-server/core": "workspace:*"
     "@spica-server/core-encryption": "workspace:*"
     "@spica-server/database": "workspace:*"
-    "@spica-server/interface-replication": "workspace:*"
     "@spica-server/interface-secret": "workspace:*"
     "@spica-server/replication": "workspace:*"
     rxjs: "npm:^7.8.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8961,6 +8961,9 @@ __metadata:
     "@nestjs/common": "npm:^10.4.15"
     "@spica-server/database": "workspace:*"
     "@spica-server/interface-env_var": "workspace:*"
+    "@spica-server/interface-replication": "workspace:*"
+    "@spica-server/replication": "workspace:*"
+    rxjs: "npm:^7.8.1"
   languageName: unknown
   linkType: soft
 
@@ -10173,7 +10176,10 @@ __metadata:
     "@spica-server/core": "workspace:*"
     "@spica-server/core-encryption": "workspace:*"
     "@spica-server/database": "workspace:*"
+    "@spica-server/interface-replication": "workspace:*"
     "@spica-server/interface-secret": "workspace:*"
+    "@spica-server/replication": "workspace:*"
+    rxjs: "npm:^7.8.1"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

Follow-up to the config `watchConfig` change, applying the same pattern to **env-var** and **secret**.

`FunctionService.watchFunctionsForEnvChanges()` / `watchFunctionsForSecretChanges()` previously opened a **MongoDB change stream** on the `env_var` / `secret` collections (with an `operationType` `$match` pipeline) to **reload** or **eject** functions when a referenced env-var/secret changed. This replaces that with an **in-process RxJS `Subject`** that emits on the service write methods, broadcast across replicas via **`ClassCommander`**.

The consumer contract is preserved: the engine still receives `{fns, envVarId|secretId, operationType}` and uses `operationType` to choose eject (`delete`) vs reload (`update`/`replace`).

## What's different from the config dispatcher

The config dispatcher emitted just the document. Here the consumer **needs `operationType`**, so `EnvVarChangeDispatcher` / `SecretChangeDispatcher` emit `{operationType, documentKey: {_id}}` — the same shape the change-stream events had, so `FunctionService`'s `map`/`filter` callbacks are essentially unchanged.

## How it works

- **`EnvVarChangeDispatcher` / `SecretChangeDispatcher`** (new) own a `Subject<CollectionChangeEvent>` and register `dispatch()` with `ClassCommander` in `SYNC` mode for cross-replica fan-out. **Distinct class names** keep env-var and secret broadcasts isolated (ClassCommander routes by `ctx.constructor.name`). The commander is `@Optional()` (a single replica has no peer to broadcast to).
- **`EnvVarService` / `SecretService`** override `insertOne` / `findOneAndUpdate` / `findOneAndReplace` / `findOneAndDelete` to dispatch the matching `operationType` from the write result, and expose `watchChanges()`.
- **`FunctionService`** consumes `watchChanges()` and filters `update`/`replace`/`delete` via an RxJS `filter` — dropping the now-redundant change-stream `$match` pipeline. `insert` is excluded because a brand-new env-var/secret has no functions referencing it yet.

## Replication / shared-singleton wiring

`SecretModule` already registers secret services via `ServicesModule.forRoot()` once, so `SecretService` + its dispatcher are a single global instance shared with `FunctionService` — no wiring change needed.

`env_var` is different: `EnvVarServicesModule.forRoot()` is never called; both `EnvVarModule` and the function services module import the **bare `@Global` class** and **re-provide `EnvVarService`** (two instances). Calling `forRoot()` in two importers would double-register and split the bus, so the dispatcher is provided on the **static `@Global` `@Module` decorator** — imported by class reference and therefore registered exactly once — giving both `EnvVarService` instances one shared dispatcher to dispatch to and watch.

## Notes

- **Change streams remain enabled** (`changeStreamPreAndPostImages`) on both collections — the env-var/secret **realtime** websocket modules still use them. Only the function-reload path moved off change streams.
- `engine.spec` constructs the services directly with `new`, so it now passes a dispatcher instance.
- `rxjs` + `@spica-server/replication` declared as explicit deps on both services packages; `yarn.lock` regenerated (verified `yarn install --immutable` passes).

## Tests (all green locally)

- `api/function` full suite — **147 ✓** (incl. `engine.spec` env/secret reload+eject, `controller.spec` inject/eject)
- `api/env_var` — 14 ✓ · `api/secret` — 32 ✓
- `api/env_var/realtime` — 8 ✓ · `api/secret/realtime` — 8 ✓ (change-stream realtime preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)