### PR TITLE
fix(bucket): key bucket hook subscriptions on target identity

### DIFF
--- a/packages/api/bucket/hooks/src/enqueuer.ts
+++ b/packages/api/bucket/hooks/src/enqueuer.ts
@@ -170,6 +170,6 @@ export class ChangeEnqueuer extends Enqueuer<ChangeOptions> {
   }
 
   getTargetKey(target: event.Target) {
-    return JSON.stringify(target.toObject());
+    return JSON.stringify({id: target.id, cwd: target.cwd, handler: target.handler});
   }
 }

--- a/packages/api/bucket/hooks/test/enqueuer.spec.ts
+++ b/packages/api/bucket/hooks/test/enqueuer.spec.ts
@@ -2,6 +2,10 @@ import {EventQueue} from "@spica-server/function-queue";
 import {event} from "@spica-server/function-queue-proto";
 import {ChangeEnqueuer} from "@spica-server/bucket-hooks/src/enqueuer";
 import {ChangeEmitter} from "@spica-server/bucket-hooks/src/emitter";
+import {ChangeQueue} from "@spica-server/bucket-hooks/src/queue";
+
+const targetKey = (target: event.Target) =>
+  JSON.stringify({id: target.id, cwd: target.cwd, handler: target.handler});
 
 describe("ChangeEnqueuer", () => {
   let changeEnqeuer: ChangeEnqueuer;
@@ -38,9 +42,7 @@ describe("ChangeEnqueuer", () => {
       type: "INSERT"
     });
 
-    expect(
-      changeEnqeuer["changeTargets"].get(JSON.stringify(noopTarget.toObject())).options
-    ).toEqual({
+    expect(changeEnqeuer["changeTargets"].get(targetKey(noopTarget)).options).toEqual({
       bucket: "test_collection",
       type: "INSERT"
     });
@@ -63,12 +65,8 @@ describe("ChangeEnqueuer", () => {
 
     changeEnqeuer.unsubscribe(noopTarget);
 
-    expect(changeEnqeuer["changeTargets"].get(JSON.stringify(noopTarget.toObject()))).toEqual(
-      undefined
-    );
-    expect(
-      changeEnqeuer["changeTargets"].get(JSON.stringify(noopTarget2.toObject())).options
-    ).toEqual({
+    expect(changeEnqeuer["changeTargets"].get(targetKey(noopTarget))).toEqual(undefined);
+    expect(changeEnqeuer["changeTargets"].get(targetKey(noopTarget2)).options).toEqual({
       bucket: "test_collection",
       type: "GET"
     });
@@ -76,5 +74,46 @@ describe("ChangeEnqueuer", () => {
     expect(changeEmitter.off).toHaveBeenCalledTimes(1);
 
     expect(changeEmitter.off.mock.calls[0][0]).toEqual("test_collection_insert");
+  });
+
+  describe("onChangeHandler", () => {
+    let changeQueue: jest.Mocked<ChangeQueue>;
+
+    beforeEach(() => {
+      changeQueue = {
+        enqueue: jest.fn()
+      } as unknown as jest.Mocked<ChangeQueue>;
+
+      changeEnqeuer = new ChangeEnqueuer(eventQueue, changeQueue, changeEmitter);
+    });
+
+    const rawChange = {type: "insert", documentKey: "doc1", previous: undefined, current: {a: 1}};
+
+    it("should keep enqueueing after the scheduler attaches a context to the target", () => {
+      changeEnqeuer.subscribe(noopTarget, {bucket: "test_collection", type: "INSERT"});
+
+      changeEnqeuer.onChangeHandler(rawChange, noopTarget);
+
+      noopTarget.context = new event.SchedulingContext({env: [], timeout: 60});
+
+      expect(() => changeEnqeuer.onChangeHandler(rawChange, noopTarget)).not.toThrow();
+      expect(eventQueue.enqueue).toHaveBeenCalledTimes(2);
+      expect(changeQueue.enqueue.mock.calls[1][1].bucket).toEqual("test_collection");
+    });
+
+    it("should resolve a target rebuilt from a drained event", () => {
+      changeEnqeuer.subscribe(noopTarget, {bucket: "test_collection", type: "INSERT"});
+
+      const rebuilt = new event.Target({
+        id: noopTarget.id,
+        cwd: noopTarget.cwd,
+        handler: noopTarget.handler,
+        context: new event.SchedulingContext({env: [], timeout: 60})
+      });
+
+      changeEnqeuer.onChangeHandler(rawChange, rebuilt);
+
+      expect(eventQueue.enqueue).toHaveBeenCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
## The bug

Every bucket write on a bucket with a hook trigger fails with a 500 after the trigger's first event:

```
ERROR [ExceptionsHandler] Cannot destructure property 'options' of 'this.changeTargets.get(...)' as it is undefined.
    at ChangeEnqueuer.onChangeHandler (bucket-hooks/dist/src/enqueuer.js:63:17)
    at ChangeEmitter.changeHandler (bucket-hooks/dist/src/enqueuer.js:43:78)
    at ChangeEmitter.emitChange (bucket-hooks/dist/src/emitter.js:14:14)
    at BucketDataController.insertOne (bucket/dist/src/bucket-data.controller.js:119:32)
```

`emitChange` runs inline in `BucketDataController.insertOne`, so the throw takes the write down with it.

## Why

`ChangeEnqueuer` derives its `changeTargets` key from `target.toObject()`, which includes `context`. `PlanExecutor.buildTarget` builds the target with no context, so at subscribe time the key is `{"id":…,"cwd":…,"handler":…}`, and the handler closes over that target instance.

On the first change, `onChangeHandler` resolves the target and passes it to `new event.Event({target})` — which protobuf holds **by reference** — then enqueues. `Scheduler.enqueue` does:

```ts
ev.target.context = this.contextConfigs.get(ev.target.id) ?? …
```

That writes onto the object the key was derived from. The next change serializes a key that now carries a `context` member, misses the map, and throws.

So each subscription served exactly one change and then broke every subsequent write to that bucket until the function was re-saved.

The defect is that a subscription is keyed on a field that is mutable runtime state. Regression from #1897, which moved context injection out of subscribe-time targets and into `Scheduler.enqueue`. `ChangeEnqueuer` is the only enqueuer keyed on a serialized target, so bucket hooks are the only ones affected.

## The fix

Key on identity (`id`/`cwd`/`handler`) so nothing that happens to the target downstream can invalidate the key.

This also fixes a second instance of the same defect, independently broken today: `shift()` rebuilds a target from `event.target.toObject()` **with** a context, so its key could never match a subscribe-time key. That path worked before #1897 (both sides included the context) and has been broken since.

Deliberately not in this PR: `Scheduler.enqueue` mutating a caller-owned target is a code smell, but it is inert once the key doesn't depend on it, and touching the enqueue path for every trigger type isn't worth the blast radius here.

## Testing

Two tests added to `enqueuer.spec.ts` — a context attached to the target post-enqueue, and a target rebuilt from a drained event. Both fail on `master` with the exact production error and pass here.

`api/bucket/hooks` passes 8/8. `api/function` can't run locally — `devkit/database:bundle` fails to find its rollup script on a clean tree too, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)