### PR TITLE
fix(function): stop warm pool draining across replicas on function update

### DIFF
--- a/packages/api/function/scheduler/src/scheduler.ts
+++ b/packages/api/function/scheduler/src/scheduler.ts
@@ -35,7 +35,6 @@ import {
 } from "@spica-server/function-runtime-io";
 import {generateLog} from "@spica-server/function-runtime-logger";
 import {ClassCommander, JobReducer} from "@spica-server/replication";
-import {CommandType} from "@spica-server/interface-replication";
 import {AttachStatusTracker, ATTACH_STATUS_TRACKER} from "@spica-server/interface-status";
 import {GuardService} from "@spica-server/passport-guard-services";
 import uniqid from "uniqid";
@@ -74,10 +73,6 @@ export class Scheduler implements OnModuleInit, OnModuleDestroy {
     @Optional() @Inject(ATTACH_STATUS_TRACKER) private attachStatusTracker: AttachStatusTracker,
     private guardService: GuardService
   ) {
-    if (this.commander) {
-      this.commander.register(this, [this.outdateWorkers], CommandType.SYNC);
-    }
-
     this.outputs = this.createOutputs(database);
 
     this.languages.set("typescript", new Typescript(options.tsCompilerPath));
@@ -447,8 +442,7 @@ export class Scheduler implements OnModuleInit, OnModuleDestroy {
       .filter(worker => worker.hasSameTarget(targetId))
       .forEach(worker => {
         if (worker.state != WorkerState.Outdated) {
-          const wasWarm =
-            worker.state == WorkerState.Warm || worker.state == WorkerState.Warming;
+          const wasWarm = worker.state == WorkerState.Warm || worker.state == WorkerState.Warming;
           worker.markAsOutdated();
           // Warm workers never execute on their own, so they can't drain by finishing
           // an event — kill them now. The reserve is refilled by the engine's reconcile


### PR DESCRIPTION
## Problem

In a multi-replica deployment (`--replication`), updating a warm-enabled function (changing `warmWorkers`, editing code, etc.) **drained every replica's warm worker pool to zero**. Follow-up: the pre-warmed workers silently disappear cluster-wide, so requests fall back to cold starts until each function is edited again or the replicas restart.

Reproduced with two replicas: creating `warmWorkers: 2` gives `warm: 2` on both; a `warmWorkers 2→3` update takes both to `warm: 0` (workers spawn, then die before ever becoming ready).

## Root cause

`scheduler.outdateWorkers` was registered for `ClassCommander` SYNC **in addition to** the already-synced `engine.categorizeChanges`.

Each replica's synced `categorizeChanges` already does the right thing, in order: outdate its stale workers (via enqueuer `unsubscribe → schedulerUnsubscription → outdateWorkers`) **and then** re-provision the warm pool from the function's fresh state. The extra, independent `outdateWorkers` broadcast from a peer arrives **after** that reconcile and kills the freshly-spawned warm workers — with no accompanying refill. Both replicas settle at zero.

Single-replica updates were unaffected (no peer to broadcast the stray outdate), which is why this only showed up in a cluster.

## Fix

Remove the redundant `outdateWorkers` commander registration (and its now-unused `CommandType` import). Outdating is already propagated to every replica by the commander-synced `categorizeChanges`, which outdates and reconciles the pool locally in the correct order and with the function's fresh env — so nothing races it.

Chose this over "make `outdateWorkers` re-provision the pool" because that path would respawn warm workers with a stale env target on env changes.

## Verification

Two replicas, `--replication true`, shared DB + persistent path:

| Action on replica 1 | replica 1 | replica 2 |
|---|---|---|
| create `warmWorkers: 2` | 2 | — |
| **start replica 2 (new replica)** | 2 | **2** (self-provisions on startup) |
| update `warmWorkers` 2 → 3 | **3** | **3** |
| update function code (index) | **3** | **3** (refreshed with new code) |
| disable (`warmWorkers: 0`) | **0** | **0** |

Scheduler unit tests: 33/33 green.

Fixes a regression shipped in #1889.

🤖 Generated with [Claude Code](https://claude.com/claude-code)