### PR TITLE
fix(db): scope changeStreamPreAndPostImages to function_assets only

### DIFF
--- a/apps/migrate/src/migrations/0.16.0/enable_changeStreamPreAndPostImages.ts
+++ b/apps/migrate/src/migrations/0.16.0/enable_changeStreamPreAndPostImages.ts
@@ -1,7 +1,7 @@
 import {Context} from "../../migrate";
 
 export default async function (ctx: Context) {
-  const collections = ["buckets", "function", "env_var", "policies"];
+  const collections = ["function_assets"];
 
   for (const collectionName of collections) {
     try {

--- a/apps/migrate/test/migrations/0_16_0_enable_changeStreamPreAndPostImages.spec.ts
+++ b/apps/migrate/test/migrations/0_16_0_enable_changeStreamPreAndPostImages.spec.ts
@@ -25,51 +25,33 @@ describe("Enable changeStreamPreAndPostImages for collections", () => {
     db = connection.db(args[3]);
   });
 
-  it("should enable changeStreamPreAndPostImages for collections", async () => {
+  it("should enable changeStreamPreAndPostImages only for the function_assets collection", async () => {
+    await db
+      .collection("function_assets")
+      .insertOne({_id: new ObjectId(), functionId: new ObjectId(), filename: "index.ts"});
     await db.collection("buckets").insertOne({_id: new ObjectId(), name: "test bucket"});
     await db
       .collection("function")
       .insertOne({_id: new ObjectId(), name: "test function", env: {}});
-    await db.collection("env_var").insertOne({_id: new ObjectId(), name: "test env var"});
-    await db.collection("policies").insertOne({_id: new ObjectId(), name: "test policy"});
-    await db.collection("webhooks").insertOne({_id: new ObjectId(), name: "test webhook"});
 
     await run([...args, "--from", "0.15.0", "--to", "0.16.0", "--continue-if-versions-are-equal"]);
 
+    const assetsInfo = (await db.listCollections({name: "function_assets"}).toArray()) as any;
+    expect(assetsInfo[0].options?.changeStreamPreAndPostImages?.enabled).toBe(true);
+
     const bucketsInfo = (await db.listCollections({name: "buckets"}).toArray()) as any;
-    expect(bucketsInfo[0].options?.changeStreamPreAndPostImages?.enabled).toBe(true);
+    expect(bucketsInfo[0].options?.changeStreamPreAndPostImages?.enabled).toBe(undefined);
 
     const functionInfo = (await db.listCollections({name: "function"}).toArray()) as any;
-    expect(functionInfo[0].options?.changeStreamPreAndPostImages?.enabled).toBe(true);
-
-    const envVarInfo = (await db.listCollections({name: "env_var"}).toArray()) as any;
-    expect(envVarInfo[0].options?.changeStreamPreAndPostImages?.enabled).toBe(true);
-
-    const policiesInfo = (await db.listCollections({name: "policies"}).toArray()) as any;
-    expect(policiesInfo[0].options?.changeStreamPreAndPostImages?.enabled).toBe(true);
-
-    const webhooksInfo = (await db.listCollections({name: "webhooks"}).toArray()) as any;
-    expect(webhooksInfo[0].options?.changeStreamPreAndPostImages?.enabled).toBe(undefined);
+    expect(functionInfo[0].options?.changeStreamPreAndPostImages?.enabled).toBe(undefined);
   });
 
-  it("should enable changeStreamPreAndPostImages only for existing collections", async () => {
+  it("should skip when the function_assets collection does not exist", async () => {
     await db.collection("buckets").insertOne({_id: new ObjectId(), name: "test bucket"});
-    await db
-      .collection("function")
-      .insertOne({_id: new ObjectId(), name: "test function", env: {}});
 
     await run([...args, "--from", "0.15.0", "--to", "0.16.0", "--continue-if-versions-are-equal"]);
 
-    const bucketsInfo = (await db.listCollections({name: "buckets"}).toArray()) as any;
-    expect(bucketsInfo[0].options?.changeStreamPreAndPostImages?.enabled).toBe(true);
-
-    const functionInfo = (await db.listCollections({name: "function"}).toArray()) as any;
-    expect(functionInfo[0].options?.changeStreamPreAndPostImages?.enabled).toBe(true);
-
-    const envVarInfo = (await db.listCollections({name: "env_var"}).toArray()) as any;
-    expect(envVarInfo.length).toBe(0);
-
-    const policiesInfo = (await db.listCollections({name: "policies"}).toArray()) as any;
-    expect(policiesInfo.length).toBe(0);
+    const assetsInfo = (await db.listCollections({name: "function_assets"}).toArray()) as any;
+    expect(assetsInfo.length).toBe(0);
   });
 });

--- a/packages/api/bucket/services/src/bucket.service.ts
+++ b/packages/api/bucket/services/src/bucket.service.ts
@@ -54,9 +54,7 @@ export class BucketService
     private changeDispatcher: BucketChangeDispatcher,
     @Optional() @Inject(BUCKET_DATA_LIMIT) private bucketDataLimit
   ) {
-    super(db, {
-      collectionOptions: {changeStreamPreAndPostImages: {enabled: true}}
-    });
+    super(db);
   }
 
   async onModuleInit() {

--- a/packages/api/bucket/services/test/bucket.service.spec.ts
+++ b/packages/api/bucket/services/test/bucket.service.spec.ts
@@ -23,12 +23,6 @@ describe("Bucket Service", () => {
       }).compile();
       bs = module.get(BucketService);
       bds = module.get(BucketDataService);
-
-      await bs.db
-        .createCollection("buckets", {
-          changeStreamPreAndPostImages: {enabled: true}
-        })
-        .catch(console.warn);
     });
 
     afterEach(async () => {

--- a/packages/api/dashboard/src/dashboard.service.ts
+++ b/packages/api/dashboard/src/dashboard.service.ts
@@ -5,8 +5,6 @@ import {BaseCollection, DatabaseService} from "@spica-server/database";
 @Injectable()
 export class DashboardService extends BaseCollection<Dashboard>("dashboard") {
   constructor(db: DatabaseService) {
-    super(db, {
-      collectionOptions: {changeStreamPreAndPostImages: {enabled: true}}
-    });
+    super(db);
   }
 }

--- a/packages/api/env_var/services/src/service.ts
+++ b/packages/api/env_var/services/src/service.ts
@@ -22,8 +22,7 @@ export class EnvVarService extends BaseCollection<EnvVar>("env_var") {
     private readonly changeDispatcher: EnvVarChangeDispatcher
   ) {
     super(db, {
-      afterInit: () => this._coll.createIndex({key: 1}, {unique: true}),
-      collectionOptions: {changeStreamPreAndPostImages: {enabled: true}}
+      afterInit: () => this._coll.createIndex({key: 1}, {unique: true})
     });
   }
 

--- a/packages/api/function/services/src/service.ts
+++ b/packages/api/function/services/src/service.ts
@@ -33,7 +33,6 @@ export class FunctionService extends BaseCollection<Function>(collectionName) {
   ) {
     super(database, {
       entryLimit: options.entryLimit,
-      collectionOptions: {changeStreamPreAndPostImages: {enabled: true}},
       afterInit: () =>
         Promise.all([
           this.createIndex({env_vars: 1}),

--- a/packages/api/passport/policy/src/policy.service.ts
+++ b/packages/api/passport/policy/src/policy.service.ts
@@ -13,9 +13,7 @@ export class PolicyService extends BaseCollection<Policy>("policies") {
   }
 
   constructor(db: DatabaseService) {
-    super(db, {
-      collectionOptions: {changeStreamPreAndPostImages: {enabled: true}}
-    });
+    super(db);
     this.managedPolicies = managedPolicies.map(p => ({...p, system: true}) as PolicyWithType);
   }
 

--- a/packages/api/secret/services/src/service.ts
+++ b/packages/api/secret/services/src/service.ts
@@ -25,8 +25,7 @@ export class SecretService extends BaseCollection<Secret>("secret") {
     private readonly changeDispatcher: SecretChangeDispatcher
   ) {
     super(db, {
-      afterInit: () => this._coll.createIndex({key: 1}, {unique: true}),
-      collectionOptions: {changeStreamPreAndPostImages: {enabled: true}}
+      afterInit: () => this._coll.createIndex({key: 1}, {unique: true})
     });
   }
 


### PR DESCRIPTION
## Summary

`changeStreamPreAndPostImages` only earns its keep for change-stream consumers that read `fullDocumentBeforeChange` (the pre-image). An audit of every `.watch()` in the codebase found exactly **one** such consumer:

- **`FunctionAssetWatcher`** (`packages/api/function/src/asset-watcher.ts`) watches the `function_assets` collection with `fullDocumentBeforeChange: "whenAvailable"` and uses the pre-image to recover the asset `key` on **delete** events (where `fullDocument` is null) for peer directory cleanup.

Everywhere else the option was enabled — `buckets`, `function`, `env_var`, `policies`, `dashboard`, `secret` — **no watcher requests pre-images**, so MongoDB was storing pre/post-images for nothing. (`webhook/src/invoker.ts` reads `fullDocumentBeforeChange` as a fallback but never requests it in its watch options, so it was always `undefined`.)

There was also a mismatch: the one collection that genuinely needs it (`function_assets`) was **not** covered by the `0.16.0` migration, so existing clusters only received it via fresh-install `createCollection`.

## Changes

- **Migration** (`0.16.0/enable_changeStreamPreAndPostImages.ts`): target list narrowed from `["buckets", "function", "env_var", "policies"]` → `["function_assets"]`.
- **Service constructors**: removed `collectionOptions: {changeStreamPreAndPostImages: {enabled: true}}` from `bucket`, `function`, `policy`, `dashboard`, `secret`, and `env_var` services. `function/services/asset.service.ts` (the real consumer) is untouched.
- **Tests**: rewrote the migration spec to assert `function_assets` gets enabled while other collections don't (and a graceful skip when absent); removed the now-dead pre-image setup block from the bucket service spec.

## Notes

- Fresh installs still enable the option on `function_assets` via `BaseCollection.createCollection`; the migration now converges existing clusters for that collection too.
- This does **not** add a migration to *disable* the option on the six collections that previously had it. Leaving it enabled is harmless-but-wasteful; disabling via `collMod` is a separate reclaim step. Happy to add a companion migration if desired.

## Test plan

- [ ] `yarn nx test migrate`
- [ ] `yarn nx test bucket`

🤖 Generated with [Claude Code](https://claude.com/claude-code)