### PR TITLE
perf(webhook): replace webhook-collection change stream with in-memory dispatcher

### DIFF
--- a/packages/api/function/webhook/src/change-dispatcher.ts
+++ b/packages/api/function/webhook/src/change-dispatcher.ts
@@ -1,0 +1,9 @@
+import {Injectable, Optional} from "@nestjs/common";
+import {ClassCommander, CollectionChangeDispatcher} from "@spica-server/replication";
+
+@Injectable()
+export class WebhookChangeDispatcher extends CollectionChangeDispatcher {
+  constructor(@Optional() commander?: ClassCommander) {
+    super(commander);
+  }
+}

--- a/packages/api/function/webhook/src/index.ts
+++ b/packages/api/function/webhook/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./webhook.module.js";
 export * from "./webhook.service.js";
+export * from "./change-dispatcher.js";

--- a/packages/api/function/webhook/src/webhook.controller.ts
+++ b/packages/api/function/webhook/src/webhook.controller.ts
@@ -126,9 +126,9 @@ export class WebhookController {
   @UseGuards(AuthGuard(["IDENTITY", "APIKEY"]), ActionGuard("webhook:delete"))
   @HttpCode(HttpStatus.NO_CONTENT)
   async deleteOne(@Param("id", OBJECT_ID) id: ObjectId) {
-    const deletedCount = await this.webhookService.deleteOne({_id: id});
-    if (!deletedCount) {
-      throw new NotFoundException(`Activity with ID ${id} not found`);
+    const res = await this.webhookService.findOneAndDelete({_id: id});
+    if (!res) {
+      throw new NotFoundException(`Webhook with ID ${id} not found`);
     }
   }
 }

--- a/packages/api/function/webhook/src/webhook.module.ts
+++ b/packages/api/function/webhook/src/webhook.module.ts
@@ -4,6 +4,7 @@ import {WebhookInvoker} from "./invoker.js";
 import {SchemaResolver} from "./schema.js";
 import {WebhookController} from "./webhook.controller.js";
 import {WebhookService} from "./webhook.service.js";
+import {WebhookChangeDispatcher} from "./change-dispatcher.js";
 import {WebhookLogService} from "./log.service.js";
 import {WebhookLogController} from "./log.controller.js";
 import {WebhookOptions, WEBHOOK_OPTIONS} from "@spica-server/interface-function-webhook";
@@ -20,6 +21,7 @@ export class WebhookModule {
         SchemaResolver,
         WebhookLogService,
         WebhookService,
+        WebhookChangeDispatcher,
         {
           provide: WEBHOOK_OPTIONS,
           useValue: options

--- a/packages/api/function/webhook/src/webhook.service.ts
+++ b/packages/api/function/webhook/src/webhook.service.ts
@@ -1,12 +1,53 @@
 import {Injectable} from "@nestjs/common";
-import {BaseCollection, DatabaseService} from "@spica-server/database";
+import {
+  BaseCollection,
+  DatabaseService,
+  Filter,
+  FindOneAndDeleteOptions,
+  FindOneAndReplaceOptions,
+  OptionalUnlessRequiredId,
+  WithId
+} from "@spica-server/database";
 import {Observable} from "rxjs";
 import {Webhook, TargetChange, ChangeKind} from "@spica-server/interface-function-webhook";
+import {WebhookChangeDispatcher} from "./change-dispatcher.js";
 
 @Injectable()
 export class WebhookService extends BaseCollection<Webhook>("webhook") {
-  constructor(database: DatabaseService) {
+  constructor(
+    database: DatabaseService,
+    private readonly changeDispatcher: WebhookChangeDispatcher
+  ) {
     super(database);
+  }
+
+  async insertOne(doc: OptionalUnlessRequiredId<Webhook>): Promise<WithId<Webhook>> {
+    const result = await super.insertOne(doc);
+    this.changeDispatcher.dispatch({operationType: "insert", documentKey: {_id: result._id}});
+    return result;
+  }
+
+  async findOneAndReplace(
+    filter: Filter<Webhook>,
+    doc: Webhook,
+    options?: FindOneAndReplaceOptions
+  ): Promise<WithId<Webhook>> {
+    const result = await super.findOneAndReplace(filter, doc, options);
+    if (result) {
+      this.changeDispatcher.dispatch({operationType: "replace", documentKey: {_id: result._id}});
+    }
+    return result;
+  }
+
+  async findOneAndDelete(
+    filter: Filter<Webhook>,
+    options?: FindOneAndDeleteOptions
+  ): Promise<WithId<Webhook>> {
+    const result = await super.findOneAndDelete(filter, options);
+    if (result) {
+      this.changeDispatcher.dispatch({operationType: "delete", documentKey: {_id: result._id}});
+    }
+    return result;
   }
 
   targets(): Observable<TargetChange> {
@@ -26,7 +67,7 @@ export class WebhookService extends BaseCollection<Webhook>("webhook") {
         }
         observer.next(change);
       };
-      super.find().then(hooks => {
+      let chain = super.find().then(hooks => {
         for (const hook of hooks) {
           if (!hook.trigger.active) {
             continue;
@@ -35,22 +76,23 @@ export class WebhookService extends BaseCollection<Webhook>("webhook") {
         }
       });
 
-      const sub = this.watch([], {fullDocument: "updateLookup"}).subscribe(change => {
-        switch (change.operationType) {
-          case "replace":
-          case "update":
-            emitHook(change.fullDocument as Webhook, ChangeKind.Updated);
-            break;
-          case "insert":
-            emitHook(change.fullDocument as Webhook, ChangeKind.Added);
-            break;
-          case "delete":
-            observer.next({
-              kind: ChangeKind.Removed,
-              target: change.documentKey._id.toHexString()
-            });
-            break;
-        }
+      // Serialize processing onto a single promise chain: each event reloads the document
+      // asynchronously, so without this an insert's Added could be emitted after a later
+      // delete's Removed, leaving the invoker with a dangling target stream.
+      const sub = this.changeDispatcher.watch().subscribe(change => {
+        chain = chain.then(async () => {
+          const _id = change.documentKey._id;
+          if (change.operationType === "delete") {
+            observer.next({kind: ChangeKind.Removed, target: _id.toHexString()});
+            return;
+          }
+          const hook = await super.findOne({_id});
+          if (!hook) {
+            observer.next({kind: ChangeKind.Removed, target: _id.toHexString()});
+            return;
+          }
+          emitHook(hook, change.operationType === "insert" ? ChangeKind.Added : ChangeKind.Updated);
+        });
       });
       return () => sub.unsubscribe();
     });

--- a/packages/api/function/webhook/test/invoker.spec.ts
+++ b/packages/api/function/webhook/test/invoker.spec.ts
@@ -1,12 +1,27 @@
 import {Test, TestingModule} from "@nestjs/testing";
 import {DatabaseService, DatabaseTestingModule, stream} from "@spica-server/database-testing";
-import {WebhookService} from "@spica-server/function-webhook";
+import {WebhookService, WebhookChangeDispatcher} from "@spica-server/function-webhook";
 import {Webhook, WEBHOOK_OPTIONS} from "@spica-server/interface-function-webhook";
 import {WebhookInvoker} from "@spica-server/function-webhook/src/invoker";
 import {WebhookLogService} from "@spica-server/function-webhook/src/log.service";
 import __fetch__ from "node-fetch";
 
 jest.setTimeout(60_000);
+
+// The webhook collection is no longer watched via a change stream; WebhookService now emits
+// through an in-memory dispatcher, so target (un)registration is driven by promise resolution
+// rather than the `stream` shim. Wait on the invoker's own subscribe/unsubscribe spies to know
+// when a webhook mutation has been applied, then use the `stream` shim only for the target
+// collection stream (purpose #1), which still uses a real change stream.
+async function waitForCall(spy: jest.SpyInstance, times = 1) {
+  const start = Date.now();
+  while (spy.mock.calls.length < times) {
+    if (Date.now() - start > 20_000) {
+      throw new Error("timed out waiting for spy to be called");
+    }
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+}
 
 describe("Webhook Invoker", () => {
   let invoker: WebhookInvoker;
@@ -28,6 +43,7 @@ describe("Webhook Invoker", () => {
       providers: [
         WebhookInvoker,
         WebhookService,
+        WebhookChangeDispatcher,
         WebhookLogService,
         {
           provide: WEBHOOK_OPTIONS,
@@ -42,7 +58,6 @@ describe("Webhook Invoker", () => {
     db = module.get(DatabaseService);
     logService = module.get(WebhookLogService);
     invoker = module.get(WebhookInvoker);
-    await stream.wait();
 
     subscribeSpy = jest.spyOn(invoker, "subscribe" as never);
     unsubscribeSpy = jest.spyOn(invoker, "unsubscribe" as never);
@@ -50,8 +65,6 @@ describe("Webhook Invoker", () => {
     const nodeFetch = {fetch: __fetch__};
     fetchSpy = jest.spyOn(nodeFetch, "fetch");
     insertLogSpy = jest.spyOn(logService, "insertOne" as never).mockImplementation();
-
-    await new Promise(resolve => setTimeout(() => resolve(""), 2000));
 
     webhook = {
       title: "wh1",
@@ -79,7 +92,7 @@ describe("Webhook Invoker", () => {
 
   it("should subscribe and open a change stream against the collection", async () => {
     const {_id, ...hook} = await service.insertOne(webhook);
-    await stream.change.wait();
+    await waitForCall(subscribeSpy);
     const subsequentStream = await stream.wait();
     expect(subscribeSpy).toHaveBeenCalledTimes(1);
     expect(subscribeSpy).toHaveBeenCalledWith(_id.toHexString(), hook);
@@ -94,25 +107,29 @@ describe("Webhook Invoker", () => {
 
   it("should unsubscribe after the webhook has deleted", async () => {
     const hook = await service.insertOne(webhook);
-    await stream.change.wait();
-    await service.deleteOne({_id: hook._id});
-    await stream.change.wait();
+    await waitForCall(subscribeSpy);
+    await service.findOneAndDelete({_id: hook._id});
+    await waitForCall(unsubscribeSpy);
     expect(unsubscribeSpy).toHaveBeenCalledTimes(1);
     expect(unsubscribeSpy).toHaveBeenCalledWith(hook._id.toHexString());
   });
 
   it("should unsubscribe after the webhook has disabled", async () => {
     const hook = await service.insertOne(webhook);
-    await stream.change.wait();
-    await service.updateOne({_id: hook._id}, {$unset: {"trigger.active": ""}});
-    await stream.change.wait();
+    await waitForCall(subscribeSpy);
+    await service.findOneAndReplace(
+      {_id: hook._id},
+      {...webhook, trigger: {...webhook.trigger, active: false}}
+    );
+    await waitForCall(unsubscribeSpy);
     expect(unsubscribeSpy).toHaveBeenCalledTimes(1);
     expect(unsubscribeSpy).toHaveBeenCalledWith(hook._id.toHexString());
   });
 
   it("should report changes from the database", async () => {
     await service.insertOne(webhook);
-    await stream.change.wait();
+    await waitForCall(subscribeSpy);
+    await stream.wait();
     stream.change.next();
     const doc = await db.collection("stream_coll").insertOne({doc: "fromdb"});
     await stream.change.wait();
@@ -134,7 +151,8 @@ describe("Webhook Invoker", () => {
   it("should report changes from the database with mapping", async () => {
     webhook.body = "{{{toJSON document}}}";
     await service.insertOne(webhook);
-    await stream.change.wait();
+    await waitForCall(subscribeSpy);
+    await stream.wait();
     stream.change.next();
     const doc = await db.collection("stream_coll").insertOne({doc: "fromdb"});
     await stream.change.wait();
@@ -151,7 +169,8 @@ describe("Webhook Invoker", () => {
 
   it("should insert a log when hook has been invoked", async () => {
     const hook = await service.insertOne(webhook);
-    await stream.change.wait();
+    await waitForCall(subscribeSpy);
+    await stream.wait();
     stream.change.next();
     const doc = await db.collection("stream_coll").insertOne({doc: "fromdb"});
     await stream.change.wait();
@@ -190,7 +209,8 @@ describe("Webhook Invoker", () => {
   it("should insert log when webhook body compilation failed", async () => {
     webhook.body = "{{{document.title}}}";
     const hook = await service.insertOne(webhook);
-    await stream.change.wait();
+    await waitForCall(subscribeSpy);
+    await stream.wait();
     stream.change.next();
     const doc = await db.collection("stream_coll").insertOne({doc: "fromdb"});
     await stream.change.wait();

--- a/packages/api/function/webhook/test/webhook.controller.spec.ts
+++ b/packages/api/function/webhook/test/webhook.controller.spec.ts
@@ -3,7 +3,7 @@ import {Test, TestingModule} from "@nestjs/testing";
 import {SchemaModule} from "@spica-server/core-schema";
 import {CoreTestingModule, Request} from "@spica-server/core-testing";
 import {DatabaseService, DatabaseTestingModule, ObjectId} from "@spica-server/database-testing";
-import {WebhookService} from "@spica-server/function-webhook";
+import {WebhookService, WebhookChangeDispatcher} from "@spica-server/function-webhook";
 import {Webhook} from "@spica-server/interface-function-webhook";
 import {SchemaResolver} from "@spica-server/function-webhook/src/schema";
 import {WebhookController} from "@spica-server/function-webhook/src/webhook.controller";
@@ -29,6 +29,7 @@ describe("Webhook Controller", () => {
       controllers: [WebhookController],
       providers: [
         WebhookService,
+        WebhookChangeDispatcher,
         SchemaResolver,
         WebhookInvoker,
         WebhookLogService,

--- a/packages/api/function/webhook/test/webhook.service.spec.ts
+++ b/packages/api/function/webhook/test/webhook.service.spec.ts
@@ -1,6 +1,6 @@
 import {Test, TestingModule} from "@nestjs/testing";
-import {DatabaseTestingModule, stream} from "@spica-server/database-testing";
-import {WebhookService} from "@spica-server/function-webhook";
+import {DatabaseTestingModule} from "@spica-server/database-testing";
+import {WebhookService, WebhookChangeDispatcher} from "@spica-server/function-webhook";
 import {Webhook, ChangeKind} from "@spica-server/interface-function-webhook";
 import {bufferCount, bufferTime, take} from "rxjs/operators";
 
@@ -12,7 +12,7 @@ describe("Webhook Service", () => {
   beforeEach(async () => {
     module = await Test.createTestingModule({
       imports: [DatabaseTestingModule.replicaSet()],
-      providers: [WebhookService]
+      providers: [WebhookService, WebhookChangeDispatcher]
     }).compile();
     service = module.get(WebhookService);
 
@@ -85,7 +85,7 @@ describe("Webhook Service", () => {
         });
         done();
       });
-    stream.wait().then(() => service.insertOne(webhook).then(_hook => (hook = _hook)));
+    service.insertOne(webhook).then(_hook => (hook = _hook));
   });
 
   it("should report removed hook", done => {
@@ -113,7 +113,7 @@ describe("Webhook Service", () => {
           done();
         });
 
-      stream.wait().then(() => service.deleteOne({_id: hook._id}));
+      service.findOneAndDelete({_id: hook._id});
     });
   });
 
@@ -141,9 +141,10 @@ describe("Webhook Service", () => {
           ]);
           done();
         });
-      stream
-        .wait()
-        .then(() => service.updateOne({_id: hook._id}, {$set: {"trigger.active": false}}));
+      service.findOneAndReplace(
+        {_id: hook._id},
+        {...webhook, trigger: {...webhook.trigger, active: false}}
+      );
     });
   });
 });

--- a/packages/api/function/webhook/tsconfig.json
+++ b/packages/api/function/webhook/tsconfig.json
@@ -3,6 +3,9 @@
   "include": ["src/**/*.ts", "index.ts"],
   "references": [
     {
+      "path": "../../replication"
+    },
+    {
       "path": "../../passport/guard"
     },
     {


### PR DESCRIPTION
## Context

Webhooks used MongoDB change streams for **two** purposes:

1. **Target-collection streams** — watch the user's data collection to fire the HTTP webhook. Inherent to the feature; **left unchanged**.
2. **A stream on the `webhook` collection itself** — watch for webhook create/update/delete so the invoker can (re)register/unregister target streams.

Purpose #2 is redundant infrastructure: the **only** writers to the `webhook` collection are `WebhookController`'s endpoints, all of which go through `WebhookService`. This PR replaces that change stream with the established in-process pub/sub pattern (`CollectionChangeDispatcher`) — exactly what `env_var`, `secret`, and `bucket` already do.

**Result:** one fewer active change stream per API replica, with equivalent behavior. Multi-replica correctness is preserved via the optional `ClassCommander` SYNC broadcast.

## Changes

- **New `WebhookChangeDispatcher`** (`change-dispatcher.ts`) — subclass of `CollectionChangeDispatcher`, provided in `WebhookModule.forRoot`.
- **`WebhookService`** — dispatches on `insertOne` / `findOneAndReplace` / `findOneAndDelete`; `targets()` rebuilt on top of `changeDispatcher.watch()`, reloading the document via `findOne` (the event carries only `_id`, like `BucketService.watchBucket`).
  - Reloads are **serialized on a promise chain** so an insert's `Added` can never be emitted after a later delete's `Removed` (which would otherwise leave the invoker with a dangling target stream).
- **`WebhookController`** — delete endpoint switched from `deleteOne` (count only) to `findOneAndDelete` (returns the doc) so the `_id` is available to dispatch.
- **Tests** — provide `WebhookChangeDispatcher`; mutations now go through the dispatching service methods; the invoker spec's `stream`-shim coordination (which depended on the removed webhook stream) is replaced with a `waitForCall` helper on the invoker's own subscribe/unsubscribe spies.
- **`tsconfig.json`** — `nx sync` added the new `@spica-server/replication` project reference.

## Verification

- `yarn nx test api/function/webhook` → **33 passed, 6 suites**
- `yarn build:api` → compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)