### PR TITLE
fix(panel): include triggers when saving function config edits

### DIFF
--- a/apps/panel/src/components/prefabs/navigations/function/FunctionModal.tsx
+++ b/apps/panel/src/components/prefabs/navigations/function/FunctionModal.tsx
@@ -11,7 +11,7 @@ import {
   useUpdateFunctionIndexMutation,
   useGetFunctionInformationQuery
 } from "../../../../store/api/functionApi";
-import type {SpicaFunction} from "../../../../store/api/functionApi";
+import type {SpicaFunction, TriggerMap} from "../../../../store/api/functionApi";
 import styles from "./FunctionModal.module.scss";
 
 type FunctionModalProps = {
@@ -110,7 +110,11 @@ const FunctionModal = ({isOpen, onClose, functionToEdit, onSaved}: FunctionModal
             timeout,
             category: trimmedCategory || undefined,
             warmWorkers,
-            concurrencyPerWorker
+            concurrencyPerWorker,
+            // PUT /function/:id validates against the full function schema, which
+            // requires `triggers`. It merges via $set, so echoing the existing
+            // triggers back keeps them unchanged while satisfying validation.
+            triggers: functionToEdit.triggers as TriggerMap
           }
         }).unwrap();
         onSaved(result);


### PR DESCRIPTION
## Problem

On the function detail page (`/function/:id`), the **Edit Function** drawer fails to save Warm Pool, concurrency, or other config changes with:

> must have required property 'triggers'

## Root cause

- `FunctionModal` (edit mode) sends the update as `PUT /function/:id` with a body of `{name, language, timeout, category, warmWorkers, concurrencyPerWorker}` — **no `triggers`**.
- The backend `replaceOne` handler validates that body against the **full** function schema via `@Body(Schema.validate(generate))`, and `function.json` lists `triggers` in `required: ["name", "triggers", "timeout", "language"]`. Missing `triggers` → the request is rejected before it ever touches the DB.
- Although the endpoint is named "replace", `CRUD.replace` applies the body with `findOneAndUpdate({_id}, {$set: fn})` — a **merge**, not a document replacement. So the only real blocker was schema validation, not a genuine need to resend the whole document.

## Fix

Include the existing function's `triggers` in the edit-mode PUT body. The drawer already has the full function (loaded via `GET /function/:id`), so echoing `triggers` back satisfies validation, and because the backend uses `$set`, the triggers are re-set to the same value — a no-op that leaves triggers, env vars, and secrets untouched.

## Testing

- Reload a function, open **Edit**, change the Warm Pool slider, and **Save** → now succeeds.
- `tsc` on `apps/panel` introduces no new errors in `FunctionModal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
