### PR TITLE
fix(cli,ci): build portable panel images so CLI dashboard loads anywhere

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ env:
   NX_NO_CLOUD: true
   VERSION: master
   BASE_URL: /
-  VITE_BASE_URL: https://master.spicaengine.com/api
+  VITE_BASE_URL: /api
 
 on:
   push:

--- a/apps/cli/src/commands/project/start.ts
+++ b/apps/cli/src/commands/project/start.ts
@@ -339,7 +339,6 @@ async function create({args: cmdArgs, options}: ActionParameters) {
       const client = await machine.createContainer({
         Image: `spicaengine/panel:${options.imageVersion}`,
         name: `${name}-spica`,
-        Env: ["BASE_URL=/"],
         Labels: {namespace: name},
         HostConfig: {
           RestartPolicy: {


### PR DESCRIPTION
## Problem

Running `spica project start <name>` and opening the dashboard, the page loaded the login screen but **could not authenticate or load any data against the local instance**. Network inspection (Chrome DevTools) showed the panel calling `https://master.spicaengine.com/api/...` instead of the local `http://localhost:<port>/api/...`.

## Root cause

`spica project start` defaults to `--image-version latest` and pulls `spicaengine/panel:latest`, which is produced by `.github/workflows/deploy.yml` (*Spica Master Deployment*, on every push to `master`). That workflow builds the panel with:

```yaml
VITE_BASE_URL: https://master.spicaengine.com/api
```

`VITE_BASE_URL` is baked into the SPA at **build time**, so the published image hardcodes the master demo API URL. Verified on the live image — `baseUrl:"https://master.spicaengine.com/api"` appears 7× in `panel:latest`'s bundle. Any instance not served from `master.spicaengine.com` (e.g. a local CLI instance) gets a UI that talks to the wrong API.

## Fix

The absolute URL was never necessary. The master deployment ingress serves the panel (`/?(.*)`) and the API (`/api/?(.*)`) on the **same host** (`master.spicaengine.com`), so a relative `/api` resolves to exactly the same origin (confirmed in `deployment.yaml`). Making the API path relative everywhere produces a single **portable** image that runs anywhere — local CLI, master demo, or self-hosted.

- **`deploy.yml`** — `VITE_BASE_URL: /api` (relative). The build is now portable, so the existing `:latest` push keeps its intended meaning: the bleeding-edge "latest features" master build, just no longer pinned to the master host.
- **`apps/cli/.../project/start.ts`** — remove the dead `Env: ["BASE_URL=/"]` on the panel container. `BASE_URL` is a Vite **build-time** variable; setting it at container runtime does nothing and falsely implies the CLI controls the panel base path.

`release.yml` already builds with the portable `VITE_BASE_URL: /api` and publishes stable `:<version>` tags — unchanged.

## CLI publish check

The task also asked to verify the CLI publish workflow has no similar issue. The `cli` npm publish (`release.yml` → `npm-packages` → `yarn run publish:cli`) does **not** embed `BASE_URL`/`VITE_BASE_URL` — the CLI is a Node bundle. Its only exposure was the default `--image-version latest`, which this PR fixes by making every panel build (including `:latest`) portable.

## Verification

Built and linked the CLI (`yarn nx bundle cli` → `npm link`), built a panel image with the portable spec (`BASE_URL=/ VITE_BASE_URL=/api`, identical to what `deploy.yml` now produces), and ran `spica project start`:

- SPA assets load at root (`/assets/...`), no bundle 404s.
- API calls target the local instance: `POST /api/passport/identify [200]`, `GET /api/dashboard [200]`, `GET /api/bucket? [200]`.
- Login with `spica/spica` succeeds and the dashboard renders ("Welcome back, Spica").

🤖 Generated with [Claude Code](https://claude.com/claude-code)