### PR TITLE
fix(function): don't kill retired workers — it strands in-flight responses

### DIFF
--- a/packages/api/function/scheduler/src/scheduler.ts
+++ b/packages/api/function/scheduler/src/scheduler.ts
@@ -465,12 +465,10 @@ export class Scheduler implements OnModuleInit, OnModuleDestroy {
       const worker = this.workers.get(workerId);
       worker?.onComplete();
 
-      // A retired (superseded → outdated) worker that just drained its last in-flight event is
-      // done and would otherwise linger; reap it now. Guarded to Outdated so live workers, which
-      // go Busy→Targeted here and get reused, are never killed.
-      if (worker && worker.state == WorkerState.Outdated && worker.isIdle()) {
-        worker.kill();
-      }
+      // A drained retired worker is deliberately NOT killed here. `complete` only tells us the
+      // handler finished — the event's response travels to the client over a separate channel and
+      // may still be in flight, so killing the worker now races that delivery and strands the
+      // request. Retired workers are reaped by their execution timeout instead.
 
       const routers = this.logRouters.get(workerId);
       if (routers) {
@@ -627,8 +625,10 @@ export class Scheduler implements OnModuleInit, OnModuleDestroy {
   }
 
   // Retire one superseded (old-code) worker now that a fresh replacement has taken over. Idle
-  // workers are reaped immediately; busy ones finish their in-flight events and are reaped by
-  // complete(). When the last superseded worker of the function is retired, the cutover is done.
+  // Marking it Outdated is enough to stop it taking new events; it is never killed here. A worker
+  // that has served events may still be delivering a completed event's response, and `isIdle()`
+  // only tracks handler completion — killing on it races that delivery and strands the request.
+  // Its execution timeout reaps it, exactly as a plain outdate does.
   private retireOneSuperseded(fnId: string) {
     const stale = Array.from(this.workers.values()).find(
       worker =>
@@ -640,9 +640,6 @@ export class Scheduler implements OnModuleInit, OnModuleDestroy {
 
     if (stale) {
       stale.markAsOutdated();
-      if (stale.isIdle()) {
-        stale.kill();
-      }
     }
 
     const remaining = Array.from(this.workers.values()).some(
@@ -664,12 +661,7 @@ export class Scheduler implements OnModuleInit, OnModuleDestroy {
         worker =>
           worker.hasSameTarget(fnId) && worker.isSuperseded && worker.state != WorkerState.Outdated
       )
-      .forEach(worker => {
-        worker.markAsOutdated();
-        if (worker.isIdle()) {
-          worker.kill();
-        }
-      });
+      .forEach(worker => worker.markAsOutdated());
 
     this.clearReplacementState(fnId);
   }

--- a/packages/api/function/scheduler/test/scheduler.spec.ts
+++ b/packages/api/function/scheduler/test/scheduler.spec.ts
@@ -913,6 +913,24 @@ describe("Scheduler", () => {
       expect(active.state).toEqual(WorkerState.Outdated);
     });
 
+    it("retires a superseded worker without killing it, so its last response can still land", () => {
+      // Regression: killing a retired worker on isIdle() races the delivery of its just-completed
+      // event's response and strands that request (observed end-to-end as one hung request per
+      // update). Retirement must only mark it Outdated; the execution timeout reaps it.
+      const [, active] = activeWorkerFor("1");
+      completeEvent("1"); // handler finished — response may still be in flight
+      expect(active.isIdle()).toBe(true);
+
+      const killSpy = jest.spyOn(active, "kill");
+      scheduler.supersedeWorkers(makeTarget("1"));
+      connectWarmingWorkers();
+
+      scheduler.enqueue(new event.Event({target: makeTarget("1"), type: -1 as any}));
+
+      expect(active.state).toEqual(WorkerState.Outdated);
+      expect(killSpy).not.toHaveBeenCalled();
+    });
+
     it("keeps serving from the superseded worker when no replacement is ready yet", () => {
       const [, active] = activeWorkerFor("1");
       scheduler.supersedeWorkers(makeTarget("1"));


### PR DESCRIPTION
Follow-up to #1899, found by driving the real system end-to-end (local API + Mongo, ~2.4k rps under load while pushing function updates).

## The bug

**Every function update stranded exactly one HTTP request** — the client hung forever, no response, no error. Reproduced consistently:

| build | scenario | stranded requests |
|---|---|---|
| `a85eddf7` (pre-#1899 baseline) | 3 updates under load | **0** |
| `a092e699` (#1899 merged) | 3 rapid updates | **3** (×3 runs) |
| `a092e699` | 3 *spaced* updates (2.5s apart) | **3** |
| this PR | spaced ×2 + rapid | **0** |

It is one strand **per update** — independent of rapidity and of `concurrencyPerWorker` (same count at 1 and 4). In one run all 4 in-flight requests hung simultaneously and throughput dropped from ~28k to ~8.5k requests.

## Cause

Retirement killed a worker as soon as `isIdle()` returned true. But `isIdle()` only tracks **handler completion** (`inFlight == 0`) — the event's response travels back to the client over a separate channel and may still be in flight. `SIGTERM` at that instant drops it, and the request never completes.

All three eager kill paths introduced in #1899 had this race:
- `complete()` — the reap on drain
- `retireOneSuperseded()` — `if (stale.isIdle()) stale.kill()`
- `forceCutover()` — same

The pre-#1899 baseline never killed a worker that had served events (a plain outdate only *marks*), which is exactly why it never stranded.

## The fix

A worker that has served events is now only marked `Outdated` — never killed. That restores the long-standing outdate semantics, with the execution timeout reaping it. `Warm`/`Warming` workers are still killed, which is safe because they have never served an event, so no response can be in flight.

This also resolves @htuna07's review comment on the `complete()` reap ("won't be killed automatically when the timeout comes?") — the answer turned out to be yes, and the eager kill was actively harmful.

## Trade-off

Retired workers now linger idle until their execution timeout instead of exiting immediately. That is the pre-existing, proven-correct behavior, and correctness beats promptness here. If prompt reclamation is wanted later, it needs a signal that the response was actually delivered — not `isIdle()`.

## Tests

- `api/function/scheduler`: **65/65 pass**, including a new regression test (`retires a superseded worker without killing it, so its last response can still land`). Verified non-vacuous: it **fails** when the kill is re-introduced.
- `yarn nx build api` clean.
- E2E: 0 stranded requests across spaced and rapid update runs at ~2.4k rps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)