### PR TITLE
fix(chart): TCP liveness/readiness probes for mongo (stop mongosh probe CPU + log churn)

### DIFF
--- a/charts/spica/templates/database.yaml
+++ b/charts/spica/templates/database.yaml
@@ -119,7 +119,7 @@ spec:
             timeoutSeconds: {{ .Values.database.livenessProbeTimeoutSeconds }}
             failureThreshold: {{ .Values.database.livenessProbeFailureThreshold }}
           readinessProbe:
-            # TCP probe (see livenessProbe note). The startupProbe below keeps a real mongosh ping,
+            # TCP probe (see livenessProbe note). The startupProbe above keeps a real mongosh ping,
             # so the pod is only marked "started" once mongo actually answers a command; after that,
             # readiness just needs to confirm the listener is up — no recurring mongosh spawns.
             tcpSocket:

--- a/charts/spica/templates/database.yaml
+++ b/charts/spica/templates/database.yaml
@@ -107,32 +107,23 @@ spec:
             timeoutSeconds: {{ .Values.database.startupProbeTimeoutSeconds }}
             failureThreshold: {{ .Values.database.startupProbeFailureThreshold }}
           livenessProbe:
-            exec:
-              command:
-                - mongosh
-                - --username
-                - $(ROOT_USERNAME)
-                - --password
-                - $(ROOT_PASSWORD)
-                - --authenticationDatabase
-                - admin
-                - --eval
-                - "db.adminCommand('ping')"
+            # TCP probe instead of an exec'd mongosh: mongo-8 images ship only mongosh (a Node.js
+            # process), so an exec liveness check spawned a full mongosh + pooled SCRAM auths every
+            # period — heavy, traffic-independent CPU and connection-churn logs on every instance.
+            # mongod runs with --bind_ip_all on 27017, so a TCP connect succeeds iff it's accepting
+            # connections; a hung-but-listening mongod is rare and an aggressive liveness restart of
+            # a database is itself risky, so TCP is the safer default here.
+            tcpSocket:
+              port: 27017
             periodSeconds: {{ .Values.database.livenessProbePeriodSeconds }}
             timeoutSeconds: {{ .Values.database.livenessProbeTimeoutSeconds }}
             failureThreshold: {{ .Values.database.livenessProbeFailureThreshold }}
           readinessProbe:
-            exec:
-              command:
-                - mongosh
-                - --username
-                - $(ROOT_USERNAME)
-                - --password
-                - $(ROOT_PASSWORD)
-                - --authenticationDatabase
-                - admin
-                - --eval
-                - "db.adminCommand('ping')"
+            # TCP probe (see livenessProbe note). The startupProbe below keeps a real mongosh ping,
+            # so the pod is only marked "started" once mongo actually answers a command; after that,
+            # readiness just needs to confirm the listener is up — no recurring mongosh spawns.
+            tcpSocket:
+              port: 27017
             periodSeconds: {{ .Values.database.readinessProbePeriodSeconds }}
             timeoutSeconds: {{ .Values.database.readinessProbeTimeoutSeconds }}
             failureThreshold: {{ .Values.database.readinessProbeFailureThreshold }}

--- a/charts/spica/tests/database_test.yaml
+++ b/charts/spica/tests/database_test.yaml
@@ -214,18 +214,17 @@ tests:
           path: spec.template.spec.containers[0].startupProbe.failureThreshold
           value: 10
 
-  - it: should configure the liveness probe with mongosh ping
+  - it: should configure the liveness probe as a TCP socket check
     template: templates/database.yaml
     documentSelector:
       path: kind
       value: StatefulSet
     asserts:
-      - contains:
-          path: spec.template.spec.containers[0].livenessProbe.exec.command
-          content: mongosh
-      - contains:
-          path: spec.template.spec.containers[0].livenessProbe.exec.command
-          content: "db.adminCommand('ping')"
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.tcpSocket.port
+          value: 27017
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe.exec
 
   - it: should use default liveness probe timing values
     template: templates/database.yaml
@@ -263,18 +262,17 @@ tests:
           path: spec.template.spec.containers[0].livenessProbe.failureThreshold
           value: 5
 
-  - it: should configure the readiness probe with mongosh ping
+  - it: should configure the readiness probe as a TCP socket check
     template: templates/database.yaml
     documentSelector:
       path: kind
       value: StatefulSet
     asserts:
-      - contains:
-          path: spec.template.spec.containers[0].readinessProbe.exec.command
-          content: mongosh
-      - contains:
-          path: spec.template.spec.containers[0].readinessProbe.exec.command
-          content: "db.adminCommand('ping')"
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
+          value: 27017
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe.exec
 
   - it: should use default readiness probe timing values
     template: templates/database.yaml


### PR DESCRIPTION
## Problem

The mongo-8 images ship **only `mongosh`** (a Node.js shell) — the lightweight C++ `mongo` shell from the 4.x era is gone. The chart's mongo **liveness (30s)** and **readiness (10s)** probes `exec mongosh … --eval db.adminCommand('ping')`, so on **every period** they:

- spin up a full **`mongosh` Node.js process**, and
- open its driver's **connection pool (~5 connections) + SCRAM auth on each**, then tear down.

This is a **fixed, traffic- and data-independent cost on every instance**. On a low-traffic tenant it was the dominant signal:

- **~40 connection setups/min** of churn — essentially **100% of the mongod log volume** (NETWORK "Connection accepted / client metadata / Connection ended"). Observed jump from a few hundred to tens of thousands of log lines/day after upgrade.
- A steady CPU cost (mongosh Node startup + repeated SCRAM-SHA-256 auth) that **scaled with neither workload nor data size** — high CPU across all upgraded instances regardless of traffic.

On 4.x the same probe was a cheap C++ binary (or TCP), so it cost ~nothing — the mongo-8 image change to mongosh-only silently turned a cheap probe into an expensive one for every tenant.

## Change

- **`livenessProbe` + `readinessProbe` → `tcpSocket: 27017`.** mongod runs with `--bind_ip_all` on the default port, so a TCP connect succeeds iff it's accepting connections. (An aggressive exec liveness restart of a database is itself undesirable, so TCP is the safer default for liveness.)
- **`startupProbe` kept as the real `mongosh` ping** — it runs only at boot and then stops, so it's not an ongoing cost, and it ensures the pod is marked "started" only once mongo actually answers a command (avoids premature-ready during recovery). After startup, readiness just confirms the listener is up.
- `periodSeconds` / `timeoutSeconds` / `failureThreshold` values unchanged.

## Safety / testing

- **Accessibility:** mongod binds `0.0.0.0:27017` (`--bind_ip_all`, no `--port` override); pods are Ready today with mongosh connecting on 27017, and a kubelet `tcpSocket` probe connects directly (no in-container tooling needed).
- `helm lint` passes; `helm template` renders `tcpSocket` for liveness/readiness and the unchanged `mongosh` startupProbe.
- No values-schema changes; existing `*Probe*Seconds`/`*FailureThreshold` values still apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)