### PR TITLE
perf(preference): replace preferences change stream with in-memory dispatcher

### DIFF
--- a/packages/api/preference/services/index.ts
+++ b/packages/api/preference/services/index.ts
@@ -1,1 +1,2 @@
 export {PreferenceService} from "./src/preference.service.js";
+export {PreferenceChangeDispatcher} from "./src/change-dispatcher.js";

--- a/packages/api/preference/services/src/change-dispatcher.ts
+++ b/packages/api/preference/services/src/change-dispatcher.ts
@@ -1,0 +1,9 @@
+import {Injectable, Optional} from "@nestjs/common";
+import {ClassCommander, CollectionChangeDispatcher} from "@spica-server/replication";
+
+@Injectable()
+export class PreferenceChangeDispatcher extends CollectionChangeDispatcher {
+  constructor(@Optional() commander?: ClassCommander) {
+    super(commander);
+  }
+}

--- a/packages/api/preference/services/src/preference.service.ts
+++ b/packages/api/preference/services/src/preference.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from "@nestjs/common";
+import {Injectable, Logger} from "@nestjs/common";
 import {
   BaseCollection,
   Collection,
@@ -17,6 +17,7 @@ import {PreferenceChangeDispatcher} from "./change-dispatcher.js";
 
 @Injectable()
 export class PreferenceService extends BaseCollection("preferences") {
+  private readonly logger = new Logger(PreferenceService.name);
   private _defaults = new Map<string, Preference>();
 
   constructor(
@@ -31,18 +32,31 @@ export class PreferenceService extends BaseCollection("preferences") {
     {propagateOnStart}: {propagateOnStart: boolean} = {propagateOnStart: false}
   ): Observable<T> {
     return new Observable(observer => {
+      const onFailure = (error: unknown) =>
+        this.logger.error(
+          `preference watch (${scope}) failed: ${error instanceof Error ? error.message : error}`
+        );
+
       // Serialize onto a single promise chain: each event reloads the document asynchronously,
       // so without this the initial value could arrive after a change, and two rapid updates
       // could emit out of order — leaving consumers compiling against a stale preference.
+      // Every link absorbs its own failure: a rejected chain would skip each later link, silently
+      // stopping propagation for good since subscribers live as long as the process.
       let chain: Promise<unknown> = propagateOnStart
-        ? this.get<T>(scope).then(pref => observer.next(pref))
+        ? this.get<T>(scope)
+            .then(pref => observer.next(pref))
+            .catch(onFailure)
         : Promise.resolve();
 
       const sub = this.changeDispatcher.watch().subscribe(change => {
         chain = chain.then(async () => {
-          const preference = await this._coll.findOne<T>({_id: change.documentKey._id});
-          if (preference && preference.scope === scope) {
-            observer.next(preference);
+          try {
+            const preference = await this._coll.findOne<T>({_id: change.documentKey._id});
+            if (preference && preference.scope === scope) {
+              observer.next(preference);
+            }
+          } catch (error) {
+            onFailure(error);
           }
         });
       });

--- a/packages/api/preference/services/src/preference.service.ts
+++ b/packages/api/preference/services/src/preference.service.ts
@@ -5,18 +5,24 @@ import {
   DatabaseService,
   Filter,
   FindOneAndReplaceOptions,
+  ObjectId,
   OptionalId,
+  ReturnDocument,
   WithId
 } from "@spica-server/database";
 import {Preference} from "@spica-server/interface-preference";
 import {Observable} from "rxjs";
 import {deepCopy} from "@spica-server/core-patch";
+import {PreferenceChangeDispatcher} from "./change-dispatcher.js";
 
 @Injectable()
 export class PreferenceService extends BaseCollection("preferences") {
   private _defaults = new Map<string, Preference>();
 
-  constructor(db: DatabaseService) {
+  constructor(
+    db: DatabaseService,
+    private readonly changeDispatcher: PreferenceChangeDispatcher
+  ) {
     super(db, {afterInit: () => {}});
   }
 
@@ -25,17 +31,20 @@ export class PreferenceService extends BaseCollection("preferences") {
     {propagateOnStart}: {propagateOnStart: boolean} = {propagateOnStart: false}
   ): Observable<T> {
     return new Observable(observer => {
-      if (propagateOnStart) {
-        this.get<T>(scope).then(pref => observer.next(pref));
-      }
+      // Serialize onto a single promise chain: each event reloads the document asynchronously,
+      // so without this the initial value could arrive after a change, and two rapid updates
+      // could emit out of order — leaving consumers compiling against a stale preference.
+      let chain: Promise<unknown> = propagateOnStart
+        ? this.get<T>(scope).then(pref => observer.next(pref))
+        : Promise.resolve();
 
-      const sub = this.watch(
-        [{$match: {"fullDocument.scope": {$eq: scope}}}],
-        {fullDocument: "updateLookup"}
-      ).subscribe(change => {
-        if ("fullDocument" in change) {
-          observer.next(change.fullDocument as T);
-        }
+      const sub = this.changeDispatcher.watch().subscribe(change => {
+        chain = chain.then(async () => {
+          const preference = await this._coll.findOne<T>({_id: change.documentKey._id});
+          if (preference && preference.scope === scope) {
+            observer.next(preference);
+          }
+        });
       });
       return () => sub.unsubscribe();
     });
@@ -47,18 +56,31 @@ export class PreferenceService extends BaseCollection("preferences") {
       .then(preference => preference || deepCopy((this._defaults.get(scope) as T) || {}));
   }
 
-  replace<T extends Preference>(
+  async replace<T extends Preference>(
     filter: Filter<Preference>,
     preference: T,
     options?: FindOneAndReplaceOptions
   ) {
-    return this._coll.findOneAndReplace(filter, preference, options);
+    const result = await this._coll.findOneAndReplace(filter, preference, {
+      returnDocument: ReturnDocument.AFTER,
+      ...options
+    });
+    if (result) {
+      this.changeDispatcher.dispatch({
+        operationType: "replace",
+        documentKey: {_id: result._id as ObjectId}
+      });
+    }
+    return result;
   }
 
-  insertOne<T extends OptionalId<Preference>>(preference: T): Promise<WithId<Preference>> {
-    return this._coll
-      .insertOne(preference)
-      .then(result => ({_id: result.insertedId, ...preference}));
+  async insertOne<T extends OptionalId<Preference>>(preference: T): Promise<WithId<Preference>> {
+    const result = await this._coll.insertOne(preference);
+    this.changeDispatcher.dispatch({
+      operationType: "insert",
+      documentKey: {_id: result.insertedId as ObjectId}
+    });
+    return {_id: result.insertedId, ...preference};
   }
 
   default<T extends Preference>(preference: T) {

--- a/packages/api/preference/services/tsconfig.json
+++ b/packages/api/preference/services/tsconfig.json
@@ -7,13 +7,16 @@
   "include": ["src/**/*.ts", "index.ts"],
   "references": [
     {
-      "path": "../../../core/patch"
+      "path": "../../replication"
     },
     {
       "path": "../../../interface/preference"
     },
     {
       "path": "../../../database"
+    },
+    {
+      "path": "../../../core/patch"
     }
   ]
 }

--- a/packages/api/preference/src/preference.module.ts
+++ b/packages/api/preference/src/preference.module.ts
@@ -1,6 +1,6 @@
 import {Global, Module} from "@nestjs/common";
 import {DatabaseModule} from "@spica-server/database";
-import {PreferenceService} from "@spica-server/preference-services";
+import {PreferenceService, PreferenceChangeDispatcher} from "@spica-server/preference-services";
 import {PreferenceController} from "./preference.controller.js";
 
 @Global()
@@ -11,8 +11,8 @@ export class PreferenceModule {
       module: PreferenceModule,
       imports: [DatabaseModule],
       controllers: [PreferenceController],
-      providers: [PreferenceService],
-      exports: [PreferenceService]
+      providers: [PreferenceService, PreferenceChangeDispatcher],
+      exports: [PreferenceService, PreferenceChangeDispatcher]
     };
   }
 }

--- a/packages/api/preference/test/preference.integration.spec.ts
+++ b/packages/api/preference/test/preference.integration.spec.ts
@@ -82,4 +82,36 @@ describe("Preference Integration", () => {
       }
     });
   });
+
+  it("should recompile bucket schema when a language is added", async () => {
+    const bucket = {
+      title: "bucket",
+      description: "bucket",
+      properties: {
+        title: {
+          type: "string",
+          options: {
+            translate: true
+          }
+        }
+      }
+    };
+    const bucketId = await req.post("/bucket", bucket).then(res => res.body._id);
+
+    const document = {title: {en_US: "new title", fr_FR: "nouveau titre"}};
+
+    const rejected = await req.post(`/bucket/${bucketId}/data`, document).catch(e => e);
+    expect(rejected.statusCode).toBe(400);
+
+    await req.put("/preference/bucket", {
+      scope: "bucket",
+      language: {
+        available: {en_US: "English", fr_FR: "French"},
+        default: "en_US"
+      }
+    });
+
+    const accepted = await req.post(`/bucket/${bucketId}/data`, document).catch(e => e);
+    expect(accepted.statusCode).toBe(201);
+  });
 });

--- a/packages/api/preference/test/services/preference.service.spec.ts
+++ b/packages/api/preference/test/services/preference.service.spec.ts
@@ -32,6 +32,8 @@ describe("Preference Service", () => {
     await addPref(prefs);
   });
 
+  afterEach(() => jest.restoreAllMocks());
+
   afterAll(async () => {
     await module.close();
   });
@@ -109,6 +111,36 @@ describe("Preference Service", () => {
 
       preferenceService
         .replace({scope: "bucket"}, {scope: "bucket", property: "updated bucket property"})
+        .catch();
+    });
+
+    it("should keep propagating after a reload fails", done => {
+      const coll = (preferenceService as any)._coll;
+      const findOne = coll.findOne.bind(coll);
+      let alreadyFailed = false;
+
+      jest.spyOn((preferenceService as any).logger, "error").mockImplementation(() => {});
+      jest.spyOn(coll, "findOne").mockImplementation((...args) => {
+        if (!alreadyFailed) {
+          alreadyFailed = true;
+          return Promise.reject(new Error("transient failure"));
+        }
+        return findOne(...args);
+      });
+
+      preferenceService
+        .watchPreference("bucket")
+        .pipe(take(1))
+        .subscribe(next => {
+          expect(next.property).toBe("second update");
+          done();
+        });
+
+      preferenceService
+        .replace({scope: "bucket"}, {scope: "bucket", property: "first update"})
+        .then(() =>
+          preferenceService.replace({scope: "bucket"}, {scope: "bucket", property: "second update"})
+        )
         .catch();
     });
   });

--- a/packages/api/preference/test/services/preference.service.spec.ts
+++ b/packages/api/preference/test/services/preference.service.spec.ts
@@ -1,6 +1,6 @@
 import {Test, TestingModule} from "@nestjs/testing";
 import {DatabaseService, DatabaseTestingModule} from "@spica-server/database-testing";
-import {PreferenceService} from "@spica-server/preference-services";
+import {PreferenceService, PreferenceChangeDispatcher} from "@spica-server/preference-services";
 import {Preference} from "@spica-server/interface-preference";
 import {Observable} from "rxjs";
 import {take} from "rxjs/operators";
@@ -15,7 +15,7 @@ describe("Preference Service", () => {
   beforeAll(async () => {
     module = await Test.createTestingModule({
       imports: [DatabaseTestingModule.replicaSet()],
-      providers: [PreferenceService]
+      providers: [PreferenceService, PreferenceChangeDispatcher]
     }).compile();
     preferenceService = module.get(PreferenceService);
   }, 120000);
@@ -107,11 +107,9 @@ describe("Preference Service", () => {
           done();
         });
 
-      setTimeout(() => {
-        preferenceService
-          .updateOne({scope: "bucket"}, {$set: {property: "updated bucket property"}})
-          .catch();
-      }, 100);
+      preferenceService
+        .replace({scope: "bucket"}, {scope: "bucket", property: "updated bucket property"})
+        .catch();
     });
   });
 });


### PR DESCRIPTION
Follow-up to #1907, applying the same treatment to **preferences**.

## Context

`PreferenceService.watchPreference(scope)` opened a MongoDB change stream on the `preferences` collection so consumers could re-read a preference when it changed. That stream is redundant: **every production write to `preferences` goes through `PreferenceService`** — verified by grepping the raw collection name repo-wide. In fact there is a single production write site, `PreferenceController.replaceOne` (`PUT /preference/:scope`).

Replaced with the in-process pub/sub (`CollectionChangeDispatcher`) already used by `env_var`, `secret`, `bucket`, and `webhook`.

**Extra win over the webhook case:** `watchPreference` returned a *cold* observable, so every subscriber opened its own change stream. They now share a single in-memory `Subject`.

Multi-replica correctness is preserved via the optional `ClassCommander` SYNC broadcast.

## Changes

- **New `PreferenceChangeDispatcher`** (`services/src/change-dispatcher.ts`), provided + exported by `PreferenceModule.forRoot()` (already `@Global`, provides the service once).
- **`PreferenceService`** — dispatches on `insertOne` and `replace`. `replace` now defaults `returnDocument` to `AFTER` so the replaced document (and its `_id`) is available to dispatch from; an explicit caller can still override it. All three existing callers are unaffected — the controller already passes `AFTER`, and the two tests ignore the return value.
- **`watchPreference`** rebuilt on the dispatcher. Consumers key off `scope` but the event carries only `_id`, so it reloads by `_id` and filters on `scope` — exactly what the old `$match: {"fullDocument.scope": ...}` did. **Deletions still do not propagate**, matching the previous behaviour (delete events carried no `fullDocument`).
- Reloads are **serialized on a promise chain**, so the `propagateOnStart` value cannot arrive after a change and two rapid updates cannot emit out of order — which would otherwise leave `BucketSchemaResolver` compiling against a stale preference.

## Behaviour left untouched

- `default()` is in-memory only and never wrote to Mongo — unchanged.
- The `0.16.0` migration writes `preferences` directly, but migrations run as a separate offline process with no API watcher live.
- `PreferenceTestingModule` supplies a fake service via `useValue` and never constructs the real one, so the ~45 specs depending on it are unaffected.

## Tests

The only real consumer chain — `BucketService.watchPreferences()` → `BucketSchemaResolver` — had **no real coverage** (its own spec stubs `watchPreferences`). Added a regression test asserting the bucket schema recompiles when a language is added: posting a document in a not-yet-available language is rejected, and accepted after `PUT /preference/bucket` adds it.

I verified the test has teeth by temporarily disabling the dispatch — it fails (400 instead of 201). Notably the pre-existing "language deleted" test still passed under that break, confirming it only covered the finalizer, not the watch.

The service spec's propagation test moved off the inherited `updateOne` (which no longer dispatches) to `replace`, dropping a `setTimeout`-based race.

## Verification

- `yarn nx test api/preference` → **12 passed, 4 suites**
- `yarn nx run-many -t test -p api/bucket/test api/bucket/services` → **150 passed, 17 suites**
- `yarn build:api` → compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)