### PR TITLE
fix(status): honor http-status-tracking flag for function HTTP triggers

### DIFF
--- a/packages/api/status/services/src/module.ts
+++ b/packages/api/status/services/src/module.ts
@@ -12,10 +12,10 @@ export class CoreStatusServiceModule {
       providers: [
         {
           provide: ATTACH_STATUS_TRACKER,
-          useFactory: service => {
-            return attachStatusTrackerFactory(service);
+          useFactory: (service, options: StatusOptions) => {
+            return options.httpStatusTracking ? attachStatusTrackerFactory(service) : undefined;
           },
-          inject: [StatusService]
+          inject: [StatusService, STATUS_OPTIONS]
         },
 
         {provide: STATUS_OPTIONS, useValue: options},

--- a/packages/api/status/services/test/interceptor.spec.ts
+++ b/packages/api/status/services/test/interceptor.spec.ts
@@ -5,6 +5,7 @@ import {StatusModule} from "@spica-server/status";
 import {Test} from "@nestjs/testing";
 import {DatabaseTestingModule} from "@spica-server/database-testing";
 import {PassportTestingModule} from "@spica-server/passport-testing";
+import {ATTACH_STATUS_TRACKER} from "@spica-server/interface-status";
 
 const MbInKb = 1000 * 1000;
 
@@ -115,6 +116,31 @@ describe("Status Interceptor", () => {
           }
         }
       });
+    });
+  });
+
+  describe("ATTACH_STATUS_TRACKER provider", () => {
+    async function getTracker(httpStatusTracking: boolean) {
+      const module = await Test.createTestingModule({
+        imports: [
+          DatabaseTestingModule.standalone(),
+          CoreTestingModule,
+          StatusModule.forRoot({expireAfterSeconds: 60 * 60, httpStatusTracking}),
+          PassportTestingModule.initialize()
+        ]
+      }).compile();
+
+      const tracker = module.get(ATTACH_STATUS_TRACKER, {strict: false});
+      await module.close();
+      return tracker;
+    }
+
+    it("should provide a tracker when httpStatusTracking is enabled", async () => {
+      expect(typeof (await getTracker(true))).toEqual("function");
+    });
+
+    it("should not provide a tracker when httpStatusTracking is disabled", async () => {
+      expect(await getTracker(false)).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Problem

Disabling `--http-status-tracking` had no effect on function HTTP triggers — they kept being tracked.

`http-status-tracking` is only consulted in `StatusModule.forRoot`, where it gates the global `StatusInterceptor` (`APP_INTERCEPTOR`) that covers the **main API routes**. However, `CoreStatusServiceModule.forRoot` **unconditionally** provided `ATTACH_STATUS_TRACKER`. That provider is injected into the function scheduler (`scheduler.ts:74`) and handed to `HttpEnqueuer`, which attaches the tracker to **every function HTTP-trigger request** (`enqueuer/src/http.ts:205-206`).

| Path | `http-status-tracking: false` (before) |
|---|---|
| Main API routes | tracking off ✓ |
| Function HTTP triggers | **still tracked** ✗ |

## Fix

Make the `ATTACH_STATUS_TRACKER` factory return `undefined` when `httpStatusTracking` is disabled. The consumers already handle an absent tracker:
- scheduler injects it with `@Optional()`
- `HttpEnqueuer` guards with `if (this.attachStatusTracker)`

## Tests

Added coverage in `interceptor.spec.ts` asserting the `ATTACH_STATUS_TRACKER` provider resolves to a function when the flag is on and to `undefined` when off. Full `api/status/services/test` suite passes (7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)