### PR TITLE
fix(webhook): keep the target watch chain alive when a reload fails

### DIFF
--- a/packages/api/function/webhook/src/webhook.service.ts
+++ b/packages/api/function/webhook/src/webhook.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from "@nestjs/common";
+import {Injectable, Logger} from "@nestjs/common";
 import {
   BaseCollection,
   DatabaseService,
@@ -14,6 +14,8 @@ import {WebhookChangeDispatcher} from "./change-dispatcher.js";
 
 @Injectable()
 export class WebhookService extends BaseCollection<Webhook>("webhook") {
+  private readonly logger = new Logger(WebhookService.name);
+
   constructor(
     database: DatabaseService,
     private readonly changeDispatcher: WebhookChangeDispatcher
@@ -67,31 +69,48 @@ export class WebhookService extends BaseCollection<Webhook>("webhook") {
         }
         observer.next(change);
       };
-      let chain = super.find().then(hooks => {
-        for (const hook of hooks) {
-          if (!hook.trigger.active) {
-            continue;
+      const onFailure = (error: unknown) =>
+        this.logger.error(
+          `webhook target watch failed: ${error instanceof Error ? error.message : error}`
+        );
+
+      let chain: Promise<unknown> = super
+        .find()
+        .then(hooks => {
+          for (const hook of hooks) {
+            if (!hook.trigger.active) {
+              continue;
+            }
+            emitHook(hook, ChangeKind.Added);
           }
-          emitHook(hook, ChangeKind.Added);
-        }
-      });
+        })
+        .catch(onFailure);
 
       // Serialize processing onto a single promise chain: each event reloads the document
       // asynchronously, so without this an insert's Added could be emitted after a later
       // delete's Removed, leaving the invoker with a dangling target stream.
+      // Every link absorbs its own failure: a rejected chain would skip each later link, silently
+      // stopping target registration for good since the invoker subscribes once per process.
       const sub = this.changeDispatcher.watch().subscribe(change => {
         chain = chain.then(async () => {
-          const _id = change.documentKey._id;
-          if (change.operationType === "delete") {
-            observer.next({kind: ChangeKind.Removed, target: _id.toHexString()});
-            return;
+          try {
+            const _id = change.documentKey._id;
+            if (change.operationType === "delete") {
+              observer.next({kind: ChangeKind.Removed, target: _id.toHexString()});
+              return;
+            }
+            const hook = await super.findOne({_id});
+            if (!hook) {
+              observer.next({kind: ChangeKind.Removed, target: _id.toHexString()});
+              return;
+            }
+            emitHook(
+              hook,
+              change.operationType === "insert" ? ChangeKind.Added : ChangeKind.Updated
+            );
+          } catch (error) {
+            onFailure(error);
           }
-          const hook = await super.findOne({_id});
-          if (!hook) {
-            observer.next({kind: ChangeKind.Removed, target: _id.toHexString()});
-            return;
-          }
-          emitHook(hook, change.operationType === "insert" ? ChangeKind.Added : ChangeKind.Updated);
         });
       });
       return () => sub.unsubscribe();

--- a/packages/api/function/webhook/test/webhook.service.spec.ts
+++ b/packages/api/function/webhook/test/webhook.service.spec.ts
@@ -15,6 +15,7 @@ describe("Webhook Service", () => {
       providers: [WebhookService, WebhookChangeDispatcher]
     }).compile();
     service = module.get(WebhookService);
+    jest.restoreAllMocks();
 
     webhook = {
       title: "wh1",
@@ -146,5 +147,37 @@ describe("Webhook Service", () => {
         {...webhook, trigger: {...webhook.trigger, active: false}}
       );
     });
+  });
+
+  it("should keep reporting after a reload fails", done => {
+    const coll = (service as any)._coll;
+    const findOne = coll.findOne.bind(coll);
+    let alreadyFailed = false;
+
+    jest.spyOn((service as any).logger, "error").mockImplementation(() => {});
+    jest.spyOn(coll, "findOne").mockImplementation((...args) => {
+      if (!alreadyFailed) {
+        alreadyFailed = true;
+        return Promise.reject(new Error("transient failure"));
+      }
+      return findOne(...args);
+    });
+
+    service
+      .targets()
+      .pipe(take(1))
+      .subscribe(target => {
+        expect(target.kind).toEqual(ChangeKind.Added);
+        expect(target.webhook.title).toBe("wh2");
+        done();
+      });
+
+    // insertOne stamps _id onto the given document, so build the second one up front
+    const second = {...webhook, title: "wh2"};
+
+    service
+      .insertOne(webhook)
+      .then(() => service.insertOne(second))
+      .catch();
   });
 });


### PR DESCRIPTION
Fixes a regression I introduced in #1907. Found via review feedback on #1908, which had the identical bug in `PreferenceService` — this is the webhook half, already merged to master.

## The bug

`WebhookService.targets()` serializes reloads onto a single promise chain:

```ts
chain = chain.then(async () => { ... await super.findOne({_id}) ... });
```

Each link is appended with `chain.then(onFulfilled)` and **no rejection handler**. Per promise semantics, once `chain` is rejected, every later `.then(onFulfilled)` skips its callback and forwards the rejection. So a single failed reload — a transient Mongo error, a replica-set failover/step-down — leaves the chain permanently rejected and `targets()` silently stops reporting webhook changes.

It does not self-heal: `WebhookInvoker` subscribes once in its constructor and holds that subscription for the process lifetime. After one bad reload, no webhook is ever registered or torn down again — newly created webhooks never fire, and deleted ones keep firing — until the process restarts, with nothing logged anywhere.

## The fix

Absorb the failure inside each link and log it via `Logger`, matching the existing idiom in `BucketService` (which logs errors from its own change-dispatcher watch). A failed reload now costs one missed change instead of all future ones. The same guard is applied to the initial `find()` seed.

I deliberately did not swallow silently — a dropped registration with no signal is exactly the kind of failure that is impossible to diagnose in production.

## Test

Added `should keep reporting after a reload fails`: forces the first `findOne` to reject, then asserts a subsequent insert is still reported.

Verified it has teeth — with the `try/catch` removed the test hangs until the 30s timeout, which is precisely the production symptom.

## Verification

- `yarn nx test api/function/webhook` → **34 passed, 6 suites**
- `yarn build:api` → compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)