### PR TITLE
feat(env_var,secret): add server-managed updated_at

### DIFF
--- a/packages/api/env_var/src/crud.ts
+++ b/packages/api/env_var/src/crud.ts
@@ -46,17 +46,29 @@ export function findOne(evs: EnvVarService, id: ObjectId): Promise<EnvVar> {
   return evs.findOne({_id: id});
 }
 
-export async function insert(evs: EnvVarService, envVar: EnvVar) {
-  if (envVar._id) {
-    envVar._id = new ObjectId(envVar._id);
+export async function insert(evs: EnvVarService, body: EnvVar) {
+  const envVar: EnvVar = {
+    key: body.key,
+    value: body.value,
+    updated_at: new Date()
+  };
+
+  if (body._id) {
+    envVar._id = new ObjectId(body._id);
   }
+
   await evs.insertOne(envVar);
   return envVar;
 }
 
-export async function replace(evs: EnvVarService, envVar: EnvVar) {
-  const _id = new ObjectId(envVar._id);
-  delete envVar._id;
+export async function replace(evs: EnvVarService, body: EnvVar) {
+  const _id = new ObjectId(body._id);
+
+  const envVar = {
+    key: body.key,
+    value: body.value,
+    updated_at: new Date()
+  };
 
   const currentSchema = await evs.findOneAndReplace({_id}, envVar, {
     returnDocument: ReturnDocument.AFTER

--- a/packages/api/env_var/src/schema.json
+++ b/packages/api/env_var/src/schema.json
@@ -20,6 +20,5 @@
       "type": "string",
       "examples": ["123abc", "true"]
     }
-  },
-  "additionalProperties": false
+  }
 }

--- a/packages/api/env_var/test/asset.e2e.spec.ts
+++ b/packages/api/env_var/test/asset.e2e.spec.ts
@@ -51,12 +51,16 @@ describe("EnvVar", () => {
 
   afterEach(() => app.close());
 
+  function stripTimestamps({updated_at, ...rest}) {
+    return rest;
+  }
+
   function getEnvVars() {
-    return req.get("env-var").then(r => r.body);
+    return req.get("env-var").then(r => r.body.map(stripTimestamps));
   }
 
   function getEnvVar(id) {
-    return req.get(`env-var/${id}`).then(r => r.body);
+    return req.get(`env-var/${id}`).then(r => stripTimestamps(r.body));
   }
 
   let envVarv1Resource;

--- a/packages/api/env_var/test/controller.spec.ts
+++ b/packages/api/env_var/test/controller.spec.ts
@@ -38,7 +38,7 @@ describe("Environment Variable", () => {
       await req.post("/env-var", envVar);
 
       const res = await req.get("/env-var");
-      const bodyWithoutIds = res.body.map(({_id, ...rest}) => rest);
+      const bodyWithoutIds = res.body.map(({_id, updated_at, ...rest}) => rest);
       expect(bodyWithoutIds).toEqual([envVar]);
     });
 
@@ -56,7 +56,7 @@ describe("Environment Variable", () => {
         limit: 1,
         sort: JSON.stringify({value: -1})
       });
-      const bodySkip = resSkip.body.map(({_id, ...rest}) => rest);
+      const bodySkip = resSkip.body.map(({_id, updated_at, ...rest}) => rest);
       expect(bodySkip).toEqual([envVar1]);
     });
 
@@ -72,7 +72,10 @@ describe("Environment Variable", () => {
       ]);
 
       const res = await req.get(`/env-var`, {paginate: true, sort: JSON.stringify({_id: -1})});
-      const bodyWithoutIds = {...res.body, data: res.body.data.map(({_id, ...rest}) => rest)};
+      const bodyWithoutIds = {
+        ...res.body,
+        data: res.body.data.map(({_id, updated_at, ...rest}) => rest)
+      };
       expect(bodyWithoutIds).toEqual({
         meta: {total: 3},
         data: [envVar3, envVar2, envVar1]
@@ -91,12 +94,12 @@ describe("Environment Variable", () => {
       ]);
 
       const res = await req.get(`/env-var`, {filter: JSON.stringify({key: "ENV_KEY_3"})});
-      const bodyWithoutIds = res.body.map(({_id, ...rest}) => rest);
+      const bodyWithoutIds = res.body.map(({_id, updated_at, ...rest}) => rest);
       expect(bodyWithoutIds.length).toBe(1);
       expect(bodyWithoutIds).toEqual([envVar3]);
 
       const res2 = await req.get(`/env-var`, {filter: JSON.stringify({value: "val_2"})});
-      const bodyWithoutIds2 = res2.body.map(({_id, ...rest}) => rest);
+      const bodyWithoutIds2 = res2.body.map(({_id, updated_at, ...rest}) => rest);
       expect(bodyWithoutIds2).toEqual([envVar2]);
     });
   });
@@ -109,6 +112,7 @@ describe("Environment Variable", () => {
 
       const res = await req.get(`/env-var/${body._id}`);
       delete res.body._id;
+      delete res.body.updated_at;
       expect(res.body).toEqual(envVar);
     });
   });
@@ -125,7 +129,32 @@ describe("Environment Variable", () => {
 
       const res = await req.get(`/env-var/${body._id}`);
       delete res.body._id;
+      delete res.body.updated_at;
       expect(res.body).toEqual(envVar);
+    });
+
+    it("should set updated_at on insert", async () => {
+      const {body} = await req.post("/env-var", envVar);
+      expect(body.updated_at).not.toBeFalsy();
+      expect(new Date(body.updated_at).toString()).not.toBe("Invalid Date");
+    });
+
+    it("should ignore client-sent updated_at and unknown fields", async () => {
+      const clientTimestamp = new Date("2000-01-01T00:00:00.000Z").toISOString();
+      const {body, statusCode} = await req.post("/env-var", {
+        key: "ENV_KEY",
+        value: "123",
+        updated_at: clientTimestamp,
+        injected: "should-be-dropped"
+      });
+
+      expect(statusCode).toBe(201);
+      expect(body.updated_at).not.toBe(clientTimestamp);
+      expect(body.injected).toBeUndefined();
+
+      const res = await req.get(`/env-var/${body._id}`);
+      expect(res.body.injected).toBeUndefined();
+      expect(Object.keys(res.body).sort()).toEqual(["_id", "key", "updated_at", "value"]);
     });
 
     it("should return validation errors", async () => {
@@ -155,6 +184,19 @@ describe("Environment Variable", () => {
       expect(res.body._id).not.toBeFalsy();
       expect(res.body.key).toBe("ENV_KEY");
       expect(res.body.value).toBe("456");
+    });
+
+    it("should advance updated_at on update", async () => {
+      const {body} = await req.post("/env-var", {key: "ENV_KEY", value: "123"});
+
+      const {body: updated} = await req.put(`/env-var/${body._id}`, {
+        key: "ENV_KEY",
+        value: "456"
+      });
+
+      expect(new Date(updated.updated_at).getTime()).toBeGreaterThanOrEqual(
+        new Date(body.updated_at).getTime()
+      );
     });
 
     it("should not update and return 404", async () => {

--- a/packages/api/function/test/controller.spec.ts
+++ b/packages/api/function/test/controller.spec.ts
@@ -275,7 +275,8 @@ describe("Function Controller", () => {
       await request.put(`/function/${inserted._id}/secret/${secret._id}`);
 
       const found = await request.get(`/function/${inserted._id}`).then(r => r.body);
-      expect(found.secrets).toEqual([{_id: secret._id, key: "MY_SECRET"}]);
+      const secrets = found.secrets.map(({updated_at, ...rest}) => rest);
+      expect(secrets).toEqual([{_id: secret._id, key: "MY_SECRET"}]);
       expect(found.secrets[0].value).toBeUndefined();
     });
   });

--- a/packages/api/secret/src/crud.ts
+++ b/packages/api/secret/src/crud.ts
@@ -61,7 +61,8 @@ export async function findOne(ss: SecretService, id: ObjectId): Promise<HiddenSe
 export async function insert(ss: SecretService, body: DecryptedSecret): Promise<HiddenSecret> {
   const secret: Secret = {
     key: body.key,
-    value: encrypt(body.value, ss.encryptionSecret)
+    value: encrypt(body.value, ss.encryptionSecret),
+    updated_at: new Date()
   };
 
   if (body._id) {
@@ -82,7 +83,7 @@ export async function replace(
 
   const result = await ss.findOneAndReplace(
     {_id: id},
-    {_id: id, key: body.key, value: encrypted},
+    {_id: id, key: body.key, value: encrypted, updated_at: new Date()},
     {returnDocument: ReturnDocument.AFTER}
   );
 

--- a/packages/api/secret/src/schema.json
+++ b/packages/api/secret/src/schema.json
@@ -20,6 +20,5 @@
       "type": "string",
       "examples": ["my-secret-value"]
     }
-  },
-  "additionalProperties": false
+  }
 }

--- a/packages/api/secret/test/controller.spec.ts
+++ b/packages/api/secret/test/controller.spec.ts
@@ -159,6 +159,50 @@ describe("Secret", () => {
     });
   });
 
+  describe("updated_at", () => {
+    it("should set updated_at on insert and return it while value stays hidden", async () => {
+      const {body} = await req.post("/secret", {key: "TS_KEY", value: "val"});
+
+      expect(body.updated_at).not.toBeFalsy();
+      expect(body.value).toBeUndefined();
+
+      const res = await req.get(`/secret/${body._id}`);
+      expect(res.body.updated_at).not.toBeFalsy();
+      expect(res.body.value).toBeUndefined();
+    });
+
+    it("should advance updated_at on update", async () => {
+      const {body: inserted} = await req.post("/secret", {key: "TS_KEY", value: "val"});
+
+      const {body: updated} = await req.put(`/secret/${inserted._id}`, {
+        key: "TS_KEY",
+        value: "val2"
+      });
+
+      expect(new Date(updated.updated_at).getTime()).toBeGreaterThanOrEqual(
+        new Date(inserted.updated_at).getTime()
+      );
+    });
+
+    it("should ignore client-sent updated_at and unknown fields", async () => {
+      const clientTimestamp = new Date("2000-01-01T00:00:00.000Z").toISOString();
+      const {body, statusCode} = await req.post("/secret", {
+        key: "TS_KEY",
+        value: "val",
+        updated_at: clientTimestamp,
+        injected: "should-be-dropped"
+      });
+
+      expect(statusCode).toBe(201);
+      expect(body.updated_at).not.toBe(clientTimestamp);
+      expect(body.injected).toBeUndefined();
+
+      const res = await req.get(`/secret/${body._id}`);
+      expect(res.body.injected).toBeUndefined();
+      expect(Object.keys(res.body).sort()).toEqual(["_id", "key", "updated_at"]);
+    });
+  });
+
   describe("delete", () => {
     it("should delete secret", async () => {
       const {body} = await req.post("/secret", {key: "TO_DELETE", value: "val"});

--- a/packages/api/secret/test/crud.spec.ts
+++ b/packages/api/secret/test/crud.spec.ts
@@ -60,6 +60,28 @@ describe("Secret CRUD", () => {
       expect(result.key).toBe("CUSTOM_ID_KEY");
       expect((result as any).value).toBeUndefined();
     });
+
+    it("should set updated_at as a Date on insert", async () => {
+      const result = await CRUD.insert(ss, {key: "TS_KEY", value: "val"});
+
+      const raw = await ss.findOne({_id: result._id});
+      expect(raw.updated_at).toBeInstanceOf(Date);
+    });
+
+    it("should ignore client-sent updated_at and extra fields", async () => {
+      const clientTimestamp = new Date("2000-01-01T00:00:00.000Z");
+      const result = await CRUD.insert(ss, {
+        key: "TS_KEY",
+        value: "val",
+        updated_at: clientTimestamp,
+        injected: "nope"
+      } as any);
+
+      const raw = await ss.findOne({_id: result._id});
+      expect(raw.updated_at).not.toEqual(clientTimestamp);
+      expect((raw as any).injected).toBeUndefined();
+      expect(Object.keys(raw).sort()).toEqual(["_id", "key", "updated_at", "value"]);
+    });
   });
 
   describe("findOne", () => {
@@ -174,6 +196,17 @@ describe("Secret CRUD", () => {
       await expect(CRUD.replace(ss, nonExistentId, {key: "KEY", value: "val"})).rejects.toThrow(
         NotFoundException
       );
+    });
+
+    it("should refresh updated_at on replace", async () => {
+      const inserted = await CRUD.insert(ss, {key: "TS_KEY", value: "old"});
+      const before = await ss.findOne({_id: inserted._id});
+
+      await CRUD.replace(ss, inserted._id, {key: "TS_KEY", value: "new"});
+      const after = await ss.findOne({_id: inserted._id});
+
+      expect(after.updated_at).toBeInstanceOf(Date);
+      expect(after.updated_at.getTime()).toBeGreaterThanOrEqual(before.updated_at.getTime());
     });
   });
 

--- a/packages/interface/env_var/src/index.ts
+++ b/packages/interface/env_var/src/index.ts
@@ -1,6 +1,7 @@
 import {ObjectId} from "@spica-server/database";
 export interface EnvVar {
-  _id: ObjectId;
+  _id?: ObjectId;
   key: string;
   value: string;
+  updated_at?: Date;
 }

--- a/packages/interface/secret/src/index.ts
+++ b/packages/interface/secret/src/index.ts
@@ -5,6 +5,7 @@ export interface Secret {
   _id?: ObjectId;
   key: string;
   value: EncryptedData<false>;
+  updated_at?: Date;
 }
 
 export type DecryptedSecret = Omit<Secret, "value"> & {value: string};

--- a/packages/sync/src/modules/env-var.ts
+++ b/packages/sync/src/modules/env-var.ts
@@ -1,5 +1,11 @@
 import {diffSchemaFields, renderSchemaDetail} from "../planner";
-import {deleteLocalSchema, readLocalSchemas, sanitizeSlug, unwrapList, writeLocalSchema} from "../fs-utils";
+import {
+  deleteLocalSchema,
+  readLocalSchemas,
+  sanitizeSlug,
+  unwrapList,
+  writeLocalSchema
+} from "../fs-utils";
 import {ResourceModule} from "../types";
 
 interface EnvVar {
@@ -9,7 +15,8 @@ interface EnvVar {
   [key: string]: unknown;
 }
 
-const IGNORED_FIELDS = ["_id"];
+// "updated_at" is server-managed; ignoring it avoids permanent false-positive diffs.
+const IGNORED_FIELDS = ["_id", "updated_at"];
 
 export const envVarModule: ResourceModule<EnvVar> = {
   name: "env-var",

--- a/packages/sync/src/modules/secret.ts
+++ b/packages/sync/src/modules/secret.ts
@@ -11,7 +11,8 @@ interface Secret {
 
 // "value" is excluded from diff/render: the API never returns it (projected out server-side),
 // so comparing or displaying it would cause permanent false-positives and secret leakage.
-const IGNORED_FIELDS = ["_id", "value"];
+// "updated_at" is server-managed, so it must be ignored for the same reason.
+const IGNORED_FIELDS = ["_id", "value", "updated_at"];
 
 export const secretModule: ResourceModule<Secret> = {
   name: "secret",

--- a/packages/sync/test/modules/other-modules.spec.ts
+++ b/packages/sync/test/modules/other-modules.spec.ts
@@ -101,6 +101,15 @@ describe("envVarModule", () => {
     expect(changed).toContain("value");
     expect(changed).not.toContain("_id");
   });
+
+  it("ignores server-managed updated_at in diffFields", () => {
+    const changed = envVarModule.diffFields(
+      {key: "K", value: "v"},
+      {key: "K", value: "v", updated_at: "2020-01-01T00:00:00.000Z"}
+    );
+    expect(changed).not.toContain("updated_at");
+    expect(changed).toHaveLength(0);
+  });
 });
 
 // ─── Secret ───────────────────────────────────────────────────────────────────
@@ -149,6 +158,14 @@ describe("secretModule", () => {
     const detail = secretModule.renderDetail(local, remote);
     const diffText = Object.values(detail).join("");
     expect(diffText).not.toContain("s3cr3t");
+  });
+
+  it("ignores server-managed updated_at in diffFields", () => {
+    const local = {key: "API_KEY", value: "s3cr3t"};
+    const remote = {key: "API_KEY", updated_at: "2020-01-01T00:00:00.000Z"};
+    const changed = secretModule.diffFields(local, remote);
+    expect(changed).not.toContain("updated_at");
+    expect(changed).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Summary

Adds an **API-managed `updated_at`** timestamp to environment variables and secrets. There is intentionally **no `created_at`** — creation time is already recoverable from `_id.getTimestamp()` (Mongo ObjectId).

The field is owned entirely by the server: the write path constructs the persisted document from **only** `_id`, `key`, `value` and stamps `updated_at = new Date()`, so anything else a client sends (including its own `updated_at`) has no effect.

## Changes

- **Schemas** — remove `"additionalProperties": false` from `env_var` and `secret` schemas. `updated_at` is deliberately **not** declared as a property, so a client can't cause a format-validation error on it; extra keys are simply dropped by the pick in the CRUD layer instead of being rejected.
- **Interfaces** — add `updated_at?: Date` to `EnvVar` and `Secret` (`HiddenSecret`/`DecryptedSecret` inherit it, so reads return it; the secret read pipeline still projects out `value`).
- **CRUD** — `insert`/`replace` for both modules build the persisted doc explicitly from `_id/key/value` and set `updated_at = new Date()` (refreshed on every update).
- **CLI sync** — add `updated_at` to `IGNORED_FIELDS` in the `env-var` and `secret` sync modules so `fetch`/`plan`/`apply` don't report a permanent spurious diff on the server-managed field.

Existing documents get `updated_at` on their next write; reads tolerate its absence until then.

## Tests

- `api/env_var` — 17 passed (insert stamps `updated_at`, update advances it, client-sent `updated_at` + unknown fields ignored; asset e2e flow adjusted)
- `api/secret` — 38 passed (controller + CRUD: stored as a `Date`, returned on read while `value` stays hidden, refreshed on replace, extras stripped)
- `sync` — 104 passed (env-var & secret `diffFields` ignore `updated_at`)

CLI builds clean (bundles the updated sync package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)