### PR TITLE
feat(panel): field-level security UI for bucket fields

### DIFF
--- a/apps/panel/src/components/molecules/bucket-field-popup/BucketFieldConfigurationPopup.tsx
+++ b/apps/panel/src/components/molecules/bucket-field-popup/BucketFieldConfigurationPopup.tsx
@@ -12,6 +12,7 @@ import {FieldKind} from "../../../domain/fields";
 import styles from "./BucketFieldPopup.module.scss";
 import BucketAddField from "../../organisms/bucket-add-field/BucketAddField";
 import type {FieldFormState} from "../../../domain/fields/types";
+import type {Properties} from "../../../store/api/bucketApi";
 import {usePopoverStack, type InsetValue} from "../../../hooks/usePopoverStack";
 
 export type PopupType = "add-field" | "edit-inner-field" | "add-inner-field";
@@ -28,6 +29,8 @@ type BucketFieldConfigurationPopupProps = {
   forbiddenFieldNames?: string[];
   popoverClassName?: string;
   parentInset?: InsetValue | null;
+  bucketProperties?: Properties;
+  isTopLevelField?: boolean;
 };
 
 const BucketFieldConfigurationPopup = ({
@@ -41,7 +44,9 @@ const BucketFieldConfigurationPopup = ({
   popupType,
   forbiddenFieldNames,
   popoverClassName,
-  parentInset
+  parentInset,
+  bucketProperties,
+  isTopLevelField
 }: BucketFieldConfigurationPopupProps) => {
   const innerContainerRef = useRef<HTMLDivElement>(null);
   const bucketAddFieldRef = useRef<HTMLDivElement>(null);
@@ -146,6 +151,8 @@ const BucketFieldConfigurationPopup = ({
             fieldType={selectedType}
             popupType={popupType}
             initialValues={initialValues}
+            bucketProperties={bucketProperties}
+            isTopLevelField={isTopLevelField}
           />
         )
       }

--- a/apps/panel/src/components/molecules/bucket-more-popup/BucketMorePopup.tsx
+++ b/apps/panel/src/components/molecules/bucket-more-popup/BucketMorePopup.tsx
@@ -8,9 +8,10 @@ import {
   useCallback,
 } from "react";
 import styles from "./BucketMorePopup.module.scss";
-import {useUpdateBucketMutation, useDeleteBucketHistoryMutation, type BucketType} from "../../../store/api/bucketApi";
+import {useUpdateBucketMutation, useDeleteBucketHistoryMutation, useCreateBucketFieldMutation, type BucketType} from "../../../store/api/bucketApi";
 import Confirmation from "../confirmation/Confirmation";
 import BucketRules from "../bucket-rules/BucketRules";
+import FieldSecurityOverview from "../field-security-overview/FieldSecurityOverview";
 import BucketLimitationsForm, {
   LIMIT_EXCEED_BEHAVIOUR_OPTIONS,
   type TypeLimitExceedBehaviour
@@ -27,6 +28,7 @@ type TypeBucketMorePopup = {
 const BucketMorePopup: FC<TypeBucketMorePopup> = ({className, bucket, onManageIndexes}) => {
   const [isOpen, setIsOpen] = useState(false);
   const [isBucketRulesOpen, setIsBucketRulesOpen] = useState(false);
+  const [isFieldSecurityOpen, setIsFieldSecurityOpen] = useState(false);
   const [isDeleteHistoryConfirmationOpen, setIsDeleteHistoryConfirmationOpen] = useState(false);
   const [deleteHistoryError, setDeleteHistoryError] = useState<null | string>(null);
 
@@ -50,6 +52,7 @@ const BucketMorePopup: FC<TypeBucketMorePopup> = ({className, bucket, onManageIn
   }, [bucket]);
 
   const [updateBucket] = useUpdateBucketMutation();
+  const [createBucketField] = useCreateBucketFieldMutation();
   const [deleteBucketHistory, { isLoading: deleteBucketHistoryLoading, error: deleteBucketHistoryError }] = useDeleteBucketHistoryMutation();
   
   const isLimitationChecked = useMemo(() => Boolean(bucket?.documentSettings), [bucket]);
@@ -125,6 +128,34 @@ const BucketMorePopup: FC<TypeBucketMorePopup> = ({className, bucket, onManageIn
 
   const handleOpenBucketRules = () => setIsBucketRulesOpen(true);
 
+  const handleCloseFieldSecurity = () => {
+    setIsFieldSecurityOpen(false);
+    handleClose();
+  };
+
+  const handleOpenFieldSecurity = () => setIsFieldSecurityOpen(true);
+
+  // Persist a single field's read ACL by PUTting the whole bucket with the one
+  // property mutated — the same field-save path field edits already use.
+  const handleSaveFieldSecurity = useCallback(
+    async (fieldKey: string, acl: string | undefined) => {
+      const property = bucket.properties?.[fieldKey];
+      if (!property) return;
+
+      const nextProperty = {...property};
+      if (acl) nextProperty.acl = acl;
+      else delete nextProperty.acl;
+
+      const modifiedBucket: BucketType = {
+        ...bucket,
+        properties: {...bucket.properties, [fieldKey]: nextProperty}
+      };
+
+      await createBucketField(modifiedBucket).unwrap();
+    },
+    [bucket, createBucketField]
+  );
+
   const handleManageIndexes = () => {
     handleClose();
     onManageIndexes?.();
@@ -156,6 +187,10 @@ const BucketMorePopup: FC<TypeBucketMorePopup> = ({className, bucket, onManageIn
                   <Button variant="text" onClick={handleOpenBucketRules}>
                     <Icon name="security" />
                     <Text>Configure rules</Text>
+                  </Button>
+                  <Button variant="text" onClick={handleOpenFieldSecurity}>
+                    <Icon name="eye" />
+                    <Text>Field Security</Text>
                   </Button>
                   {onManageIndexes && (
                     <Button variant="text" onClick={handleManageIndexes}>
@@ -250,6 +285,13 @@ const BucketMorePopup: FC<TypeBucketMorePopup> = ({className, bucket, onManageIn
         />
       )}
       {isBucketRulesOpen && <BucketRules bucket={bucket} onClose={handleCloseBucketRules} />}
+      {isFieldSecurityOpen && (
+        <FieldSecurityOverview
+          bucket={bucket}
+          onSaveField={handleSaveFieldSecurity}
+          onClose={handleCloseFieldSecurity}
+        />
+      )}
     </div>
   );
 };

--- a/apps/panel/src/components/molecules/bucket-rules/BucketRules.tsx
+++ b/apps/panel/src/components/molecules/bucket-rules/BucketRules.tsx
@@ -1,12 +1,10 @@
 import {Button, FluidContainer, Icon, Modal, Popover, Text} from "oziko-ui-kit";
-import {memo, useCallback, useEffect, useMemo, useRef, useState} from "react";
+import {memo, useCallback, useEffect, useState} from "react";
 import styles from "./BucketRules.module.scss";
 import Editor from "@monaco-editor/react";
-import * as monaco from "monaco-editor";
-import {jwtDecode} from "jwt-decode";
-import type {AuthTokenJWTPayload} from "src/types/auth";
 import type {BucketType} from "../../../store/api/bucketApi";
 import {useUpdateBucketRulesMutation} from "../../../store/api/bucketApi";
+import {useRuleEditor} from "../../../hooks/useRuleEditor";
 
 type EditorFormProps = {
   bucket: BucketType;
@@ -17,9 +15,6 @@ type BucketRulesProps = {
   bucket: BucketType;
   onClose: () => void;
 };
-
-const LANGUAGE_NAME = "myLang";
-const THEME_NAME = "myCustomtheme";
 
 function shortenErrorMessage(message: string, maxTokens = 5): string {
   const regex = /Expected\s+(.*?)\s+but\s+"(.)"\s+found\./;
@@ -143,135 +138,6 @@ const parseRulesFromText = (text: string) => {
   return rules;
 };
 
-function handleEditorWillMount(
-  monaco: typeof import("monaco-editor"),
-  autoCompleteSuggestions: {
-    document: any;
-    auth: any;
-  },
-  refs: {
-    disposableRef: React.RefObject<monaco.IDisposable | null>;
-    initializedRef: React.RefObject<boolean>;
-  }
-) {
-  const {disposableRef, initializedRef} = refs;
-
-  if (!initializedRef.current) {
-    monaco.languages.register({id: LANGUAGE_NAME});
-
-    monaco.languages.setMonarchTokensProvider(LANGUAGE_NAME, {
-      defaultToken: "",
-      tokenizer: {
-        root: [
-          [/[a-zA-Z_$][\w$]*\s*:/, "key"],
-          [/[{}]/, "delimiter.bracket"],
-          {include: "@common"}
-        ],
-        common: [
-          [/\d+/, "number"],
-          [/[,.]/, "delimiter"],
-          [/[;]/, "delimiter"],
-          [/"([^"\\]|\\.)*$/, "string.invalid"],
-          [/"([^"\\]|\\.)*"/, "string"],
-          [/'([^'\\]|\\.)*$/, "string.invalid"],
-          [/'([^'\\]|\\.)*'/, "string"],
-          [/\s+/, "white"]
-        ]
-      }
-    });
-
-    monaco.editor.defineTheme(THEME_NAME, {
-      base: "vs",
-      inherit: true,
-      rules: [
-        {token: "key", foreground: "000000", fontStyle: "bold"},
-        {token: "identifier", foreground: "000000"},
-        {token: "delimiter", foreground: "000000"},
-        {token: "string", foreground: "000000"}
-      ],
-
-      colors: {
-        "editor.background": "#f4f4f4"
-      }
-    });
-
-    initializedRef.current = true;
-  }
-
-  disposableRef.current = monaco.languages.registerCompletionItemProvider(LANGUAGE_NAME, {
-    triggerCharacters: ".".split(""),
-
-    provideCompletionItems: (model, position) => {
-      const textUntilPosition = model.getValueInRange({
-        startLineNumber: position.lineNumber,
-        startColumn: 1,
-        endLineNumber: position.lineNumber,
-        endColumn: position.column
-      });
-
-      const statements = textUntilPosition
-        .split(/;|,| /)
-        .map(s => s.trim())
-        .filter(Boolean);
-      const lastStatement = statements.length > 0 ? statements[statements.length - 1] : "";
-
-      const cleaned = lastStatement.replace(/^(read|write)\s*:\s*/, "");
-
-      const suggestions: monaco.languages.CompletionItem[] = [];
-      const seen = new Set<string>();
-      if (!cleaned.includes(".")) {
-        const baseWords = ["true", "false", "auth", "document"];
-        const word = cleaned.split(/\s+/).pop() ?? "";
-
-        for (const key of baseWords) {
-          if (key.startsWith(word)) {
-            if (seen.has(key)) continue;
-            seen.add(key);
-            suggestions.push({
-              label: key,
-              kind: monaco.languages.CompletionItemKind.Keyword,
-              insertText: key
-            } as monaco.languages.CompletionItem);
-          }
-        }
-
-        return {suggestions} as monaco.languages.CompletionList;
-      }
-
-      const lastDotIndex = cleaned.lastIndexOf(".");
-      const basePath = cleaned.slice(0, lastDotIndex);
-      const partial = cleaned.slice(lastDotIndex + 1);
-
-      const pathSegments = basePath.split(".");
-      const root = pathSegments.shift();
-      if (!root || !["auth", "document"].includes(root)) return {suggestions: []};
-
-      let current = autoCompleteSuggestions[root as "auth" | "document"];
-      for (const segment of pathSegments) {
-        if (!current || typeof current !== "object") return {suggestions: []};
-        current = current[segment];
-      }
-
-      if (!current || typeof current !== "object") return {suggestions: []};
-
-      for (const key of Object.keys(current)) {
-        if (seen.has(key)) continue;
-        if (key.startsWith(partial)) {
-          seen.add(key);
-          suggestions.push({
-            label: key,
-            kind: monaco.languages.CompletionItemKind.Property,
-            insertText: key,
-            detail: `${root} property`
-          } as monaco.languages.CompletionItem);
-        }
-      }
-
-      return {suggestions} as monaco.languages.CompletionList;
-    }
-  });
-}
-
 const EditorForm = ({bucket, handleClose}: EditorFormProps) => {
   const [error, setError] = useState<string | null>(null);
   const [value, setValue] = useState<string>(`{ 
@@ -281,31 +147,10 @@ const EditorForm = ({bucket, handleClose}: EditorFormProps) => {
 
   const [updateBucketRule, { isLoading: loading, error: apiError }] = useUpdateBucketRulesMutation();
 
-  const disposableRef = useRef<monaco.IDisposable | null>(null);
-  const initializedRef = useRef(false);
-
-  // The auth token is persisted as a RAW JWT string (Authorization: IDENTITY <token>),
-  // not JSON — so it must be read directly, not through useLocalStorage (which JSON.parses).
-  // A missing/garbage token must degrade to {} so autocomplete stops suggesting auth.*
-  // instead of throwing InvalidTokenError and crashing the whole editor.
-  const auth = useMemo<Partial<AuthTokenJWTPayload>>(() => {
-    try {
-      const raw = typeof window !== "undefined" ? window.localStorage.getItem("token") : null;
-      return raw ? jwtDecode<AuthTokenJWTPayload>(raw) : {};
-    } catch {
-      return {};
-    }
-  }, []);
-
-  const suggestions = useMemo(() => {
-    return {
-      auth,
-      document: {
-        ...bucket.properties,
-        _id: bucket._id
-      }
-    };
-  }, [bucket, auth]);
+  const {language, theme, beforeMount} = useRuleEditor({
+    properties: bucket.properties,
+    documentId: bucket._id
+  });
 
   useEffect(() => {
     if (apiError) {
@@ -317,13 +162,6 @@ const EditorForm = ({bucket, handleClose}: EditorFormProps) => {
 
   useEffect(() => {
     setError(null);
-  }, []);
-
-  useEffect(() => {
-    return () => {
-      disposableRef.current?.dispose?.();
-      disposableRef.current = null;
-    };
   }, []);
 
   const handleSubmit = useCallback(
@@ -364,17 +202,12 @@ const EditorForm = ({bucket, handleClose}: EditorFormProps) => {
     <div className={styles.body}>
       <div className={styles.editorContainer}>
         <Editor
-          defaultLanguage={LANGUAGE_NAME}
-          theme={THEME_NAME}
+          defaultLanguage={language}
+          theme={theme}
           value={value}
           onChange={val => setValue(val as string)}
           className={styles.editor}
-          beforeMount={monaco =>
-            handleEditorWillMount(monaco, suggestions, {
-              disposableRef,
-              initializedRef
-            })
-          }
+          beforeMount={beforeMount}
           loading={<div className={styles.editorLoadingSkeleton}/>}
           options={{
             lineNumbers: "off",

--- a/apps/panel/src/components/molecules/field-security-editor/FieldSecurityEditor.module.scss
+++ b/apps/panel/src/components/molecules/field-security-editor/FieldSecurityEditor.module.scss
@@ -1,0 +1,72 @@
+@use "../../../styles/mixins";
+
+.fieldSecurityEditor {
+  width: 100%;
+
+  .options {
+    width: 100%;
+  }
+
+  .option {
+    width: 100% !important;
+    cursor: pointer;
+
+    .optionDescription {
+      color: var(--color-font-secondary);
+      font-size: var(--font-size-xs);
+      text-align: right;
+    }
+  }
+
+  .body {
+    width: 100%;
+
+    .label {
+      color: var(--color-font-primary);
+      font-size: var(--font-size-sm);
+      font-weight: 500;
+    }
+  }
+
+  .editorContainer {
+    position: relative;
+    width: 100%;
+    height: 128px;
+    padding: var(--padding-md);
+    background-color: var(--color-menu-contrast);
+    border-radius: var(--border-radius-md);
+
+    .editor {
+      width: 100%;
+      height: 108px;
+    }
+
+    .editorPlaceholder {
+      position: absolute;
+      top: var(--padding-md);
+      left: var(--padding-md);
+      right: var(--padding-md);
+      // Ghost text only — clicks fall through to the editor and it is never
+      // part of the model, so it can neither be selected nor submitted.
+      pointer-events: none;
+      user-select: none;
+      color: var(--color-font-secondary);
+      font-family: var(--font-family-base);
+      font-size: var(--font-size-xs);
+      line-height: 1.7;
+    }
+
+    .editorLoadingSkeleton {
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      border-radius: var(--border-radius-md);
+      background-color: var(--color-menu-contrast);
+    }
+  }
+
+  .note {
+    color: var(--color-font-secondary);
+    font-size: var(--font-size-xs);
+  }
+}

--- a/apps/panel/src/components/molecules/field-security-editor/FieldSecurityEditor.tsx
+++ b/apps/panel/src/components/molecules/field-security-editor/FieldSecurityEditor.tsx
@@ -1,0 +1,210 @@
+import {FlexElement, Icon, ListItem, Select, Text, type TypeValue} from "oziko-ui-kit";
+import Editor from "@monaco-editor/react";
+import {memo, useCallback, useMemo, type FC} from "react";
+import styles from "./FieldSecurityEditor.module.scss";
+import {buildAclExpression, type FieldAclMode, type FieldSecurity} from "../../../domain/fields/field-acl";
+import type {Properties} from "../../../store/api/bucketApi";
+import {useRuleEditor} from "../../../hooks/useRuleEditor";
+
+export type {FieldSecurity} from "../../../domain/fields/field-acl";
+
+type FieldSecurityEditorProps = {
+  value?: FieldSecurity;
+  bucketProperties: Properties;
+  onChange: (next: FieldSecurity) => void;
+  className?: string;
+};
+
+const MODE_OPTIONS: {mode: FieldAclMode; label: string; description: string}[] = [
+  {
+    mode: "everyone",
+    label: "Everyone",
+    description: "No rule — the field's value is always returned."
+  },
+  {
+    mode: "authenticated",
+    label: "Signed-in users only",
+    description: "Only requests carrying an identity can read this field."
+  },
+  {
+    mode: "owner",
+    label: "Only the record owner",
+    description: "Only the identity referenced by the chosen field can read it."
+  },
+  {
+    mode: "custom",
+    label: "Custom rule",
+    description: "Write your own expression over auth.* and document.*."
+  }
+];
+
+const DEFAULT_VALUE: FieldSecurity = {mode: "everyone", expression: ""};
+
+// Ghost guidance shown over the empty custom editor. Each line is a real, valid
+// expression: `auth.*` reasons about the requester, `document.*` about the row.
+const CUSTOM_EXAMPLES = [
+  "document.age > 24",
+  "auth.identifier == 'admin'",
+  `"HR" in auth.policies`,
+  "document.owner == auth._id"
+];
+
+const EDITOR_OPTIONS = {
+  lineNumbers: "off",
+  renderLineHighlight: "none",
+  overviewRulerLanes: 0,
+  minimap: {enabled: false},
+  glyphMargin: false,
+  folding: false,
+  lineDecorationsWidth: 0,
+  fontSize: 14,
+  lineHeight: 14,
+  insertSpaces: true,
+  detectIndentation: false,
+  fontFamily: "var(--font-family-base)",
+  suggestLineHeight: 20,
+  scrollBeyondLastLine: false,
+  wordBasedSuggestions: "off",
+  scrollbar: {
+    verticalScrollbarSize: 3,
+    horizontalScrollbarSize: 3,
+    useShadows: false
+  },
+  stickyScroll: {enabled: false}
+} as const;
+
+const FieldSecurityEditor: FC<FieldSecurityEditorProps> = ({
+  value = DEFAULT_VALUE,
+  bucketProperties,
+  onChange,
+  className
+}) => {
+  const propertyKeys = useMemo(() => Object.keys(bucketProperties ?? {}), [bucketProperties]);
+
+  const {language, theme, beforeMount} = useRuleEditor({properties: bucketProperties});
+
+  const handleModeChange = useCallback(
+    (mode: FieldAclMode) => {
+      if (mode === value.mode) return;
+
+      if (mode === "owner") {
+        const ownerField = value.ownerField || propertyKeys[0];
+        onChange({
+          mode,
+          ownerField,
+          expression: buildAclExpression({mode, ownerField, expression: ""}) ?? value.expression
+        });
+        return;
+      }
+
+      // Custom keeps whatever preset expression was last shown so it stays editable.
+      if (mode === "custom") {
+        onChange({mode, expression: value.expression, ownerField: value.ownerField});
+        return;
+      }
+
+      // Everyone / authenticated: mirror the canonical expression for display.
+      onChange({
+        mode,
+        expression: buildAclExpression({mode, expression: value.expression}) ?? "",
+        ownerField: value.ownerField
+      });
+    },
+    [value, propertyKeys, onChange]
+  );
+
+  const handleOwnerFieldChange = useCallback(
+    (next: TypeValue) => {
+      const ownerField = String(next);
+      onChange({
+        mode: "owner",
+        ownerField,
+        expression: buildAclExpression({mode: "owner", ownerField, expression: ""}) ?? ""
+      });
+    },
+    [onChange]
+  );
+
+  const handleExpressionChange = useCallback(
+    (expression?: string) => {
+      onChange({mode: "custom", expression: expression ?? "", ownerField: value.ownerField});
+    },
+    [onChange, value.ownerField]
+  );
+
+  return (
+    <FlexElement
+      direction="vertical"
+      gap={10}
+      dimensionX="fill"
+      className={`${styles.fieldSecurityEditor} ${className ?? ""}`}
+    >
+      <FlexElement direction="vertical" gap={0} dimensionX="fill" className={styles.options}>
+        {MODE_OPTIONS.map(option => (
+          <ListItem
+            key={option.mode}
+            label={option.label}
+            active={option.mode === value.mode}
+            dimensionX="fill"
+            className={styles.option}
+            onClick={() => handleModeChange(option.mode)}
+            prefix={{
+              children: (
+                <Icon
+                  name={option.mode === value.mode ? "check" : "checkboxBlankOutline"}
+                  size="sm"
+                />
+              )
+            }}
+            suffix={{
+              children: <Text className={styles.optionDescription}>{option.description}</Text>
+            }}
+          />
+        ))}
+      </FlexElement>
+
+      {value.mode === "owner" && (
+        <FlexElement direction="vertical" gap={5} dimensionX="fill" className={styles.body}>
+          <Text className={styles.label}>Owner field</Text>
+          <Select
+            dimensionX="fill"
+            options={propertyKeys}
+            value={value.ownerField ?? undefined}
+            onChange={handleOwnerFieldChange}
+            placeholder="Select a field"
+          />
+        </FlexElement>
+      )}
+
+      {value.mode === "custom" && (
+        <div className={styles.editorContainer}>
+          <Editor
+            defaultLanguage={language}
+            theme={theme}
+            value={value.expression}
+            onChange={handleExpressionChange}
+            className={styles.editor}
+            beforeMount={beforeMount}
+            loading={<div className={styles.editorLoadingSkeleton} />}
+            options={EDITOR_OPTIONS}
+          />
+          {!value.expression.trim() && (
+            <div className={styles.editorPlaceholder} aria-hidden="true">
+              {CUSTOM_EXAMPLES.map(example => (
+                <div key={example} className={styles.editorPlaceholderLine}>
+                  {example}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      <Text className={styles.note}>
+        Field rules apply only to end-user (USER) API calls. Identity & API-key access ignore them.
+      </Text>
+    </FlexElement>
+  );
+};
+
+export default memo(FieldSecurityEditor);

--- a/apps/panel/src/components/molecules/field-security-overview/FieldSecurityOverview.module.scss
+++ b/apps/panel/src/components/molecules/field-security-overview/FieldSecurityOverview.module.scss
@@ -1,0 +1,200 @@
+@use "../../../styles/mixins";
+
+.modal {
+  width: 100%;
+  padding: 0;
+  height: fit-content;
+  max-height: fit-content;
+  min-height: fit-content;
+}
+
+.body {
+  width: 640px !important;
+  height: fit-content;
+  padding: 0;
+  overflow: visible;
+}
+
+.fieldSecurityOverview {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  // Cap the whole panel to the viewport so long field lists scroll internally
+  // instead of pushing the footer/legend off-screen.
+  max-height: 80vh;
+  overflow: hidden;
+
+  .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    border-bottom: var(--border-default);
+    padding: var(--padding-xl);
+    flex-shrink: 0;
+  }
+
+  .titles {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-sm);
+  }
+
+  .title {
+    font-size: var(--font-size-lg) !important;
+    font-weight: bold !important;
+    line-height: unset;
+  }
+
+  .subtitle {
+    color: var(--color-font-secondary);
+    font-size: var(--font-size-sm);
+  }
+
+  .helpIcon {
+    color: var(--color-font-primary);
+  }
+
+  .tableHead {
+    flex-shrink: 0;
+    padding: var(--padding-md) var(--padding-xl) 0;
+  }
+
+  .table {
+    display: flex;
+    flex-direction: column;
+    // Only the rows scroll; header, legend and footer stay pinned.
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 0 var(--padding-xl) var(--padding-md);
+  }
+
+  .row {
+    display: grid;
+    grid-template-columns: 1.4fr 1fr 2fr auto;
+    align-items: center;
+    gap: var(--gap-md);
+    padding: var(--padding-sm) 0;
+    border-bottom: var(--border-default);
+  }
+
+  .headRow {
+    color: var(--color-font-secondary);
+    font-size: var(--font-size-xs);
+    text-transform: uppercase;
+  }
+
+  .field {
+    font-weight: 500;
+  }
+
+  .access {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-sm);
+  }
+
+  .rule {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-family: var(--font-mono, monospace);
+    font-size: var(--font-size-xs);
+    color: var(--color-font-primary);
+  }
+
+  .editButton {
+    justify-self: end;
+  }
+
+  .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .dotPublic {
+    background-color: var(--color-success);
+  }
+
+  .dotConditional {
+    background-color: var(--color-warning);
+  }
+
+  .dotRestricted {
+    background-color: var(--color-danger);
+  }
+
+  .legend {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-sm);
+    padding: var(--padding-md) var(--padding-xl);
+    background-color: var(--color-menu-contrast);
+    flex-shrink: 0;
+  }
+
+  .legendItem {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-sm);
+    font-size: var(--font-size-xs);
+  }
+
+  .legendLabel {
+    font-weight: 500;
+    min-width: 90px;
+  }
+
+  .legendDescription {
+    color: var(--color-font-primary);
+  }
+
+  .footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--gap-md);
+    padding: var(--padding-xl);
+    border-top: var(--border-default);
+    flex-shrink: 0;
+  }
+}
+
+.editModal {
+  width: 100%;
+  padding: 0;
+  height: fit-content;
+  max-height: fit-content;
+  min-height: fit-content;
+}
+
+.editBody {
+  width: 460px !important;
+  height: fit-content;
+  padding: 0;
+  overflow: visible;
+}
+
+.editHeader {
+  padding: var(--padding-xl);
+  border-bottom: var(--border-default);
+
+  .editTitle {
+    font-size: var(--font-size-md) !important;
+    font-weight: bold !important;
+  }
+}
+
+.editContent {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: var(--padding-xl);
+
+  .editActions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--gap-md);
+  }
+}

--- a/apps/panel/src/components/molecules/field-security-overview/FieldSecurityOverview.tsx
+++ b/apps/panel/src/components/molecules/field-security-overview/FieldSecurityOverview.tsx
@@ -1,0 +1,246 @@
+import {Button, FluidContainer, Icon, Modal, Text} from "oziko-ui-kit";
+import {memo, useCallback, useMemo, useState, type FC} from "react";
+import styles from "./FieldSecurityOverview.module.scss";
+import type {BucketType} from "../../../store/api/bucketApi";
+import {
+  aclStatus,
+  buildAclExpression,
+  inferSecurityFromAcl
+} from "../../../domain/fields/field-acl";
+import FieldSecurityEditor, {
+  type FieldSecurity
+} from "../field-security-editor/FieldSecurityEditor";
+
+type FieldSecurityOverviewProps = {
+  bucket: BucketType;
+  // The caller owns persistence; `acl` is `undefined` when the field is public.
+  onSaveField: (fieldKey: string, acl: string | undefined) => Promise<void> | void;
+  onClose: () => void;
+  visible?: boolean;
+};
+
+type FieldStatus = ReturnType<typeof aclStatus>;
+
+const STATUS_META: Record<FieldStatus, {label: string; description: string; dotClass: string}> = {
+  public: {
+    label: "Everyone",
+    description: "Always returned by the data API.",
+    dotClass: styles.dotPublic
+  },
+  conditional: {
+    label: "Conditional",
+    description: "Returned only for rows that match the rule.",
+    dotClass: styles.dotConditional
+  },
+  restricted: {
+    label: "Restricted",
+    description: "Gated on the requesting identity.",
+    dotClass: styles.dotRestricted
+  }
+};
+
+const LEGEND_ORDER: FieldStatus[] = ["public", "conditional", "restricted"];
+
+type FieldRow = {key: string; title: string; acl: string | undefined};
+
+type FieldSecurityRowProps = {
+  fieldKey: string;
+  title: string;
+  acl: string | undefined;
+  onEdit: (fieldKey: string) => void;
+};
+
+const FieldSecurityRow: FC<FieldSecurityRowProps> = memo(({fieldKey, title, acl, onEdit}) => {
+  const status = aclStatus(acl);
+  const meta = STATUS_META[status];
+
+  const handleEdit = useCallback(() => onEdit(fieldKey), [onEdit, fieldKey]);
+
+  return (
+    <div className={styles.row}>
+      <Text className={styles.field}>{title}</Text>
+      <div className={styles.access}>
+        <span className={`${styles.dot} ${meta.dotClass}`} />
+        <Text>{meta.label}</Text>
+      </div>
+      <Text className={styles.rule} title={acl || undefined}>
+        {acl || "—"}
+      </Text>
+      <Button
+        variant="text"
+        shape="circle"
+        onClick={handleEdit}
+        className={styles.editButton}
+        aria-label={`Edit read access for ${title}`}
+      >
+        <Icon name="pencil" size="sm" />
+      </Button>
+    </div>
+  );
+});
+
+FieldSecurityRow.displayName = "FieldSecurityRow";
+
+const FieldSecurityOverview: FC<FieldSecurityOverviewProps> = ({
+  bucket,
+  onSaveField,
+  onClose,
+  visible = true
+}) => {
+  const [editingKey, setEditingKey] = useState<string | null>(null);
+  const [pending, setPending] = useState<FieldSecurity | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const fields = useMemo<FieldRow[]>(
+    () =>
+      Object.entries(bucket.properties ?? {}).map(([key, property]) => ({
+        key,
+        title: (property as {title?: string}).title || key,
+        acl: (property as {acl?: string}).acl
+      })),
+    [bucket.properties]
+  );
+
+  const editingTitle = useMemo(() => {
+    if (!editingKey) return "";
+    return (bucket.properties?.[editingKey] as {title?: string})?.title || editingKey;
+  }, [bucket.properties, editingKey]);
+
+  const handleEdit = useCallback(
+    (fieldKey: string) => {
+      const acl = (bucket.properties?.[fieldKey] as {acl?: string})?.acl;
+      setPending(inferSecurityFromAcl(acl));
+      setEditingKey(fieldKey);
+    },
+    [bucket.properties]
+  );
+
+  const handleCancelEdit = useCallback(() => {
+    setEditingKey(null);
+    setPending(null);
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (!editingKey) return;
+    setSaving(true);
+    try {
+      await onSaveField(editingKey, buildAclExpression(pending ?? undefined));
+      setEditingKey(null);
+      setPending(null);
+    } finally {
+      setSaving(false);
+    }
+  }, [editingKey, pending, onSaveField]);
+
+  return (
+    <>
+      <Modal onClose={onClose} className={styles.modal} isOpen={visible} showCloseButton={false}>
+        <Modal.Body className={styles.body}>
+          <div className={styles.fieldSecurityOverview}>
+            <div className={styles.header}>
+              <div className={styles.titles}>
+                <Text className={styles.title}>Field Security · {bucket.title}</Text>
+                <Text className={styles.subtitle}>
+                  Control which fields are returned by the data API.
+                </Text>
+              </div>
+              <a
+                href="https://spicaengine.com/docs/concept/bucket#rules"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Icon name="help" size="md" className={styles.helpIcon} />
+              </a>
+            </div>
+
+            <div className={styles.tableHead}>
+              <div className={`${styles.row} ${styles.headRow}`}>
+                <Text className={styles.field}>Field</Text>
+                <Text>Read access</Text>
+                <Text>Rule</Text>
+                <span />
+              </div>
+            </div>
+
+            <div className={styles.table}>
+              {fields.map(field => (
+                <FieldSecurityRow
+                  key={field.key}
+                  fieldKey={field.key}
+                  title={field.title}
+                  acl={field.acl}
+                  onEdit={handleEdit}
+                />
+              ))}
+            </div>
+
+            <div className={styles.legend}>
+              {LEGEND_ORDER.map(status => (
+                <div key={status} className={styles.legendItem}>
+                  <span className={`${styles.dot} ${STATUS_META[status].dotClass}`} />
+                  <Text className={styles.legendLabel}>{STATUS_META[status].label}</Text>
+                  <Text className={styles.legendDescription}>
+                    {STATUS_META[status].description}
+                  </Text>
+                </div>
+              ))}
+            </div>
+
+            <div className={styles.footer}>
+              <Button onClick={onClose}>
+                <Icon name="check" size="sm" />
+                Done
+              </Button>
+            </div>
+          </div>
+        </Modal.Body>
+      </Modal>
+
+      {editingKey && (
+        <Modal
+          onClose={handleCancelEdit}
+          className={styles.editModal}
+          isOpen
+          showCloseButton={false}
+        >
+          <Modal.Body className={styles.editBody}>
+            <FluidContainer
+              direction="vertical"
+              gap={0}
+              prefix={{
+                children: (
+                  <div className={styles.editHeader}>
+                    <Text className={styles.editTitle}>Read access · {editingTitle}</Text>
+                  </div>
+                )
+              }}
+              suffix={{
+                children: (
+                  <div className={styles.editContent}>
+                    <FieldSecurityEditor
+                      value={pending ?? undefined}
+                      bucketProperties={bucket.properties}
+                      onChange={setPending}
+                    />
+                    <div className={styles.editActions}>
+                      <Button variant="text" onClick={handleCancelEdit} disabled={saving}>
+                        <Icon name="close" size="sm" />
+                        Cancel
+                      </Button>
+                      <Button onClick={handleSave} disabled={saving} loading={saving}>
+                        <Icon name="check" size="sm" />
+                        Save
+                      </Button>
+                    </div>
+                  </div>
+                )
+              }}
+            />
+          </Modal.Body>
+        </Modal>
+      )}
+    </>
+  );
+};
+
+export default memo(FieldSecurityOverview);

--- a/apps/panel/src/components/organisms/add-field-modal/AddFieldModal.tsx
+++ b/apps/panel/src/components/organisms/add-field-modal/AddFieldModal.tsx
@@ -7,7 +7,7 @@ import {FIELD_REGISTRY} from "../../../domain/fields/registry";
 import BucketAddField from "../bucket-add-field/BucketAddField";
 import {FieldKind} from "../../../domain/fields/types";
 import type {FieldFormState} from "../../../domain/fields/types";
-import type {BucketType} from "src/store/api/bucketApi";
+import type {BucketType, Properties} from "src/store/api/bucketApi";
 
 type AddFieldModalProps = {
   /** Render-prop trigger — used in "add" mode. Optional when `isOpen` is provided. */
@@ -23,6 +23,8 @@ type AddFieldModalProps = {
   initialFieldKind?: FieldKind;
   /** Pre-fill the config form with these values (edit mode). */
   initialValues?: FieldFormState;
+  /** Sibling bucket properties powering the Security tab's owner picker and completions. */
+  bucketProperties?: Properties;
 };
 
 const AddFieldModal = ({
@@ -33,7 +35,8 @@ const AddFieldModal = ({
   isOpen: controlledIsOpen,
   onClose: controlledOnClose,
   initialFieldKind,
-  initialValues
+  initialValues,
+  bucketProperties
 }: AddFieldModalProps) => {
   const [internalOpen, setInternalOpen] = useState(false);
   const [selectedType, setSelectedType] = useState<FieldKind | null>(null);
@@ -129,6 +132,7 @@ const AddFieldModal = ({
                       fieldType={selectedType}
                       forbiddenFieldNames={forbiddenFieldNames}
                       popupType="add-field"
+                      bucketProperties={bucketProperties}
                       initialValues={selectedType === initialFieldKind ? initialValues : undefined}
                     />
                   </div>

--- a/apps/panel/src/components/organisms/bucket-add-field/BucketAddField.module.scss
+++ b/apps/panel/src/components/organisms/bucket-add-field/BucketAddField.module.scss
@@ -142,3 +142,9 @@
   flex-direction: column;
   gap: var(--gap-md);
 }
+
+.securityContainer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-md);
+}

--- a/apps/panel/src/components/organisms/bucket-add-field/BucketAddFieldBusiness.tsx
+++ b/apps/panel/src/components/organisms/bucket-add-field/BucketAddFieldBusiness.tsx
@@ -15,7 +15,7 @@ import {
   updateInnerField
 } from "../../../domain/fields/inner-fields";
 import {useFormState} from "./BucketAddFieldHooks";
-import type {BucketType} from "src/store/api/bucketApi";
+import type {BucketType, Properties} from "src/store/api/bucketApi";
 
 function isObjectEffectivelyEmpty(obj: Object): boolean {
   if (obj === null || obj === undefined) return true;
@@ -60,6 +60,10 @@ export type BucketAddFieldBusinessProps = {
   fieldType?: FieldKind;
   popupType?: PopupType;
   initialValues?: FieldFormState;
+  /** Sibling bucket properties powering the Security tab's owner picker and completions. */
+  bucketProperties?: Properties;
+  /** Force Security-tab visibility when a top-level field is edited via an inner-field popupType. */
+  isTopLevelField?: boolean;
 };
 
 export type FormErrors = {
@@ -79,7 +83,9 @@ const BucketAddFieldBusiness: FC<BucketAddFieldBusinessProps> = ({
   forbiddenFieldNames,
   fieldType,
   popupType = "add-field",
-  initialValues
+  initialValues,
+  bucketProperties,
+  isTopLevelField
 }) => {
   const {data: buckets = []} = useGetBucketsQuery();
   const [, { error: createBucketFieldError }] = useCreateBucketFieldMutation({
@@ -239,6 +245,8 @@ const BucketAddFieldBusiness: FC<BucketAddFieldBusinessProps> = ({
       defaultInputProperty={defaultValueProperties}
       presetInputProperties={presetProperties}
       multipleSelectionTabProperties={multipleSelectionTabProperties}
+      bucketProperties={bucketProperties}
+      isTopLevelField={isTopLevelField}
       isLoading={isLoading}
       handleFormValueChange={handleFormValueChange}
       handleSaveAndClose={handleSaveAndClose}

--- a/apps/panel/src/components/organisms/bucket-add-field/BucketAddFieldHooks.tsx
+++ b/apps/panel/src/components/organisms/bucket-add-field/BucketAddFieldHooks.tsx
@@ -18,7 +18,9 @@ export function useFormState(
 
     const base = initForm(type, initialValues);
 
-    const newFormValues = {...base, type};
+    // securityValues is not part of the field-kind defaults initForm merges over,
+    // so re-apply it here to keep an edited field's saved ACL on the form.
+    const newFormValues = {...base, type, securityValues: initialValues?.securityValues};
     setFormValues(newFormValues);
     setFormErrors({});
     setIsInitialized(true);

--- a/apps/panel/src/components/organisms/bucket-add-field/BucketAddFieldView.tsx
+++ b/apps/panel/src/components/organisms/bucket-add-field/BucketAddFieldView.tsx
@@ -29,6 +29,9 @@ import {FIELD_REGISTRY} from "../../../domain/fields/registry";
 import type {TypeProperties} from "oziko-ui-kit/dist/custom-hooks/useInputRepresenter";
 import type {FieldFormState} from "../../../domain/fields/types";
 import {FieldKind, type InnerFieldFormState} from "../../../domain/fields/types";
+import FieldSecurityEditor from "../../molecules/field-security-editor/FieldSecurityEditor";
+import type {FieldSecurity} from "../../../domain/fields/field-acl";
+import type {Properties} from "../../../store/api/bucketApi";
 
 type InnerFieldProps = {
   field: InnerFieldFormState;
@@ -109,6 +112,11 @@ type BucketAddFieldViewProps = {
   defaultInputProperty?: TypeProperties[keyof TypeProperties];
   presetInputProperties?: TypeProperties;
   multipleSelectionTabProperties?: TypeProperties;
+  bucketProperties?: Properties;
+  // Field-level ACL only applies to top-level bucket properties. Editors that reuse
+  // an inner-field `popupType` to configure a top-level field (e.g. the diagram
+  // inspector) set this explicitly; otherwise it is derived from `popupType`.
+  isTopLevelField?: boolean;
   isLoading: boolean;
   handleFormValueChange: (
     values: FieldFormState,
@@ -133,6 +141,8 @@ const BucketAddFieldView: FC<BucketAddFieldViewProps> = ({
   defaultInputProperty,
   presetInputProperties,
   multipleSelectionTabProperties,
+  bucketProperties = {},
+  isTopLevelField,
   isLoading,
   handleFormValueChange,
   handleSaveAndClose,
@@ -198,6 +208,17 @@ const BucketAddFieldView: FC<BucketAddFieldViewProps> = ({
     [formValues.innerFields]
   );
 
+  // Field-level ACL projects on top-level bucket properties only, so it is not
+  // offered while configuring an inner (object/array) field. Callers that reuse an
+  // inner-field popupType for a top-level field override this via isTopLevelField.
+  const showSecurityTab = isTopLevelField ?? popupType === "add-field";
+
+  const handleSecurityChange = useCallback(
+    (next: FieldSecurity) =>
+      handleFormValueChange(next as unknown as FieldFormState, "securityValues"),
+    [handleFormValueChange]
+  );
+
   const tabs = useMemo(() => {
     const items: TypeFluidContainer[] = [];
     let currentIndex = 0;
@@ -251,8 +272,32 @@ const BucketAddFieldView: FC<BucketAddFieldViewProps> = ({
       "Configuration",
       <div className={styles.configurationOptionsContainer}>{configurationInputs}</div>
     );
+
+    if (showSecurityTab) {
+      createConfig(
+        "Security",
+        <div className={styles.securityContainer}>
+          <FieldSecurityEditor
+            value={formValues.securityValues}
+            bucketProperties={bucketProperties}
+            onChange={handleSecurityChange}
+          />
+        </div>
+      );
+    }
+
     return items;
-  }, [type, innerFieldExists, configurationInputs, formValues.innerFields, defaultInput]);
+  }, [
+    type,
+    innerFieldExists,
+    configurationInputs,
+    formValues.innerFields,
+    formValues.securityValues,
+    defaultInput,
+    showSecurityTab,
+    bucketProperties,
+    handleSecurityChange
+  ]);
 
   const tabItems: {prefix?: TypeFlexElement}[] = useMemo(
     () => tabs.map(i => ({prefix: i.prefix})),

--- a/apps/panel/src/components/organisms/bucket-diagram-inspector/BucketDiagramInspector.tsx
+++ b/apps/panel/src/components/organisms/bucket-diagram-inspector/BucketDiagramInspector.tsx
@@ -13,6 +13,7 @@ import {
 } from "../../../store/api/bucketApi";
 import type {FieldFormState, FieldKind} from "../../../domain/fields/types";
 import {FIELD_REGISTRY, isFieldKind} from "../../../domain/fields/registry";
+import {inferSecurityFromAcl} from "../../../domain/fields/field-acl";
 import type {Field} from "../../../pages/diagram/hooks/useBucketConverter";
 
 export type BucketDiagramInspectorProps = {
@@ -146,6 +147,10 @@ const EditFieldButton: React.FC<EditFieldButtonProps> = memo(
 
     const forbiddenFieldNames = getSiblingFieldNames();
 
+    // This button edits both top-level and nested fields through the same
+    // inner-field popupType; only top-level properties carry a field-level ACL.
+    const isTopLevelField = getFieldNestingLevel(fieldPath) === 0;
+
     const handleOpen = (e: React.MouseEvent) => {
       e.stopPropagation();
       setIsOpen(true);
@@ -169,6 +174,8 @@ const EditFieldButton: React.FC<EditFieldButtonProps> = memo(
         popupType="add-inner-field"
         forbiddenFieldNames={forbiddenFieldNames}
         initialValues={initialValues}
+        isTopLevelField={isTopLevelField}
+        bucketProperties={isTopLevelField ? bucket.properties : undefined}
       >
         <Button variant="icon" className={styles.editButton} onClick={handleOpen}>
           <Icon name="pencil" />
@@ -317,7 +324,9 @@ const BucketDiagramInspector: React.FC<BucketDiagramInspectorProps> = ({bucket, 
           translate: property.options?.translate || false
         },
         presetValues: buildPresetValues(property),
-        defaultValue: property.default
+        defaultValue: property.default,
+        // Rehydrate the field-level ACL so the Security tab reflects the saved rule.
+        securityValues: inferSecurityFromAcl(property.acl)
       };
 
       if (property.type === "multiselect") {
@@ -602,6 +611,7 @@ const BucketDiagramInspector: React.FC<BucketDiagramInspectorProps> = ({bucket, 
           onSaveAndClose={handleSaveAndClose}
           forbiddenFieldNames={forbiddenFieldNames}
           containerClassName={styles.newFieldButtonContainer}
+          bucketProperties={bucket.properties}
         >
           {({onOpen}) => (
             <Button variant="icon" onClick={onOpen} className={styles.newFieldButton}>

--- a/apps/panel/src/components/organisms/bucket-table/BucketTable.tsx
+++ b/apps/panel/src/components/organisms/bucket-table/BucketTable.tsx
@@ -760,6 +760,7 @@ const BucketTable: React.FC<BucketTableNewProps> = ({
         <BucketFieldPopup
           onSaveAndClose={handleSaveAndClose}
           forbiddenFieldNames={forbiddenFieldNames}
+          bucketProperties={bucket.properties as unknown as BucketType["properties"]}
         >
           {({onOpen}) => (
             <FlexElement className={styles.newFieldHeader} dimensionY={34} dimensionX="fill" onClick={onOpen}>
@@ -790,6 +791,7 @@ const BucketTable: React.FC<BucketTableNewProps> = ({
         initialValues={editingField.formState}
         onSaveAndClose={handleEditSaveAndClose}
         forbiddenFieldNames={editForbiddenFieldNames}
+        bucketProperties={bucket.properties as unknown as BucketType["properties"]}
       />
     )}
 </>

--- a/apps/panel/src/domain/fields/field-acl.spec.ts
+++ b/apps/panel/src/domain/fields/field-acl.spec.ts
@@ -1,0 +1,112 @@
+import {describe, it, expect} from "@jest/globals";
+import {
+  aclStatus,
+  buildAclExpression,
+  inferSecurityFromAcl,
+  referencesScope,
+  type FieldSecurity
+} from "./field-acl";
+
+describe("field-acl", () => {
+  describe("buildAclExpression", () => {
+    it("emits no acl for everyone", () => {
+      expect(buildAclExpression({mode: "everyone", expression: ""})).toBeUndefined();
+    });
+
+    it("emits the canonical authenticated expression", () => {
+      expect(buildAclExpression({mode: "authenticated", expression: ""})).toBe(
+        "auth._id != undefined"
+      );
+    });
+
+    it("emits the owner template from ownerField", () => {
+      expect(
+        buildAclExpression({mode: "owner", expression: "", ownerField: "author"})
+      ).toBe("document.author == auth._id");
+    });
+
+    it("falls back to undefined for owner without a field", () => {
+      expect(buildAclExpression({mode: "owner", expression: ""})).toBeUndefined();
+    });
+
+    it("trims a custom expression and drops empty", () => {
+      expect(buildAclExpression({mode: "custom", expression: "  auth.role == 'admin'  "})).toBe(
+        "auth.role == 'admin'"
+      );
+      expect(buildAclExpression({mode: "custom", expression: "   "})).toBeUndefined();
+    });
+
+    it("returns undefined when security is absent", () => {
+      expect(buildAclExpression(undefined)).toBeUndefined();
+    });
+  });
+
+  describe("inferSecurityFromAcl", () => {
+    it("maps empty/undefined to everyone", () => {
+      expect(inferSecurityFromAcl(undefined)).toEqual({mode: "everyone", expression: ""});
+      expect(inferSecurityFromAcl("")).toEqual({mode: "everyone", expression: ""});
+    });
+
+    it("recognizes the authenticated expression", () => {
+      expect(inferSecurityFromAcl("auth._id != undefined")).toEqual({
+        mode: "authenticated",
+        expression: "auth._id != undefined"
+      });
+    });
+
+    it("recognizes the owner template and captures the field", () => {
+      expect(inferSecurityFromAcl("document.author == auth._id")).toEqual({
+        mode: "owner",
+        expression: "document.author == auth._id",
+        ownerField: "author"
+      });
+    });
+
+    it("treats anything else as custom", () => {
+      expect(inferSecurityFromAcl("auth.role == 'admin'")).toEqual({
+        mode: "custom",
+        expression: "auth.role == 'admin'"
+      });
+    });
+  });
+
+  describe("round-trip", () => {
+    const presets: FieldSecurity[] = [
+      {mode: "everyone", expression: ""},
+      {mode: "authenticated", expression: ""},
+      {mode: "owner", expression: "", ownerField: "author"},
+      {mode: "custom", expression: "auth.role == 'admin'"}
+    ];
+
+    it.each(presets)("preserves the mode for %o", preset => {
+      const acl = buildAclExpression(preset);
+      expect(inferSecurityFromAcl(acl).mode).toBe(preset.mode);
+    });
+
+    it("keeps a hand-written custom expression as custom", () => {
+      const acl = "document.author == auth._id || auth.role == 'admin'";
+      const inferred = inferSecurityFromAcl(acl);
+      expect(inferred.mode).toBe("custom");
+      expect(buildAclExpression(inferred)).toBe(acl);
+    });
+  });
+
+  describe("referencesScope", () => {
+    it("detects auth and document references", () => {
+      expect(referencesScope("auth._id != undefined", "auth")).toBe(true);
+      expect(referencesScope("auth._id != undefined", "document")).toBe(false);
+      expect(referencesScope("document.author == auth._id", "document")).toBe(true);
+      expect(referencesScope(undefined, "auth")).toBe(false);
+    });
+  });
+
+  describe("aclStatus", () => {
+    it("classifies visibility", () => {
+      expect(aclStatus(undefined)).toBe("public");
+      expect(aclStatus("")).toBe("public");
+      expect(aclStatus("document.author == auth._id")).toBe("conditional");
+      expect(aclStatus("auth._id != undefined")).toBe("restricted");
+      expect(aclStatus("false")).toBe("restricted");
+    });
+  });
+});

--- a/apps/panel/src/domain/fields/field-acl.ts
+++ b/apps/panel/src/domain/fields/field-acl.ts
@@ -1,0 +1,76 @@
+/**
+ * Field-level ACL
+ * ------------------------------------------------------------
+ * Single source of truth for translating between the security presets shown in
+ * the field-config form and the raw `acl` expression string the API stores on a
+ * bucket property. The expression is read-visibility only: when it evaluates
+ * false for a request, the API strips that field from the response. Expressions
+ * reference `auth.*` (the requesting identity) and `document.*` (the row).
+ *
+ * Pure module — no React, no side effects.
+ */
+
+export type FieldAclMode = "everyone" | "authenticated" | "owner" | "custom";
+
+export interface FieldSecurity {
+  mode: FieldAclMode;
+  expression: string;
+  ownerField?: string;
+}
+
+const AUTHENTICATED_EXPRESSION = "auth._id != undefined";
+
+// Owner preset: `document.<field> == auth._id`. Capture the field name so an
+// existing expression authored by the preset round-trips back to owner mode.
+const OWNER_EXPRESSION_PATTERN = /^document\.([A-Za-z_$][\w$]*)\s*==\s*auth\._id$/;
+
+export function buildAclExpression(security?: FieldSecurity): string | undefined {
+  if (!security) return undefined;
+
+  switch (security.mode) {
+    case "everyone":
+      return undefined;
+    case "authenticated":
+      return AUTHENTICATED_EXPRESSION;
+    case "owner": {
+      const ownerField = security.ownerField?.trim();
+      // Without a chosen owner field there is no canonical expression to emit;
+      // the caller keeps whatever custom expression the user had instead.
+      if (!ownerField) return undefined;
+      return `document.${ownerField} == auth._id`;
+    }
+    case "custom": {
+      const expression = security.expression?.trim();
+      return expression ? expression : undefined;
+    }
+    default:
+      return undefined;
+  }
+}
+
+export function inferSecurityFromAcl(acl: string | undefined): FieldSecurity {
+  const expression = acl?.trim();
+  if (!expression) return {mode: "everyone", expression: ""};
+
+  if (expression === AUTHENTICATED_EXPRESSION) {
+    return {mode: "authenticated", expression};
+  }
+
+  const ownerMatch = expression.match(OWNER_EXPRESSION_PATTERN);
+  if (ownerMatch) {
+    return {mode: "owner", expression, ownerField: ownerMatch[1]};
+  }
+
+  return {mode: "custom", expression};
+}
+
+export function referencesScope(acl: string | undefined, scope: "auth" | "document"): boolean {
+  if (!acl) return false;
+  return new RegExp(`\\b${scope}\\.`).test(acl);
+}
+
+export function aclStatus(acl: string | undefined): "public" | "conditional" | "restricted" {
+  if (!acl || !acl.trim()) return "public";
+  if (referencesScope(acl, "document")) return "conditional";
+  return "restricted";
+}

--- a/apps/panel/src/domain/fields/propertyToFormState.ts
+++ b/apps/panel/src/domain/fields/propertyToFormState.ts
@@ -11,6 +11,7 @@
  */
 
 import {initForm} from ".";
+import {inferSecurityFromAcl} from "./field-acl";
 import {FieldKind, type FieldFormState, type InnerFieldFormState} from "./types";
 import type {BucketSchema, BucketProperty} from "../../components/organisms/bucket-table/types";
 
@@ -33,7 +34,13 @@ function innerPropertyToFormState(
   const kind = apiTypeToFieldKind(property.type);
   const partial = buildPartialFormState(fieldKey, property, kind, undefined, undefined);
   const merged = initForm(kind, partial as FieldFormState);
-  return {...merged, id: crypto.randomUUID()} as InnerFieldFormState;
+  // initForm only carries keys present in the field-kind defaults; securityValues
+  // is not seeded there, so re-apply it after the merge (mirrors innerFields).
+  return {
+    ...merged,
+    securityValues: partial.securityValues,
+    id: crypto.randomUUID()
+  } as InnerFieldFormState;
 }
 
 /**
@@ -185,7 +192,9 @@ function buildPartialFormState(
     fieldValues: {...baseFieldValues, ...specificFieldValues},
     configurationValues: {...baseConfigValues, ...specificConfigValues},
     presetValues,
-    defaultValue
+    defaultValue,
+    // No acl yields {mode: "everyone", expression: ""} so the security form is stable.
+    securityValues: inferSecurityFromAcl(property.acl)
   };
 
   if (multipleSelectionTab !== undefined) {
@@ -239,6 +248,9 @@ export function propertyToFieldFormState(
   if (partial.innerFields !== undefined) {
     merged.innerFields = partial.innerFields;
   }
+  // securityValues is not part of the field-kind defaults initForm merges over,
+  // so re-apply it here to keep the parsed acl on the edit form.
+  merged.securityValues = partial.securityValues;
   return merged;
 }
 

--- a/apps/panel/src/domain/fields/registry.ts
+++ b/apps/panel/src/domain/fields/registry.ts
@@ -7,6 +7,7 @@
 
 import type {BucketType, Property} from "src/store/api/bucketApi";
 import {BASE_FORM_DEFAULTS, DEFAULT_COORDINATES, freezeFormDefaults} from "./defaults";
+import {buildAclExpression} from "./field-acl";
 import {applyPresetLogic} from "./presets";
 import {
   type FieldDefinition,
@@ -67,11 +68,12 @@ export function isFieldKind(value: string): value is FieldKind {
 }
 
 function buildBaseProperty(values: FieldFormState): Property {
-  const {fieldValues, configurationValues, type, innerFields} = values;
+  const {fieldValues, configurationValues, securityValues, type, innerFields} = values;
   return {
     type,
     title: fieldValues.title,
     description: fieldValues.description || undefined,
+    acl: buildAclExpression(securityValues),
     options: {
       translate: configurationValues.translate || undefined
     },

--- a/apps/panel/src/domain/fields/types.ts
+++ b/apps/panel/src/domain/fields/types.ts
@@ -44,6 +44,11 @@ export interface FieldCreationForm {
   presetValues: Record<string, any>;
   defaultValue?: any;
   multipleSelectionTab?: Record<string, any>;
+  securityValues?: {
+    mode: "everyone" | "authenticated" | "owner" | "custom";
+    expression: string;
+    ownerField?: string;
+  };
   type: FieldKind;
 }
 

--- a/apps/panel/src/hooks/useRuleEditor.ts
+++ b/apps/panel/src/hooks/useRuleEditor.ts
@@ -1,0 +1,195 @@
+import {useCallback, useEffect, useMemo, useRef} from "react";
+import * as monaco from "monaco-editor";
+import {jwtDecode} from "jwt-decode";
+import type {AuthTokenJWTPayload} from "src/types/auth";
+
+/**
+ * Shared Monaco setup for Spica rule expressions (bucket ACL rules and
+ * field-level ACL). Both editors speak the same tiny language: bare expressions
+ * over `auth.*` (the requesting identity) and `document.*` (the row). Keeping the
+ * language registration, theme and `auth.*`/`document.*` completion provider in
+ * one place means the bucket-rules modal and the field security editor can never
+ * drift apart.
+ */
+
+const LANGUAGE_NAME = "myLang";
+const THEME_NAME = "myCustomtheme";
+
+type RuleEditorSuggestions = {
+  document: any;
+  auth: any;
+};
+
+function registerRuleEditor(
+  monaco: typeof import("monaco-editor"),
+  autoCompleteSuggestions: RuleEditorSuggestions,
+  refs: {
+    disposableRef: React.RefObject<monaco.IDisposable | null>;
+    initializedRef: React.RefObject<boolean>;
+  }
+) {
+  const {disposableRef, initializedRef} = refs;
+
+  if (!initializedRef.current) {
+    monaco.languages.register({id: LANGUAGE_NAME});
+
+    monaco.languages.setMonarchTokensProvider(LANGUAGE_NAME, {
+      defaultToken: "",
+      tokenizer: {
+        root: [
+          [/[a-zA-Z_$][\w$]*\s*:/, "key"],
+          [/[{}]/, "delimiter.bracket"],
+          {include: "@common"}
+        ],
+        common: [
+          [/\d+/, "number"],
+          [/[,.]/, "delimiter"],
+          [/[;]/, "delimiter"],
+          [/"([^"\\]|\\.)*$/, "string.invalid"],
+          [/"([^"\\]|\\.)*"/, "string"],
+          [/'([^'\\]|\\.)*$/, "string.invalid"],
+          [/'([^'\\]|\\.)*'/, "string"],
+          [/\s+/, "white"]
+        ]
+      }
+    });
+
+    monaco.editor.defineTheme(THEME_NAME, {
+      base: "vs",
+      inherit: true,
+      rules: [
+        {token: "key", foreground: "000000", fontStyle: "bold"},
+        {token: "identifier", foreground: "000000"},
+        {token: "delimiter", foreground: "000000"},
+        {token: "string", foreground: "000000"}
+      ],
+
+      colors: {
+        "editor.background": "#f4f4f4"
+      }
+    });
+
+    initializedRef.current = true;
+  }
+
+  disposableRef.current = monaco.languages.registerCompletionItemProvider(LANGUAGE_NAME, {
+    triggerCharacters: ".".split(""),
+
+    provideCompletionItems: (model, position) => {
+      const textUntilPosition = model.getValueInRange({
+        startLineNumber: position.lineNumber,
+        startColumn: 1,
+        endLineNumber: position.lineNumber,
+        endColumn: position.column
+      });
+
+      const statements = textUntilPosition
+        .split(/;|,| /)
+        .map(s => s.trim())
+        .filter(Boolean);
+      const lastStatement = statements.length > 0 ? statements[statements.length - 1] : "";
+
+      const cleaned = lastStatement.replace(/^(read|write)\s*:\s*/, "");
+
+      const suggestions: monaco.languages.CompletionItem[] = [];
+      const seen = new Set<string>();
+      if (!cleaned.includes(".")) {
+        const baseWords = ["true", "false", "auth", "document"];
+        const word = cleaned.split(/\s+/).pop() ?? "";
+
+        for (const key of baseWords) {
+          if (key.startsWith(word)) {
+            if (seen.has(key)) continue;
+            seen.add(key);
+            suggestions.push({
+              label: key,
+              kind: monaco.languages.CompletionItemKind.Keyword,
+              insertText: key
+            } as monaco.languages.CompletionItem);
+          }
+        }
+
+        return {suggestions} as monaco.languages.CompletionList;
+      }
+
+      const lastDotIndex = cleaned.lastIndexOf(".");
+      const basePath = cleaned.slice(0, lastDotIndex);
+      const partial = cleaned.slice(lastDotIndex + 1);
+
+      const pathSegments = basePath.split(".");
+      const root = pathSegments.shift();
+      if (!root || !["auth", "document"].includes(root)) return {suggestions: []};
+
+      let current = autoCompleteSuggestions[root as "auth" | "document"];
+      for (const segment of pathSegments) {
+        if (!current || typeof current !== "object") return {suggestions: []};
+        current = current[segment];
+      }
+
+      if (!current || typeof current !== "object") return {suggestions: []};
+
+      for (const key of Object.keys(current)) {
+        if (seen.has(key)) continue;
+        if (key.startsWith(partial)) {
+          seen.add(key);
+          suggestions.push({
+            label: key,
+            kind: monaco.languages.CompletionItemKind.Property,
+            insertText: key,
+            detail: `${root} property`
+          } as monaco.languages.CompletionItem);
+        }
+      }
+
+      return {suggestions} as monaco.languages.CompletionList;
+    }
+  });
+}
+
+type UseRuleEditorParams = {
+  /** Bucket properties powering `document.*` completions. */
+  properties: Record<string, any> | undefined;
+  /** Row id exposed as `document._id` in completions, when known. */
+  documentId?: string;
+};
+
+export function useRuleEditor({properties, documentId}: UseRuleEditorParams) {
+  const disposableRef = useRef<monaco.IDisposable | null>(null);
+  const initializedRef = useRef(false);
+
+  // The auth token is persisted as a RAW JWT string (Authorization: IDENTITY <token>),
+  // not JSON — so it must be read directly, not through useLocalStorage (which JSON.parses).
+  // A missing/garbage token must degrade to {} so autocomplete stops suggesting auth.*
+  // instead of throwing InvalidTokenError and crashing the whole editor.
+  const auth = useMemo<Partial<AuthTokenJWTPayload>>(() => {
+    try {
+      const raw = typeof window !== "undefined" ? window.localStorage.getItem("token") : null;
+      return raw ? jwtDecode<AuthTokenJWTPayload>(raw) : {};
+    } catch {
+      return {};
+    }
+  }, []);
+
+  const suggestions = useMemo<RuleEditorSuggestions>(
+    () => ({
+      auth,
+      document: documentId !== undefined ? {...properties, _id: documentId} : {...properties}
+    }),
+    [properties, auth, documentId]
+  );
+
+  useEffect(() => {
+    return () => {
+      disposableRef.current?.dispose?.();
+      disposableRef.current = null;
+    };
+  }, []);
+
+  const beforeMount = useCallback(
+    (monacoInstance: typeof import("monaco-editor")) =>
+      registerRuleEditor(monacoInstance, suggestions, {disposableRef, initializedRef}),
+    [suggestions]
+  );
+
+  return {language: LANGUAGE_NAME, theme: THEME_NAME, beforeMount};
+}

--- a/apps/panel/src/store/api/bucketApi.ts
+++ b/apps/panel/src/store/api/bucketApi.ts
@@ -49,6 +49,9 @@ export type Property =
 interface IProperty {
   type: string;
   enum?: any[];
+  // Field-level read ACL expression (references auth.* / document.*); when it
+  // evaluates false the field is stripped from the response by the API.
+  acl?: string;
   [key: string]: any;
 }
 


### PR DESCRIPTION
## Summary

Adds a UI for the backend **field-level ACL** system. Each bucket property can carry an `acl` expression (`packages/interface/bucket` `PropertyOptions.acl`) that controls whether that field's **value is returned by the bucket data API** — read-visibility only, and enforced only for end-user (USER strategy) calls. Until now this could only be set by editing the schema by hand.

> **Base branch:** this PR is **stacked on `feat/panel-bucket-nav-filters-concurrency`** (not `master`), because it was built on top of that in-flight branch and `bucketApi.ts` already diverges there. Retarget to `master` once the parent merges.

## Two surfaces

**1. Inline "Security" tab** (field add/edit, incl. diagram inspector for top-level fields)
- Presets: **Everyone** / **Signed-in users only** / **Only the record owner** (with a field picker) / **Custom rule**.
- Custom rule → Monaco editor with `auth.*` / `document.*` autocomplete and a muted format placeholder showing real examples (`document.age > 24`, `auth.identifier == 'admin'`, `"HR" in auth.policies`, `document.owner == auth._id`).
- Hidden for genuine nested/inner fields (field ACL only applies to top-level properties).
- Note surfaced: rules apply only to USER API calls; Identity & API-key access ignore them.

**2. "Field Security" overview modal** (bucket **More** menu, next to Configure rules)
- Per-field status matrix: 🟢 public / 🟡 conditional / 🔴 restricted, derived from the expression's scope.
- Inline editing per row via the same editor.
- Capped to the viewport; header/legend/footer pinned, rows scroll for large buckets.

## Implementation notes
- `domain/fields/field-acl.ts` — pure helper, single source of truth for preset ↔ expression mapping + status derivation (17 unit tests).
- `IProperty.acl` added; `securityValues` form slice serialized on save (`registry.ts`) and rehydrated on edit (`propertyToFormState.ts`).
- Shared `useRuleEditor` hook extracted from `BucketRules` (pure refactor — existing bucket-rules editor behavior unchanged).
- **Bug fix:** `useFormState` re-ran `initForm` and silently dropped `securityValues`, discarding a saved rule on reopen (affected all edit paths) — now preserved.
- Persists via the existing full-bucket PUT (`useCreateBucketFieldMutation`) — **no backend change**.

## Verification
- `yarn nx build panel` — passes, **zero net-new type errors**.
- `field-acl.spec.ts` — 17/17 pass (preset round-trips).
- No runnable panel e2e target exists; manual review recommended: `yarn nx serve panel` → add/edit a field → **Security** tab, and **More → Field Security**. Confirm the shared bucket-level **Configure rules** autocomplete still behaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)