### PR TITLE
perf(function): page function logs before resolving names; fix api crash on log write failure

### DIFF
--- a/packages/api/function/log/jest.config.ts
+++ b/packages/api/function/log/jest.config.ts
@@ -4,7 +4,11 @@ export default {
   projects: [
     {
       preset: "../../../../jest.preset.js",
-      testMatch: ["<rootDir>/test/authorization.spec.ts","<rootDir>/test/service.spec.ts"],
+      testMatch: [
+        "<rootDir>/test/authorization.spec.ts",
+        "<rootDir>/test/service.spec.ts",
+        "<rootDir>/test/log.controller.spec.ts"
+      ],
     },
     {
       preset: "../../../../jest.preset.js",

--- a/packages/api/function/log/src/log.controller.ts
+++ b/packages/api/function/log/src/log.controller.ts
@@ -57,24 +57,7 @@ export class LogController {
       match.content = {$regex: content, $options: "i"};
     }
 
-    const pipeline: any[] = [
-      {
-        $match: match
-      },
-      {
-        $lookup: {
-          from: "function",
-          let: {fn: {$toObjectId: "$function"}},
-          pipeline: [{$match: {$expr: {$eq: ["$_id", "$$fn"]}}}],
-          as: "fn"
-        }
-      },
-      {$unwind: "$fn"},
-      {$set: {function: "$fn.name"}},
-      {$unset: ["fn"]}
-    ];
-
-    pipeline.push({$sort: {_id: -1}});
+    const pipeline: any[] = [{$match: match}, {$sort: {_id: -1}}];
 
     if (skip > 0) {
       pipeline.push({$skip: skip});
@@ -83,6 +66,21 @@ export class LogController {
     if (limit > 0) {
       pipeline.push({$limit: limit});
     }
+
+    pipeline.push(
+      {$set: {fn_id: {$toObjectId: "$function"}}},
+      {
+        $lookup: {
+          from: "function",
+          localField: "fn_id",
+          foreignField: "_id",
+          as: "fn"
+        }
+      },
+      {$unwind: {path: "$fn", preserveNullAndEmptyArrays: true}},
+      {$set: {function: {$ifNull: ["$fn.name", "$function"]}}},
+      {$unset: ["fn", "fn_id"]}
+    );
 
     return this.logService.aggregate(pipeline).toArray();
   }

--- a/packages/api/function/log/src/log.service.ts
+++ b/packages/api/function/log/src/log.service.ts
@@ -5,6 +5,12 @@ import {FUNCTION_LOG_OPTIONS, Log, LogOptions} from "@spica-server/interface-fun
 @Injectable()
 export class LogService extends BaseCollection<Log>("function_logs") {
   constructor(db: DatabaseService, @Inject(FUNCTION_LOG_OPTIONS) options: LogOptions) {
-    super(db, {afterInit: () => this.upsertTTLIndex(options.expireAfterSeconds)});
+    super(db, {
+      afterInit: () =>
+        Promise.all([
+          this.upsertTTLIndex(options.expireAfterSeconds),
+          this._coll.createIndex({function: 1, _id: -1})
+        ])
+    });
   }
 }

--- a/packages/api/function/log/test/log.controller.spec.ts
+++ b/packages/api/function/log/test/log.controller.spec.ts
@@ -1,0 +1,124 @@
+import {INestApplication} from "@nestjs/common";
+import {Test} from "@nestjs/testing";
+import {LogModule} from "@spica-server/function-log";
+import {CoreTestingModule, Request} from "@spica-server/core-testing";
+import {DatabaseService, ObjectId} from "@spica-server/database";
+import {DatabaseTestingModule} from "@spica-server/database-testing";
+import {PassportTestingModule} from "@spica-server/passport-testing";
+
+describe("Log Controller", () => {
+  let app: INestApplication;
+  let req: Request;
+  let db: DatabaseService;
+
+  const fnId = new ObjectId();
+  const deletedFnId = new ObjectId();
+
+  // _id encodes the timestamp, and the controller filters/sorts on it, so logs have to be seeded
+  // with ids built from a known second rather than freshly generated ones.
+  const day = Math.floor(new Date("2024-01-02T00:00:00.000Z").getTime() / 1000);
+  const logId = (offsetSeconds: number, counter: number) =>
+    new ObjectId(
+      (day + offsetSeconds).toString(16).padStart(8, "0") + counter.toString(16).padStart(16, "0")
+    );
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      imports: [
+        DatabaseTestingModule.replicaSet(),
+        CoreTestingModule,
+        LogModule.forRoot({expireAfterSeconds: 60, realtime: false}),
+        PassportTestingModule.initialize()
+      ]
+    }).compile();
+
+    app = module.createNestApplication();
+    req = module.get(Request);
+    db = module.get(DatabaseService);
+    await app.listen(req.socket);
+  });
+
+  afterAll(() => app.close());
+
+  beforeEach(async () => {
+    await db.collection("function").insertMany([{_id: fnId, name: "my-fn"}]);
+    await db.collection("function_logs").insertMany([
+      {
+        _id: logId(1, 1),
+        function: fnId.toString(),
+        event_id: "event",
+        channel: "stdout",
+        level: 1,
+        content: "first",
+        created_at: new Date()
+      },
+      {
+        _id: logId(2, 2),
+        function: fnId.toString(),
+        event_id: "event",
+        channel: "stdout",
+        level: 1,
+        content: "second",
+        created_at: new Date()
+      },
+      {
+        _id: logId(3, 3),
+        function: deletedFnId.toString(),
+        event_id: "event",
+        channel: "stdout",
+        level: 1,
+        content: "orphan",
+        created_at: new Date()
+      }
+    ]);
+  });
+
+  afterEach(async () => {
+    await db.collection("function").deleteMany({});
+    await db.collection("function_logs").deleteMany({});
+  });
+
+  const list = (query: object = {}) =>
+    req.get("/function-logs", {
+      begin: new Date(day * 1000).toISOString(),
+      end: new Date((day + 3600) * 1000).toISOString(),
+      ...query
+    });
+
+  it("should replace the function id with the function name, newest first", async () => {
+    const res = await list();
+
+    expect(res.body.map(log => [log.content, log.function])).toEqual([
+      ["orphan", deletedFnId.toString()],
+      ["second", "my-fn"],
+      ["first", "my-fn"]
+    ]);
+  });
+
+  it("should keep logs whose function no longer exists", async () => {
+    const res = await list();
+
+    expect(res.body.map(log => log.content)).toContain("orphan");
+  });
+
+  it("should apply limit against the newest logs, not an arbitrary subset", async () => {
+    const res = await list({limit: 1});
+
+    expect(res.body.map(log => log.content)).toEqual(["orphan"]);
+  });
+
+  it("should resolve the function name on a limited page", async () => {
+    const res = await list({limit: 2, skip: 1});
+
+    expect(res.body.map(log => [log.content, log.function])).toEqual([
+      ["second", "my-fn"],
+      ["first", "my-fn"]
+    ]);
+  });
+
+  it("should filter by function", async () => {
+    const res = await list({functions: [fnId.toString()]});
+
+    expect(res.body.map(log => log.content)).toEqual(["second", "first"]);
+  });
+});

--- a/packages/api/function/log/test/service.spec.ts
+++ b/packages/api/function/log/test/service.spec.ts
@@ -29,17 +29,24 @@ describe("Function Log Service", () => {
 
   it("should create ttl index", async () => {
     let indexes = await logService._coll.listIndexes().toArray();
-    expect(indexes.length).toEqual(2);
+    expect(indexes.length).toEqual(3);
 
     let ttlIndex = indexes.find(index => index.name == "created_at_1");
     expect(ttlIndex.expireAfterSeconds).toEqual(5);
+  });
+
+  it("should create an index that serves per-function listing sorted by _id", async () => {
+    const indexes = await logService._coll.listIndexes().toArray();
+
+    const listingIndex = indexes.find(index => index.name == "function_1__id_-1");
+    expect(listingIndex.key).toEqual({function: 1, _id: -1});
   });
 
   it("should update existing ttl index expireAfterSeconds value", async () => {
     await logService.upsertTTLIndex(10);
 
     let indexes = await logService._coll.listIndexes().toArray();
-    expect(indexes.length).toEqual(2);
+    expect(indexes.length).toEqual(3);
 
     let ttlIndex = indexes.find(index => index.name == "created_at_1");
     expect(ttlIndex.expireAfterSeconds).toEqual(10);

--- a/packages/api/function/runtime/io/package.json
+++ b/packages/api/function/runtime/io/package.json
@@ -10,6 +10,7 @@
     }
   },
   "dependencies": {
+    "@nestjs/common": "^10.4.22",
     "@spica-server/database": "workspace:*",
     "@spica-server/function-runtime-logger": "workspace:*",
     "@spica-server/interface-function-runtime": "workspace:*"

--- a/packages/api/function/runtime/io/src/database.ts
+++ b/packages/api/function/runtime/io/src/database.ts
@@ -3,9 +3,12 @@ import {PassThrough, Transform, Writable} from "stream";
 import {StandartStream} from "./standart_stream.js";
 import {getLogs} from "@spica-server/function-runtime-logger";
 import {StreamOptions, LogChannels} from "@spica-server/interface-function-runtime";
+import {Logger} from "@nestjs/common";
 
 export class DatabaseOutput extends StandartStream {
   private collection: Collection;
+  private readonly logger = new Logger(DatabaseOutput.name);
+
   constructor(private db: DatabaseService) {
     super();
     this.collection = this.db.collection("function_logs");
@@ -15,26 +18,28 @@ export class DatabaseOutput extends StandartStream {
     const createTransform = (channel: LogChannels) => {
       return new Transform({
         transform: (data, _, callback) => {
-          let message: any = Buffer.from(data).toString();
+          const message: any = Buffer.from(data).toString();
 
           const logs = getLogs(message, channel);
 
-          // don't use promise.all because order of logs is important
-          try {
-            logs.forEach(log => {
-              this.collection.insertOne({
+          for (const log of logs) {
+            this.collection
+              .insertOne({
                 function: options.functionId,
                 event_id: options.eventId,
                 channel,
                 level: log.level,
                 content: log.message,
                 created_at: new Date()
-              });
-            });
-            callback(undefined, data);
-          } catch (error) {
-            callback(error);
+              })
+              .catch(error =>
+                this.logger.error(
+                  `Failed to persist ${channel} log of function ${options.functionId}: ${error.message}`
+                )
+              );
           }
+
+          callback(undefined, data);
         }
       });
     };

--- a/packages/api/function/runtime/test/io/database.spec.ts
+++ b/packages/api/function/runtime/test/io/database.spec.ts
@@ -1,4 +1,5 @@
 import {Test} from "@nestjs/testing";
+import {Logger} from "@nestjs/common";
 import {DatabaseService, ObjectId} from "@spica-server/database";
 import {DatabaseTestingModule, stream} from "@spica-server/database-testing";
 import {DatabaseOutput} from "@spica-server/function-runtime-io";
@@ -23,6 +24,66 @@ describe("IO Database", () => {
 
   afterEach(async () => {
     await db.collection("function_logs").drop();
+  });
+
+  describe("when the log cannot be persisted", () => {
+    // The insert is fire-and-forget, so a rejection has no caller to surface it. Before this was
+    // caught it became an unhandled rejection, which terminates the process under Node >= 15.
+    let insertOne: jest.Mock;
+    let loggedErrors: string[];
+
+    beforeEach(async () => {
+      // the outer afterEach drops this collection, and these tests never actually insert into it
+      await db.createCollection("function_logs");
+
+      loggedErrors = [];
+      insertOne = jest
+        .fn()
+        .mockRejectedValue(new Error("Client must be connected before running operations"));
+      // db.collection() hands back a new instance per call, so the failure has to be injected at
+      // the seam DatabaseOutput reads from in its constructor.
+      jest.spyOn(db, "collection").mockReturnValue({insertOne} as any);
+      jest
+        .spyOn(Logger.prototype, "error")
+        .mockImplementation((message: string) => loggedErrors.push(message));
+      dbOutput = new DatabaseOutput(db);
+    });
+
+    afterEach(() => jest.restoreAllMocks());
+
+    it("should not emit an unhandled rejection", async () => {
+      const unhandled: unknown[] = [];
+      const onUnhandled = (reason: unknown) => unhandled.push(reason);
+      process.on("unhandledRejection", onUnhandled);
+
+      const [stdout] = dbOutput.create({eventId: "event", functionId: "1"});
+      stdout.write(Buffer.from("this is my message"));
+      await sleep(1000);
+
+      process.off("unhandledRejection", onUnhandled);
+
+      expect(insertOne).toHaveBeenCalled();
+      expect(unhandled).toEqual([]);
+    });
+
+    it("should report the failure instead of swallowing it", async () => {
+      const [stdout] = dbOutput.create({eventId: "event", functionId: "1"});
+      stdout.write(Buffer.from("this is my message"));
+      await sleep(1000);
+
+      expect(loggedErrors).toEqual([
+        "Failed to persist stdout log of function 1: Client must be connected before running operations"
+      ]);
+    });
+
+    it("should keep the stream flowing so the function is not blocked", async () => {
+      const [stdout] = dbOutput.create({eventId: "event", functionId: "1"});
+      const written = await new Promise<Error>(resolve =>
+        stdout.write(Buffer.from("this is my message"), err => resolve(err))
+      );
+
+      expect(written).toEqual(null);
+    });
   });
 
   it("should write stdout to collection", done => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9602,6 +9602,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@spica-server/function-runtime-io@workspace:packages/api/function/runtime/io"
   dependencies:
+    "@nestjs/common": "npm:^10.4.22"
     "@spica-server/database": "workspace:*"
     "@spica-server/function-runtime-logger": "workspace:*"
     "@spica-server/interface-function-runtime": "workspace:*"


### PR DESCRIPTION
Two independent changes to the function log path, found while investigating a 150s slow query from a running server.

## 1. Log listing: 150s → milliseconds

The pipeline ran `$match` → `$lookup` → `$unwind` → `$sort` → `$limit`. Because the join came first, it resolved a function name for **every log in the range**, then blocking-sorted the whole set to return 100 rows.

The captured slow query, over a 24-hour window on a collection taking ~1M logs/day:

```
keysExamined: 1043542   docsExamined: 1043542   nreturned: 100
bytesRead: 1.99GB       cpuNanos: 60.4s         durationMillis: 150075
```

Moving `$sort`/`$skip`/`$limit` ahead of the `$lookup` lets the `_id` index serve the sort directly and joins only the page returned. Measured against a real mongod on 200k logs — a fifth of a day's volume:

| | before | after |
|---|---|---|
| no filter | 4577ms, 200,000 docs examined | **4ms, 100 docs** |
| function filter | 927ms, 40,000 docs | **4ms, 100 docs** |

The 2GB read is worth calling out separately: WiredTiger's cache is ~50% of RAM, so a couple of concurrent log views would evict the working set for buckets and everything else. This likely helps API-wide p99, not just this endpoint.

### Index `{function: 1, _id: -1}`

A no-op when logs are spread evenly across functions, so it's justified by the skewed case: filtering a **low-volume** function while a noisy one dominates examined 100,000 docs to fill a page, and now examines 100. Measured as free on the write path at 1M inserts/day. It also covers the `clearLogs` delete filter.

### Behaviour fixes carried along

`$unwind` was non-preserving, silently dropping logs whose function had been deleted. Harmless while the lookup ran before `$limit`; it would become short pages now that it runs after. It now preserves them and falls back to the raw id.

The join now uses `localField`/`foreignField` to match the other `$lookup` call sites (`activity/src/pipeline.builder.ts`, `function/src/pipeline.builder.ts`). **Note for reviewers:** `$lookup` does not coerce types and logs store `function` as a *string* while `function._id` is an *ObjectId*, so the conversion needs its own `$set`. Without it the join silently matches nothing rather than erroring — verified: the naive swap resolves 0/100 names.

(The `let`/`pipeline`/`$expr` form it replaces was *not* a performance problem — it already used the `_id` index. This is a consistency change.)

### Tests

The pipeline had no coverage at all, which is how the stage ordering regressed unnoticed. Adds `log.controller.spec.ts`: name resolution, orphaned logs, limit-hits-newest, paging, filtering.

## 2. API crash when a log fails to persist

`DatabaseOutput` fires `insertOne` without awaiting, so a rejection has no caller. There is no `unhandledRejection` handler anywhere in the API and the runner is Node 22, where an unhandled rejection **terminates the process** — so a transient database failure while any function is logging takes the whole API down. Reproduced: exit code 1.

The `try/catch` around it never helped — `insertOne` is async, so its throw always becomes a rejection and never reaches the `catch`.

Now a `.catch()` reports the failure. Losing a log line is survivable; a database blip killing the API is not.

### Why it stays fire-and-forget

Awaiting pushes database latency back onto the function's stdout as backpressure: **~10,000 logs/sec unawaited vs ~155 awaited**. Ordering doesn't depend on awaiting either — the driver assigns `_id` at call time, verified with 500 concurrent inserts reading back in exact order.

### Why not `callback(error)`

Both shapes still crash — it moves the crash rather than fixing it:

- From the async `.catch()`: `callback(undefined, data)` already ran synchronously, so this is a second invocation → `ERR_MULTIPLE_CALLBACK` → unhandled `'error'` event → crash.
- Restructured to `await` first: emits `'error'` on a stream nothing attaches a listener to (`worker.attach()` only pipes, and `pipe()` doesn't forward destination errors) → crash. It also *destroys* the function's stdout pipe, losing every subsequent log line rather than one.

### Tests

Three tests covering no-unhandled-rejection, the error being reported, and the stream staying unblocked. Verified non-vacuous: all three fail with the `.catch()` removed.

## Known limitations

- A sustained outage logs one error line per failed insert with no throttling (~12/sec at this volume).
- Benchmarks ran on mongod 7.0.24 (`mongodb-memory-server`); the production slow log shows 8.0 fields. Index eligibility only improved after 5.0, so 8.0 won't be worse, but it wasn't verified directly.
- `@nestjs/common` added to `runtime/io/package.json`, which was previously framework-free. `@spica-server/database` already depends on it and every sibling using `Logger` declares it the same way.

## Not addressed (measured, deliberately skipped)

- **Batching log inserts** — looks like a 90x win, but that measures *awaited* inserts. In the real fire-and-forget shape it's 1.4x (10,137 → 14,535/sec) against a ~12/sec workload. Not a bottleneck.
- **Deep `$skip`** — 82ms at skip=150k; cursor pagination would be 4ms. Only matters if users page deep.
- **`content` regex** — ~250ms per 200k scanned when it matches nothing. No index can serve substring regex.

## Test plan

- `yarn nx test api/function/log` — 19 passed
- `yarn nx test api/function/runtime` — 54 passed
- `yarn nx test api/function` — passed, plus 12 dependent tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)