### PR TITLE
fix(function): count Initial workers as pending-fresh to stop over-spawn

### DIFF
--- a/packages/api/function/scheduler/src/scheduler.ts
+++ b/packages/api/function/scheduler/src/scheduler.ts
@@ -295,7 +295,9 @@ export class Scheduler implements OnModuleInit, OnModuleDestroy {
       w => w.state == WorkerState.Warm || w.state == WorkerState.Warming
     ).length;
     const activated = workers.length - initial - fresh - warm;
-    const superseded = workers.filter(w => w.isSuperseded && w.state != WorkerState.Outdated).length;
+    const superseded = workers.filter(
+      w => w.isSuperseded && w.state != WorkerState.Outdated
+    ).length;
 
     return {
       activated: activated,
@@ -742,7 +744,15 @@ export class Scheduler implements OnModuleInit, OnModuleDestroy {
   }
 
   private scaleWorkers() {
-    const hasFreshWorker = Array.from(this.workers.values()).find(worker => worker.isFresh());
+    // Count Initial workers as pending-fresh: spawnWorker() returns a worker that stays in Initial
+    // for the whole async boot+subscribe window before it graduates to Fresh. Ignoring them here
+    // makes every scaleWorkers() call during that window spawn another standby, and since nothing
+    // trims Fresh workers at runtime the surplus lingers for the process lifetime. Warm/replacement
+    // spawns leave Initial synchronously (markAsWarming), so Initial only ever means a booting
+    // generic worker.
+    const hasFreshWorker = Array.from(this.workers.values()).find(
+      worker => worker.isFresh() || worker.state == WorkerState.Initial
+    );
 
     if (hasFreshWorker) {
       return;

--- a/packages/api/function/scheduler/src/scheduler.ts
+++ b/packages/api/function/scheduler/src/scheduler.ts
@@ -744,12 +744,6 @@ export class Scheduler implements OnModuleInit, OnModuleDestroy {
   }
 
   private scaleWorkers() {
-    // Count Initial workers as pending-fresh: spawnWorker() returns a worker that stays in Initial
-    // for the whole async boot+subscribe window before it graduates to Fresh. Ignoring them here
-    // makes every scaleWorkers() call during that window spawn another standby, and since nothing
-    // trims Fresh workers at runtime the surplus lingers for the process lifetime. Warm/replacement
-    // spawns leave Initial synchronously (markAsWarming), so Initial only ever means a booting
-    // generic worker.
     const hasFreshWorker = Array.from(this.workers.values()).find(
       worker => worker.isFresh() || worker.state == WorkerState.Initial
     );

--- a/packages/api/function/scheduler/test/scheduler.spec.ts
+++ b/packages/api/function/scheduler/test/scheduler.spec.ts
@@ -177,6 +177,28 @@ describe("Scheduler", () => {
     expect(spawnSpy).toHaveBeenCalledTimes(0);
   });
 
+  it("should not spawn a second fresh worker while a spawned one is still Initial", () => {
+    // A spawned worker sits in Initial for its whole async boot+subscribe window before it
+    // graduates to Fresh. scaleWorkers must treat that pending worker as the standby, otherwise
+    // every call during the window spawns another. Since nothing trims Fresh workers at runtime,
+    // that surplus lingers for the process lifetime (observed as a fresh count stuck at ~6).
+    scheduler.workers.clear();
+
+    scheduler["scaleWorkers"]();
+    expect(allWorkers().length).toEqual(1);
+    const [[, pending]] = allWorkers();
+    expect(pending.state).toEqual(WorkerState.Initial);
+
+    // Simulate scaleWorkers firing repeatedly during a burst before the pending worker subscribes.
+    spawnSpy.mockReset();
+    scheduler["scaleWorkers"]();
+    scheduler["scaleWorkers"]();
+    scheduler["scaleWorkers"]();
+
+    expect(spawnSpy).not.toHaveBeenCalled();
+    expect(allWorkers().length).toEqual(1);
+  });
+
   it("should attach outputs when the event is enqueued", () => {
     const [[id, worker]] = freeWorkers();
     const attachSpy = jest.spyOn(worker, "attach");


### PR DESCRIPTION
## Problem

The function module's fresh (idle, generic standby) worker count settles around 6 instead of the intended 1.

`scaleWorkers()` is meant to keep exactly one `Fresh` worker on standby, but it only checked `isFresh()` (`state == Fresh`):

```ts
const hasFreshWorker = Array.from(this.workers.values()).find(worker => worker.isFresh());
if (hasFreshWorker) return;
this.spawnWorker();
```

A worker returned by `spawnWorker()` stays in `Initial` for its **whole async boot + subscribe window** — it only graduates to `Fresh` once its child process opens the event stream and calls `subscribed()`. `scaleWorkers()` runs once per event assignment inside `process()`, so during a burst (amplified by the `concurrency > 1` reuse path, where the same worker keeps taking events while `scaleWorkers` fires after each) every call in that window sees no `Fresh` worker and spawns another.

Nothing trims `Fresh` workers at runtime — `killFreeWorkers()` only runs in `onModuleDestroy` — so the over-spawned workers all graduate to `Fresh` and sit idle for the process lifetime. That's the stuck ~6.

## Fix

Treat `Initial` workers as pending-fresh in `scaleWorkers()`:

```ts
const hasFreshWorker = Array.from(this.workers.values()).find(
  worker => worker.isFresh() || worker.state == WorkerState.Initial
);
```

`Initial` unambiguously means a booting generic worker here: warm and replacement spawns leave `Initial` synchronously via `markAsWarming()` right after `spawnWorker()`, so they're never counted by mistake.

## Test

Added a regression test asserting that repeated `scaleWorkers()` calls while a spawned worker is still `Initial` do not spawn additional workers. Full scheduler suite passes (66/66).

🤖 Generated with [Claude Code](https://claude.com/claude-code)