### PR TITLE
feat(panel): per-function warm pool + HTTP trigger options in sidebar

### DIFF
--- a/apps/panel/src/components/prefabs/navigations/function/FunctionModal.module.scss
+++ b/apps/panel/src/components/prefabs/navigations/function/FunctionModal.module.scss
@@ -195,6 +195,13 @@
   font-family: var(--font-mono);
 }
 
+.warmPoolHint {
+  font-size: var(--font-size-xs, 11px);
+  color: var(--color-font-secondary, rgba(255, 255, 255, 0.5));
+  line-height: 1.35;
+  margin-top: 4px;
+}
+
 .triggerHeading {
   font-size: 11px;
   font-weight: 600;

--- a/apps/panel/src/components/prefabs/navigations/function/FunctionModal.tsx
+++ b/apps/panel/src/components/prefabs/navigations/function/FunctionModal.tsx
@@ -3,16 +3,15 @@
  * email: rio.kenan@gmail.com
  */
 
-import React, {memo, useCallback, useEffect, useMemo, useState} from "react";
-import {Button, Drawer, FlexElement, Icon, Input, NumberInput, Select, StringInput, Text} from "oziko-ui-kit";
+import React, {memo, useCallback, useEffect, useState} from "react";
+import {Button, Drawer, FlexElement, Icon, Select, StringInput, Text} from "oziko-ui-kit";
 import {
   useCreateFunctionMutation,
   useUpdateFunctionMutation,
   useUpdateFunctionIndexMutation,
   useGetFunctionInformationQuery
 } from "../../../../store/api/functionApi";
-import type {SpicaFunction, Enqueuer, TriggerMap} from "../../../../store/api/functionApi";
-import {resolveRenderer, SchemaFieldProvider} from "./schema-fields";
+import type {SpicaFunction} from "../../../../store/api/functionApi";
 import styles from "./FunctionModal.module.scss";
 
 type FunctionModalProps = {
@@ -22,101 +21,15 @@ type FunctionModalProps = {
   onSaved: (fn: SpicaFunction) => void;
 };
 
-const buildTriggersMap = (fn: SpicaFunction): TriggerMap => {
-  if (!fn.triggers) return {};
-  if (Array.isArray(fn.triggers)) {
-    return fn.triggers.reduce<TriggerMap>((acc, trigger, i) => {
-      const key = trigger.handler ?? (i === 0 ? "default" : `handler_${i}`);
-      acc[key] = {type: trigger.type, active: trigger.active ?? true, options: trigger.options ?? {}};
-      return acc;
-    }, {});
-  }
-  return {...(fn.triggers as TriggerMap)};
-};
-
-const getPrimaryTriggerKey = (map: TriggerMap): string => {
-  if (map.default) return "default";
-  const firstKey = Object.keys(map)[0];
-  return firstKey ?? "default";
-};
-
-const getTriggerFromFunction = (
-  fn: SpicaFunction
-): {key: string; type: string; options: Record<string, any>} => {
-  const map = buildTriggersMap(fn);
-  const key = getPrimaryTriggerKey(map);
-  const trigger = map[key];
-  return {key, type: trigger?.type ?? "http", options: trigger?.options ?? {}};
-};
+const WARM_POOL_MAX = 2;
 
 const LANGUAGE_OPTIONS = [
   {label: "JavaScript", value: "javascript"},
   {label: "TypeScript", value: "typescript"}
 ];
 
-const FALLBACK_TRIGGER_TYPE_OPTIONS = [
-  {label: "Http", value: "http"},
-  {label: "Firehose", value: "firehose"},
-  {label: "Database", value: "database"},
-  {label: "Scheduler", value: "schedule"},
-  {label: "System", value: "system"},
-  {label: "Bucket", value: "bucket"}
-];
-
 const TRIGGER_EXAMPLES: Record<string, string> = {
-  http: `export default function (req, res) {\n\treturn res.status(201).send("Spica is awesome!");\n}`,
-  firehose: `export default function ({ socket, pool }, message) {\n\tconsole.log(message.name);\n\tconsole.log(message.data);\n\tconst isAuthorized = false;\n\tif (isAuthorized) {\n\t\tsocket.send("authorization", { state: true });\n\t\tpool.send("connection", { id: socket.id, ip_address: socket.remoteAddress });\n\t} else {\n\t\tsocket.send("authorization", { state: false, error: "Authorization has failed." });\n\t\tsocket.close();\n\t}\n}`,
-  database: `export default function (change) {\n\tconsole.log(change.kind + " action has been performed on document with id " + change.documentKey + " of collection " + change.collection);\n\tconsole.log("Document: ", change.document);\n}`,
-  schedule: `export default function () {\n\tconsole.log("Scheduled function executed.");\n}`,
-  system: `export default function () {\n\tconsole.log("Spica is ready.");\n}`,
-  bucket: `export default function (change) {\n\tconsole.log(change.kind + " action has been performed on document with id " + change.documentKey + " of bucket with id " + change.bucket);\n\tconsole.log("Previous document: ", change.previous);\n\tif (change.current) {\n\t\tconsole.log("Current document: ", change.current);\n\t}\n}`
-};
-
-const DATABASE_EXAMPLES: Record<string, string> = {
-  INSERT: `export default function (change) {\n\tconsole.log(change.kind + " action has been performed on document with id " + change.documentKey + " of collection " + change.collection);\n\tconsole.log("Document: ",change.document);\n}`,
-  REPLACE: `export default function (change) {\n\tconsole.log(change.kind + " action has been performed on document with id " + change.documentKey + " of collection " + change.collection);\n\tconsole.log("Document: ", change.document);\n}`,
-  UPDATE: `export default function (change) {\n\tconsole.log(change.kind + " action has been performed on document with id " + change.documentKey + " of collection " + change.collection);\n\tconsole.log("Document: ",change.document);\n}`,
-  DELETE: `export default function (change) {\n\tconsole.log(change.kind + " action has been performed on document with id " + change.documentKey + " of collection " + change.collection);\n}`
-};
-
-const BUCKET_EXAMPLES: Record<string, string> = {
-  ALL: `export default function (change) {\n\tconsole.log(change.kind + " action has been performed on document with id " + change.documentKey + " of bucket with id " + change.bucket);\n\tconsole.log("Previous document: ",change.previous);\n\tif (change.current) {\n\t\tconsole.log("Current document: ",change.current)\n\t}\n}`,
-  INSERT: `export default function (change) {\n\tconsole.log(change.kind + " action has been performed on document with id " + change.documentKey + " of bucket with id " + change.bucket);\n\tconsole.log("Previous document: ",change.previous);\n\tconsole.log("Current document: ",change.current)\n}`,
-  UPDATE: `export default function (change) {\n\tconsole.log(change.kind + " action has been performed on document with id " + change.documentKey + " of bucket with id " + change.bucket);\n\tconsole.log("Previous document: ",change.previous);\n\tconsole.log("Current document: ",change.current)\n}`,
-  DELETE: `export default function (change) {\n\tconsole.log(change.kind + " action has been performed on document with id " + change.documentKey + " of bucket with id " + change.bucket);\n\tconsole.log("Previous document: ",change.previous)\n}`
-};
-
-const getSchemaDefaults = (properties: Record<string, any>): Record<string, any> => {
-  const defaults: Record<string, any> = {};
-  for (const [key, schema] of Object.entries(properties)) {
-    if (schema.default !== undefined) {
-      defaults[key] = schema.default;
-    } else if (schema.type === "object" && schema.properties) {
-      const nested = getSchemaDefaults(schema.properties);
-      if (Object.keys(nested).length > 0) defaults[key] = nested;
-    }
-  }
-  return defaults;
-};
-
-const getDefaultTriggerOptions = (enqueuers: Enqueuer[], type: string): Record<string, any> => {
-  const enqueuer = enqueuers.find(e => e.description.name === type);
-  if (!enqueuer?.options?.properties) return {};
-  return getSchemaDefaults(enqueuer.options.properties);
-};
-
-const getExampleCode = (type: string, options: Record<string, any>): string => {
-  if (type === "database") {
-    return options.type
-      ? (DATABASE_EXAMPLES[options.type] ?? TRIGGER_EXAMPLES.database)
-      : TRIGGER_EXAMPLES.database;
-  }
-  if (type === "bucket") {
-    return options.type
-      ? (BUCKET_EXAMPLES[options.type] ?? TRIGGER_EXAMPLES.bucket)
-      : TRIGGER_EXAMPLES.bucket;
-  }
-  return TRIGGER_EXAMPLES[type] ?? TRIGGER_EXAMPLES.http;
+  http: `export default function (req, res) {\n\treturn res.status(201).send("Spica is awesome!");\n}`
 };
 
 const FunctionModal = ({isOpen, onClose, functionToEdit, onSaved}: FunctionModalProps) => {
@@ -125,9 +38,7 @@ const FunctionModal = ({isOpen, onClose, functionToEdit, onSaved}: FunctionModal
   const [category, setCategory] = useState("");
   const [language, setLanguage] = useState<string>("javascript");
   const [timeout, setTimeout] = useState(10);
-  const [triggerType, setTriggerType] = useState<string>("http");
-  const [triggerOptionValues, setTriggerOptionValues] = useState<Record<string, any>>({});
-  const [editingTriggerKey, setEditingTriggerKey] = useState("default");
+  const [warmWorkers, setWarmWorkers] = useState(0);
   const [error, setError] = useState("");
 
   const {data: information} = useGetFunctionInformationQuery();
@@ -139,15 +50,14 @@ const FunctionModal = ({isOpen, onClose, functionToEdit, onSaved}: FunctionModal
 
   const maxTimeout = information?.timeout ?? 120;
 
-  const triggerTypeSelectOptions =
-    information?.enqueuers && information.enqueuers.length > 0
-      ? information.enqueuers.map(e => ({label: e.description.title, value: e.description.name}))
-      : FALLBACK_TRIGGER_TYPE_OPTIONS;
-
-  const selectedEnqueuer = useMemo(
-    () => information?.enqueuers?.find(e => e.description.name === triggerType),
-    [information, triggerType]
-  );
+  const resetForm = useCallback(() => {
+    setName("");
+    setCategory("");
+    setLanguage("javascript");
+    setTimeout(10);
+    setWarmWorkers(0);
+    setError("");
+  }, []);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -156,74 +66,12 @@ const FunctionModal = ({isOpen, onClose, functionToEdit, onSaved}: FunctionModal
       setCategory(functionToEdit.category ?? "");
       setLanguage(functionToEdit.language ?? "javascript");
       setTimeout(functionToEdit.timeout ?? 10);
-      const trigger = getTriggerFromFunction(functionToEdit);
-      setEditingTriggerKey(trigger.key);
-      setTriggerType(trigger.type);
-      setTriggerOptionValues(trigger.options);
+      setWarmWorkers(functionToEdit.warmWorkers ?? 0);
     } else {
       resetForm();
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, functionToEdit?._id]);
-
-  useEffect(() => {
-    if (isEditMode) return;
-    const defaults = getDefaultTriggerOptions(information?.enqueuers ?? [], triggerType);
-    // Http schema defaults method to "Get"; the product default is "All" (matches any verb).
-    if (triggerType === "http") defaults.method = "All";
-    setTriggerOptionValues(defaults);
-  }, [triggerType, information, isEditMode]);
-
-  const handleTriggerOptionChange = useCallback((key: string, value: any) => {
-    setTriggerOptionValues(prev => ({...prev, [key]: value}));
-  }, []);
-
-  const handleNestedOptionChange = useCallback((parentKey: string, childKey: string, value: any) => {
-    setTriggerOptionValues(prev => ({
-      ...prev,
-      [parentKey]: {...(prev[parentKey] ?? {}), [childKey]: value}
-    }));
-  }, []);
-
-  const handleArrayItemChange = useCallback(
-    (key: string, index: number, field: string, value: any) => {
-      setTriggerOptionValues(prev => {
-        const arr = [...(prev[key] ?? [])];
-        arr[index] = {...(arr[index] ?? {}), [field]: value};
-        return {...prev, [key]: arr};
-      });
-    },
-    []
-  );
-
-  const handleArrayItemAdd = useCallback((key: string) => {
-    setTriggerOptionValues(prev => ({
-      ...prev,
-      [key]: [...(prev[key] ?? []), {}]
-    }));
-  }, []);
-
-  const handleArrayItemRemove = useCallback((key: string, index: number) => {
-    setTriggerOptionValues(prev => ({
-      ...prev,
-      [key]: (prev[key] ?? []).filter((_: any, i: number) => i !== index)
-    }));
-  }, []);
-
-  const handleTriggerTypeChange = useCallback((value: string) => {
-    setTriggerType(value);
-  }, []);
-
-  const resetForm = useCallback(() => {
-    setName("");
-    setCategory("");
-    setLanguage("javascript");
-    setTimeout(10);
-    setTriggerType("http");
-    setTriggerOptionValues({});
-    setEditingTriggerKey("default");
-    setError("");
-  }, []);
 
   const handleClose = useCallback(() => {
     resetForm();
@@ -251,14 +99,6 @@ const FunctionModal = ({isOpen, onClose, functionToEdit, onSaved}: FunctionModal
 
     try {
       if (isEditMode && functionToEdit?._id) {
-        const existingTriggers = buildTriggersMap(functionToEdit);
-        const editedTrigger = existingTriggers[editingTriggerKey];
-        existingTriggers[editingTriggerKey] = {
-          type: triggerType,
-          active: editedTrigger?.active ?? true,
-          options: triggerOptionValues
-        };
-
         const result = await updateFunction({
           id: functionToEdit._id,
           body: {
@@ -266,7 +106,7 @@ const FunctionModal = ({isOpen, onClose, functionToEdit, onSaved}: FunctionModal
             language: language as "javascript" | "typescript",
             timeout,
             category: trimmedCategory || undefined,
-            triggers: existingTriggers
+            warmWorkers
           }
         }).unwrap();
         onSaved(result);
@@ -277,12 +117,13 @@ const FunctionModal = ({isOpen, onClose, functionToEdit, onSaved}: FunctionModal
           language: language as "javascript" | "typescript",
           timeout,
           category: trimmedCategory || undefined,
+          warmWorkers,
           triggers: {
-            default: {type: triggerType, active: true, options: triggerOptionValues}
+            default: {type: "http", active: true, options: {method: "All"}}
           }
         }).unwrap();
 
-        const exampleCode = getExampleCode(triggerType, triggerOptionValues);
+        const exampleCode = TRIGGER_EXAMPLES.http;
         if (result._id) {
           await updateIndex({id: result._id, index: exampleCode}).unwrap();
         }
@@ -299,9 +140,7 @@ const FunctionModal = ({isOpen, onClose, functionToEdit, onSaved}: FunctionModal
     category,
     language,
     timeout,
-    triggerType,
-    triggerOptionValues,
-    editingTriggerKey,
+    warmWorkers,
     isEditMode,
     functionToEdit,
     createFunction,
@@ -311,48 +150,6 @@ const FunctionModal = ({isOpen, onClose, functionToEdit, onSaved}: FunctionModal
     onSaved,
     onClose
   ]);
-
-  const renderField = useCallback(
-    (key: string, schema: any, value: any, onChange: (val: any) => void, prefix = "") => {
-      const fieldKey = prefix ? `${prefix}.${key}` : key;
-      const label = schema.title ?? key;
-      const {Component} = resolveRenderer(schema);
-      return (
-        <Component
-          key={fieldKey}
-          fieldKey={fieldKey}
-          label={label}
-          schema={schema}
-          value={value}
-          onChange={onChange}
-        />
-      );
-    },
-    []
-  );
-
-  const schemaFieldContextValue = useMemo(
-    () => ({
-      renderField,
-      styles,
-      onArrayItemAdd: handleArrayItemAdd,
-      onArrayItemRemove: handleArrayItemRemove,
-      onArrayItemChange: handleArrayItemChange,
-      onNestedChange: handleNestedOptionChange
-    }),
-    [renderField, handleArrayItemAdd, handleArrayItemRemove, handleArrayItemChange, handleNestedOptionChange]
-  );
-
-  const renderTriggerOptionFields = () => {
-    const properties = selectedEnqueuer?.options?.properties;
-    if (!properties) return null;
-
-    return Object.entries(properties).map(([key, schema]: [string, any]) =>
-      renderField(key, schema, triggerOptionValues[key], (val: any) => handleTriggerOptionChange(key, val))
-    );
-  };
-
-  const baseUrl = (import.meta.env.VITE_BASE_URL as string) || "";
 
   return (
     <Drawer
@@ -426,29 +223,32 @@ const FunctionModal = ({isOpen, onClose, functionToEdit, onSaved}: FunctionModal
             </div>
           </div>
 
-          <div className={styles.triggerHeading}>Trigger</div>
-
-          <FlexElement direction="vertical" alignment="leftCenter" dimensionX="fill" gap={6}>
-            <Text size="small" dimensionX="fill" className={styles.fieldLabel}>
-              Type
-            </Text>
-            <Select
-              options={triggerTypeSelectOptions}
-              value={triggerType}
-              onChange={v => handleTriggerTypeChange(v as string)}
-              dimensionX="fill"
+          <div className={styles.timeoutField}>
+            <div className={styles.timeoutHeader}>
+              <Text size="small" className={styles.fieldLabel}>Warm Pool</Text>
+              <div className={styles.timeoutValue}>
+                <span className={styles.timeoutNumber}>{warmWorkers}</span>
+                <span className={styles.timeoutUnit}>{warmWorkers === 1 ? "worker" : "workers"}</span>
+              </div>
+            </div>
+            <input
+              type="range"
+              className={styles.slider}
+              min={0}
+              max={WARM_POOL_MAX}
+              step={1}
+              value={warmWorkers}
+              style={{"--pct": `${(warmWorkers / WARM_POOL_MAX) * 100}%`} as React.CSSProperties}
+              onChange={e => setWarmWorkers(Number(e.target.value))}
             />
-          </FlexElement>
-
-          <SchemaFieldProvider value={schemaFieldContextValue}>
-            {renderTriggerOptionFields()}
-          </SchemaFieldProvider>
-
-          {triggerType === "http" && triggerOptionValues.path && (
-            <Text size="small" className={styles.httpUrlPreview}>
-              {baseUrl}/fn-execute{triggerOptionValues.path}
+            <div className={styles.timeoutRange}>
+              <span className={styles.timeoutRangeLabel}>Off</span>
+              <span className={styles.timeoutRangeLabel}>{WARM_POOL_MAX}</span>
+            </div>
+            <Text size="small" className={styles.warmPoolHint}>
+              Pre-loaded workers kept ready so events skip the cold start. 0 disables warm workers.
             </Text>
-          )}
+          </div>
 
           {error && (
             <Text variant="danger" className={styles.errorText}>
@@ -462,7 +262,7 @@ const FunctionModal = ({isOpen, onClose, functionToEdit, onSaved}: FunctionModal
             onClick={handleSave}
             variant="solid"
             color="primary"
-            disabled={isSaving || !name.trim() || !triggerType}
+            disabled={isSaving || !name.trim()}
             loading={isSaving}
           >
             <Icon name={isEditMode ? "check" : "plus"} />
@@ -479,4 +279,3 @@ const FunctionModal = ({isOpen, onClose, functionToEdit, onSaved}: FunctionModal
 };
 
 export default memo(FunctionModal);
-

--- a/apps/panel/src/pages/function/components/TriggerPanel.module.scss
+++ b/apps/panel/src/pages/function/components/TriggerPanel.module.scss
@@ -61,6 +61,78 @@
   letter-spacing: 0.02em;
 }
 
+// ─── HTTP option rows (toggles, chips, warnings) ─────────────────────────────
+
+.optionRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+}
+
+.chipRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  width: 100%;
+}
+
+.optionChip {
+  padding: 4px 10px;
+  border-radius: 6px;
+  border: 1.5px solid var(--color-border, rgba(0, 0, 0, 0.12));
+  background: transparent;
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--color-text-muted, var(--color-font-secondary));
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+
+  &:hover {
+    border-color: var(--color-accent, var(--color-primary, #6366f1));
+  }
+}
+
+.optionChipOn {
+  border-color: var(--color-accent, var(--color-primary, #6366f1));
+  background: var(--color-accent-subtle, rgba(99, 102, 241, 0.1));
+  color: var(--color-accent, var(--color-primary, #6366f1));
+}
+
+.fieldWarning {
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--color-danger, #f04438);
+  opacity: 0.85;
+}
+
+.rateLimitFields {
+  display: flex;
+  gap: 10px;
+  width: 100%;
+}
+
+.numberInput {
+  width: 100%;
+  height: 36px;
+  border: 1px solid var(--color-border, rgba(0, 0, 0, 0.12));
+  border-radius: 7px;
+  background: var(--color-input-background, transparent);
+  font-family: 'JetBrains Mono', 'Courier New', monospace;
+  font-size: 12px;
+  color: var(--color-text-secondary, var(--color-font-primary));
+  padding: 0 10px;
+  outline: none;
+  transition: border-color 0.15s;
+
+  &:focus {
+    border-color: var(--color-primary, #6366f1);
+  }
+}
+
 // ─── Path input row ───────────────────────────────────────────────────────────
 
 .inputRow {

--- a/apps/panel/src/pages/function/components/TriggerPanel.tsx
+++ b/apps/panel/src/pages/function/components/TriggerPanel.tsx
@@ -10,7 +10,8 @@ import {
   FlexElement,
   Icon,
   Input,
-  Select
+  Select,
+  Switch
 } from "oziko-ui-kit";
 import PanelAccordion, {PanelAccordionItem} from "../../../components/molecules/panel-accordion/PanelAccordion";
 import type {FunctionTrigger, Enqueuer} from "../../../store/api/functionApi";
@@ -26,6 +27,7 @@ type TriggerPanelProps = {
 const TRIGGER_TYPES: FunctionTrigger["type"][] = ["http", "firehose", "database", "schedule", "system", "bucket"];
 
 const HTTP_METHODS = ["All", "Get", "Post", "Put", "Delete", "Patch", "Head"];
+const AUTH_STRATEGIES = ["IDENTITY", "APIKEY", "USER"];
 const DB_OPERATIONS = ["INSERT", "UPDATE", "REPLACE", "DELETE"];
 const BUCKET_OPERATIONS = ["ALL", "INSERT", "UPDATE", "DELETE"];
 const SYSTEM_EVENTS = ["READY"];
@@ -73,9 +75,56 @@ const TriggerPanel = ({triggers, enqueuers, handlers, onChange}: TriggerPanelPro
   );
 
   const handleOptionChange = useCallback(
-    (index: number, key: string, value: string) => {
+    (index: number, key: string, value: any) => {
       onChange(
         triggers.map((t, i) => (i === index ? {...t, options: {...t.options, [key]: value}} : t))
+      );
+    },
+    [triggers, onChange]
+  );
+
+  const handleToggleStrategy = useCallback(
+    (index: number, strategy: string) => {
+      onChange(
+        triggers.map((t, i) => {
+          if (i !== index) return t;
+          const current: string[] = t.options.authenticate ?? [];
+          const next = current.includes(strategy)
+            ? current.filter(s => s !== strategy)
+            : [...current, strategy];
+          return {...t, options: {...t.options, authenticate: next}};
+        })
+      );
+    },
+    [triggers, onChange]
+  );
+
+  const handleToggleRateLimit = useCallback(
+    (index: number, enabled: boolean) => {
+      onChange(
+        triggers.map((t, i) => {
+          if (i !== index) return t;
+          if (enabled) {
+            return {...t, options: {...t.options, rateLimit: {limit: 100, ttl: 60000}}};
+          }
+          const {rateLimit, ...rest} = t.options;
+          return {...t, options: rest};
+        })
+      );
+    },
+    [triggers, onChange]
+  );
+
+  const handleRateLimitField = useCallback(
+    (index: number, field: "limit" | "ttl", raw: string) => {
+      const parsed = Number(raw);
+      onChange(
+        triggers.map((t, i) => {
+          if (i !== index) return t;
+          const current = t.options.rateLimit ?? {limit: 100, ttl: 60000};
+          const value = Number.isNaN(parsed) ? current[field] : parsed;
+          return {...t, options: {...t.options, rateLimit: {...current, [field]: value}}};
+        })
       );
     },
     [triggers, onChange]
@@ -212,6 +261,94 @@ const TriggerPanel = ({triggers, enqueuers, handlers, onChange}: TriggerPanelPro
                   <Icon name={urlCopied ? "check" : "contentCopy"} size="sm" />
                 </Button>
               </div>
+              {(() => {
+                const preflight = trigger.options.preflight !== false;
+                const authenticate: string[] = trigger.options.authenticate ?? [];
+                const authorize = trigger.options.authorize ?? false;
+                const rateLimit = trigger.options.rateLimit;
+                return (
+                  <>
+                    <div className={styles.fieldGroup}>
+                      <div className={styles.optionRow}>
+                        <span className={styles.fieldLabel}>Preflight (CORS)</span>
+                        <Switch
+                          checked={preflight}
+                          size="small"
+                          onChange={checked => handleOptionChange(index, "preflight", checked)}
+                        />
+                      </div>
+                    </div>
+                    <div className={styles.fieldGroup}>
+                      <span className={styles.fieldLabel}>Authentication Strategies</span>
+                      <div className={styles.chipRow}>
+                        {AUTH_STRATEGIES.map(strategy => {
+                          const selected = authenticate.includes(strategy);
+                          return (
+                            <button
+                              type="button"
+                              key={strategy}
+                              className={`${styles.optionChip} ${selected ? styles.optionChipOn : ""}`}
+                              aria-pressed={selected}
+                              onClick={() => handleToggleStrategy(index, strategy)}
+                            >
+                              {strategy}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                    <div className={styles.fieldGroup}>
+                      <div className={styles.optionRow}>
+                        <span className={styles.fieldLabel}>Authorization</span>
+                        <Switch
+                          checked={authorize}
+                          size="small"
+                          onChange={checked => handleOptionChange(index, "authorize", checked)}
+                        />
+                      </div>
+                      {authorize && authenticate.length === 0 && (
+                        <span className={styles.fieldWarning}>
+                          Select at least one authentication strategy when authorization is enabled.
+                        </span>
+                      )}
+                    </div>
+                    <div className={styles.fieldGroup}>
+                      <div className={styles.optionRow}>
+                        <span className={styles.fieldLabel}>Rate Limit</span>
+                        <Switch
+                          checked={!!rateLimit}
+                          size="small"
+                          onChange={checked => handleToggleRateLimit(index, checked)}
+                        />
+                      </div>
+                      {rateLimit && (
+                        <div className={styles.rateLimitFields}>
+                          <div className={styles.fieldGroup}>
+                            <span className={styles.fieldLabel}>Limit</span>
+                            <input
+                              className={styles.numberInput}
+                              type="number"
+                              min={1}
+                              value={rateLimit.limit}
+                              onChange={e => handleRateLimitField(index, "limit", e.target.value)}
+                            />
+                          </div>
+                          <div className={styles.fieldGroup}>
+                            <span className={styles.fieldLabel}>TTL (ms)</span>
+                            <input
+                              className={styles.numberInput}
+                              type="number"
+                              min={1}
+                              value={rateLimit.ttl}
+                              onChange={e => handleRateLimitField(index, "ttl", e.target.value)}
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  </>
+                );
+              })()}
             </>
           )}
           {trigger.type === "firehose" && (

--- a/apps/panel/src/store/api/functionApi.ts
+++ b/apps/panel/src/store/api/functionApi.ts
@@ -18,6 +18,7 @@ export interface SpicaFunction {
   language: 'javascript' | 'typescript';
   runtime?: 'nodejs' | 'deno';
   timeout?: number;
+  warmWorkers?: number;
   memoryLimit?: number;
   env?: Record<string, string>;
   env_vars?: ResolvedEnvVar[];
@@ -109,6 +110,7 @@ export interface CreateFunctionRequest {
   language: 'javascript' | 'typescript';
   runtime?: 'nodejs' | 'deno';
   timeout?: number;
+  warmWorkers?: number;
   memoryLimit?: number;
   env?: Record<string, string>;
   dependencies?: Record<string, string>;
@@ -122,6 +124,7 @@ export interface UpdateFunctionRequest {
   language?: 'javascript' | 'typescript';
   runtime?: 'nodejs' | 'deno';
   timeout?: number;
+  warmWorkers?: number;
   memoryLimit?: number;
   triggers?: TriggerMap;
   category?: string;


### PR DESCRIPTION
## Summary

- **Warm Pool config per function** — adds a Warm Pool slider (0–2) to the function New/Edit modal, wired to the existing per-function `warmWorkers` schema field (`packages/api/function/src/schema/function.json`). `0` disables warm workers.
- **Trigger section removed from the modal** — creating a function now assigns a default `http` trigger; all trigger editing lives in the sidebar `TriggerPanel` (single source of truth). Editing a function no longer overwrites its triggers.
- **HTTP trigger options restored in the sidebar** — the old modal rendered these dynamically; they were unreachable after the modal cleanup. Added to `TriggerPanel` (HTTP triggers only):
  - **Preflight (CORS)** — toggle, defaults ON
  - **Authentication Strategies** — `IDENTITY` / `APIKEY` / `USER` checkbox row
  - **Authorization** — toggle, with a soft warning when enabled with zero strategies (schema requires ≥1)
  - **Rate Limit** — enable toggle → **Limit** + **TTL (ms)** inputs

## Files
- `apps/panel/src/components/prefabs/navigations/function/FunctionModal.tsx` / `.module.scss`
- `apps/panel/src/pages/function/components/TriggerPanel.tsx` / `.module.scss`
- `apps/panel/src/store/api/functionApi.ts` — `warmWorkers?: number` added to the function types

## Notes
- Panel-only; no backend changes. `warmWorkers` and all HTTP options are already supported and validated server-side.
- Warm Pool max is hardcoded to `2` in the UI; the server still clamps to `--function-warm-workers-max` (default 10).

## Test plan
- `yarn nx build panel` — passes
- Manually: New/Edit function → Warm Pool slider under Timeout, no trigger section in modal
- Sidebar Trigger panel → HTTP trigger shows Preflight / Auth Strategies / Authorization / Rate Limit and round-trips correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)