### PR TITLE
fix(function): survive and recover from bundler-worker OOM, and allow raising its heap

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -329,6 +329,11 @@ const args = yargsInstance
         "How function sources are turned into runnable code. 'legacy' compiles the entrypoint only, 'rollup' bundles it together with its local imports and dependencies. Default value is legacy.",
       default: "legacy"
     },
+    "function-builder-max-memory": {
+      number: true,
+      description:
+        "Max heap in MB for the rollup bundler worker thread. Bundling a large dependency graph can exhaust the default (container-sized) heap and fail the build; raise this to give heavy functions more headroom. Keep it below the container's memory limit so the kernel does not OOM-kill the api. Unset uses node's default."
+    },
     "function-debug": {
       boolean: true,
       description: "Enable/disable function workers debugging mode. Default value is true",
@@ -952,6 +957,7 @@ const modules = [
     },
     debug: args["function-debug"],
     builder: args["function-builder"] as BuilderType,
+    builderMaxMemoryMb: args["function-builder-max-memory"],
     maxConcurrency: args["function-worker-concurrency"],
     eventConcurrency: args["function-worker-event-concurrency"],
     maxWarmWorkers: args["function-warm-workers-max"],

--- a/packages/api/function/builder/rollup/src/index.ts
+++ b/packages/api/function/builder/rollup/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./rollup.builder.js";
 export * from "./javascript.js";
 export * from "./typescript.js";
+export * from "./worker-host.js";

--- a/packages/api/function/builder/rollup/src/rollup.builder.ts
+++ b/packages/api/function/builder/rollup/src/rollup.builder.ts
@@ -9,9 +9,9 @@ export class RollupBuilder extends Builder {
 
   private host: RollupWorkerHost;
 
-  constructor(language: string, options: {workerPath?: string} = {}) {
+  constructor(language: string, options: {workerPath?: string; maxOldSpaceMb?: number} = {}) {
     super(language);
-    this.host = new RollupWorkerHost(options.workerPath);
+    this.host = new RollupWorkerHost(options.workerPath, options.maxOldSpaceMb);
     this.strategies = new Map<string, BuildStrategy>([
       ["javascript", new JavascriptBundle(this.host)],
       ["typescript", new TypescriptBundle(this.host)]

--- a/packages/api/function/builder/rollup/src/worker-host.ts
+++ b/packages/api/function/builder/rollup/src/worker-host.ts
@@ -43,6 +43,9 @@ export class RollupWorkerHost {
     }
     const worker = this.worker;
     this.worker = undefined;
+    // The guarded exit handler below no longer rejects once this.worker is cleared, so fail any
+    // in-flight build here — a deliberately terminated worker will never answer it.
+    this.rejectAllPending("Bundler worker was terminated.");
     return worker.terminate().then(() => {});
   }
 
@@ -57,26 +60,39 @@ export class RollupWorkerHost {
     // resourceLimits (worker execArgv rejects V8 flags like --max-old-space-size). Note a
     // --max-old-space-size on the api process itself is a hard ceiling this cannot exceed.
     // Unset -> node's default applies.
-    this.worker = new worker_threads.Worker(
+    const worker = new worker_threads.Worker(
       this.workerPath || path.join(__dirname, "rollup_worker.js"),
       this.maxOldSpaceMb
         ? {resourceLimits: {maxOldGenerationSizeMb: this.maxOldSpaceMb}}
         : undefined
     );
+    this.worker = worker;
 
-    this.worker.on("message", (response: BundleResponse) => this.settle(response));
+    worker.on("message", (response: BundleResponse) => this.settle(response));
+
+    // Both handlers guard on `this.worker !== worker`: a dead worker's queued error/exit must not
+    // clear a *newer* live worker or reject builds dispatched to it. Once a crashed worker has
+    // been replaced (or killed), its late events are inert. Without this, worker A's error clears
+    // the reference, a concurrent build spawns worker B, then A's trailing exit drops B and fails
+    // B's build — RollupWorkerHost is shared per-language across concurrent builds.
 
     // A Worker is an EventEmitter: an 'error' event with no listener is rethrown by node and
     // takes the whole api process down. A heavy bundle exhausting the worker's heap
     // (ERR_WORKER_OUT_OF_MEMORY) surfaces here, so listen and fail the in-flight builds
     // instead of crashing. Dropping the reference lets the next build spawn a fresh worker.
-    this.worker.on("error", error => {
+    worker.on("error", error => {
+      if (this.worker !== worker) {
+        return;
+      }
       this.logger.error(`Bundler worker crashed: ${error.message}`);
       this.worker = undefined;
       this.rejectAllPending(`Bundler worker crashed: ${error.message}`, "BUNDLER_WORKER_CRASH");
     });
 
-    this.worker.once("exit", exitCode => {
+    worker.once("exit", exitCode => {
+      if (this.worker !== worker) {
+        return;
+      }
       this.worker = undefined;
       if (exitCode != 0) {
         this.logger.log("Bundler worker has quit with non-zero exit code.");
@@ -86,7 +102,7 @@ export class RollupWorkerHost {
       this.rejectAllPending(`Bundler worker has quit with exit code ${exitCode}.`);
     });
 
-    return this.worker;
+    return worker;
   }
 
   private settle({id, diagnostics}: BundleResponse) {

--- a/packages/api/function/builder/rollup/src/worker-host.ts
+++ b/packages/api/function/builder/rollup/src/worker-host.ts
@@ -22,7 +22,10 @@ export class RollupWorkerHost {
   private lastId = 0;
   private pending = new Map<number, {resolve: () => void; reject: (e: unknown) => void}>();
 
-  constructor(private workerPath?: string) {}
+  constructor(
+    private workerPath?: string,
+    private maxOldSpaceMb?: number
+  ) {}
 
   run(language: string, meta: BuildMeta): Promise<void> {
     const worker = this.ensureWorker();
@@ -49,8 +52,16 @@ export class RollupWorkerHost {
     }
 
     const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    // A worker thread has its own heap. Bundling a large dependency graph can exhaust the
+    // default (container-sized) heap and kill the worker, so let an operator raise it via
+    // resourceLimits (worker execArgv rejects V8 flags like --max-old-space-size). Note a
+    // --max-old-space-size on the api process itself is a hard ceiling this cannot exceed.
+    // Unset -> node's default applies.
     this.worker = new worker_threads.Worker(
-      this.workerPath || path.join(__dirname, "rollup_worker.js")
+      this.workerPath || path.join(__dirname, "rollup_worker.js"),
+      this.maxOldSpaceMb
+        ? {resourceLimits: {maxOldGenerationSizeMb: this.maxOldSpaceMb}}
+        : undefined
     );
 
     this.worker.on("message", (response: BundleResponse) => this.settle(response));

--- a/packages/api/function/builder/rollup/src/worker-host.ts
+++ b/packages/api/function/builder/rollup/src/worker-host.ts
@@ -55,12 +55,23 @@ export class RollupWorkerHost {
 
     this.worker.on("message", (response: BundleResponse) => this.settle(response));
 
+    // A Worker is an EventEmitter: an 'error' event with no listener is rethrown by node and
+    // takes the whole api process down. A heavy bundle exhausting the worker's heap
+    // (ERR_WORKER_OUT_OF_MEMORY) surfaces here, so listen and fail the in-flight builds
+    // instead of crashing. Dropping the reference lets the next build spawn a fresh worker.
+    this.worker.on("error", error => {
+      this.logger.error(`Bundler worker crashed: ${error.message}`);
+      this.worker = undefined;
+      this.rejectAllPending(`Bundler worker crashed: ${error.message}`, "BUNDLER_WORKER_CRASH");
+    });
+
     this.worker.once("exit", exitCode => {
       this.worker = undefined;
       if (exitCode != 0) {
         this.logger.log("Bundler worker has quit with non-zero exit code.");
       }
-      // A dead worker will never answer; fail the in-flight builds instead of hanging them.
+      // A dead worker will never answer; fail any build still in flight (already drained if the
+      // crash above fired first) so it fails instead of hanging.
       this.rejectAllPending(`Bundler worker has quit with exit code ${exitCode}.`);
     });
 
@@ -80,12 +91,12 @@ export class RollupWorkerHost {
     }
   }
 
-  private rejectAllPending(reason: string) {
+  private rejectAllPending(reason: string, code = "BUNDLER_WORKER_EXIT") {
     for (const [id, pending] of this.pending) {
       this.pending.delete(id);
       pending.reject([
         {
-          code: "BUNDLER_WORKER_EXIT",
+          code,
           category: 1,
           text: reason,
           start: {line: 1, column: 1},

--- a/packages/api/function/builder/rollup/test/rollup.builder.spec.ts
+++ b/packages/api/function/builder/rollup/test/rollup.builder.spec.ts
@@ -1,5 +1,5 @@
 import {BuildMeta} from "@spica-server/interface-function-builder";
-import {RollupBuilder} from "@spica-server/function-builder-rollup";
+import {RollupBuilder, RollupWorkerHost} from "@spica-server/function-builder-rollup";
 import {FunctionTestBed} from "@spica-server/function/runtime/testing";
 import fs from "fs";
 import path from "path";
@@ -322,6 +322,41 @@ describe("RollupBuilder", () => {
       );
 
       await builder.kill();
+    });
+
+    // The host is shared per-language across concurrent builds. Worker A's error clears the
+    // reference, a concurrent build spawns worker B, then A's trailing exit must NOT drop B or
+    // fail B's build. Driving the host directly (run() dispatches synchronously) puts B's spawn
+    // in the exact window between A's error and A's exit. Fixture worker: crash on `meta.crash`,
+    // otherwise succeed.
+    it("should not let a crashed worker's exit fail a concurrent build on a fresh worker", async () => {
+      const fixture = path.join(process.env.TEST_TMPDIR, "crash-or-succeed-worker.cjs");
+      fs.writeFileSync(
+        fixture,
+        `const {parentPort} = require("worker_threads");
+         parentPort.on("message", ({id, meta}) => {
+           if (meta && meta.crash) { throw new Error("simulated worker crash"); }
+           parentPort.postMessage({id, diagnostics: []});
+         });`
+      );
+
+      const host = new RollupWorkerHost(fixture);
+      const base = {outDir: ".build", entrypoints: {build: "i", runtime: "i"}};
+      const crashMeta = {...base, cwd: "/crash", crash: true} as unknown as BuildMeta;
+      const healthyMeta = {...base, cwd: "/healthy"} as unknown as BuildMeta;
+
+      const first = host.run("javascript", crashMeta);
+      // dispatch the concurrent build in first's rejection microtask, before A's exit macrotask
+      const second = first.then(
+        () => undefined,
+        () => host.run("javascript", healthyMeta)
+      );
+
+      // guard present: B survives A's stale exit and its build resolves.
+      // guard removed: A's exit drops B and rejects this build -> the assertion fails.
+      await expect(second).resolves.toBeUndefined();
+
+      await host.kill();
     });
   });
 });

--- a/packages/api/function/builder/rollup/test/rollup.builder.spec.ts
+++ b/packages/api/function/builder/rollup/test/rollup.builder.spec.ts
@@ -263,4 +263,65 @@ describe("RollupBuilder", () => {
       expect(await readBundle(second)).toContain("second");
     });
   });
+
+  // Regression: a worker that dies (e.g. a heavy bundle exhausting its heap ->
+  // ERR_WORKER_OUT_OF_MEMORY) emits an 'error' event. Without a listener node rethrows it and
+  // the whole api process crashes. A crashing worker here must fail the build instead — if the
+  // handler regressed, the unhandled 'error' would take down this test process.
+  describe("worker crash", () => {
+    let crashingWorkerPath: string;
+
+    beforeAll(() => {
+      crashingWorkerPath = path.join(process.env.TEST_TMPDIR, "crashing-worker.cjs");
+      fs.writeFileSync(
+        crashingWorkerPath,
+        `const {parentPort} = require("worker_threads");
+         parentPort.on("message", () => { throw new Error("simulated worker crash"); });`
+      );
+    });
+
+    const meta: BuildMeta = {
+      cwd: undefined,
+      entrypoints: {build: "index.mjs", runtime: "index.mjs"},
+      outDir: ".build"
+    };
+
+    beforeEach(() => {
+      meta.cwd = FunctionTestBed.initialize(`export default function() {}`, meta);
+      return fs.promises.mkdir(path.join(meta.cwd, "node_modules"), {recursive: true});
+    });
+
+    // A dying worker emits 'error' and 'exit'; whichever settles the pending build first
+    // decides the diagnostic code (CRASH vs EXIT). Both mean "worker died, build fails as a
+    // 422", so assert the shape, not the racy code. The test merely completing proves the fix:
+    // before it, the unhandled 'error' would crash this jest process.
+    it("should reject the build with a diagnostic instead of crashing the process", async () => {
+      const builder = new RollupBuilder("javascript", {workerPath: crashingWorkerPath});
+
+      const diagnostics = await builder.build(meta).catch(e => e);
+
+      expect(Array.isArray(diagnostics)).toBe(true);
+      expect(diagnostics[0]).toEqual(
+        expect.objectContaining({category: 1, text: expect.stringMatching(/worker/i)})
+      );
+
+      await builder.kill();
+    });
+
+    it("should respawn a fresh worker for the next build after a crash", async () => {
+      const builder = new RollupBuilder("javascript", {workerPath: crashingWorkerPath});
+
+      await builder.build(meta).catch(() => {});
+      // second attempt spawns a new worker (the crashed one was dropped); it fails the same
+      // way, proving a usable worker was created rather than the host being left wedged.
+      const second = await builder.build(meta).catch(e => e);
+
+      expect(Array.isArray(second)).toBe(true);
+      expect(second[0]).toEqual(
+        expect.objectContaining({category: 1, text: expect.stringMatching(/worker/i)})
+      );
+
+      await builder.kill();
+    });
+  });
 });

--- a/packages/api/function/scheduler/src/scheduler.ts
+++ b/packages/api/function/scheduler/src/scheduler.ts
@@ -214,7 +214,10 @@ export class Scheduler implements OnModuleInit, OnModuleDestroy {
 
   private createBuilder(language: string): Builder {
     return this.options.builder == BuilderType.Rollup
-      ? new RollupBuilder(language, {workerPath: this.options.rollupWorkerPath})
+      ? new RollupBuilder(language, {
+          workerPath: this.options.rollupWorkerPath,
+          maxOldSpaceMb: this.options.builderMaxMemoryMb
+        })
       : new LegacyBuilder(language, {tsCompilerPath: this.options.tsCompilerPath});
   }
 

--- a/packages/api/function/src/function.module.ts
+++ b/packages/api/function/src/function.module.ts
@@ -71,6 +71,7 @@ export class FunctionModule {
           workerLogOutput: options.workerLogOutput,
           spawnEntrypointPath: options.spawnEntrypointPath,
           builder: options.builder,
+          builderMaxMemoryMb: options.builderMaxMemoryMb,
           tsCompilerPath: options.tsCompilerPath,
           rollupWorkerPath: options.rollupWorkerPath,
           grpcPort: options.grpcPort,

--- a/packages/interface/function/scheduler/src/index.ts
+++ b/packages/interface/function/scheduler/src/index.ts
@@ -29,6 +29,7 @@ export interface SchedulingOptions {
   workerLogOutput?: ("database" | "stdout")[];
   spawnEntrypointPath?: string;
   builder?: BuilderType;
+  builderMaxMemoryMb?: number;
   tsCompilerPath?: string;
   rollupWorkerPath?: string;
   grpcPort?: number;


### PR DESCRIPTION
Follow-up to #1910 (already merged). Two related changes for the production `ERR_WORKER_OUT_OF_MEMORY` crash.

## 1. Don't crash the api when the bundler worker dies

An API in production (rollup builder) crashed with:

```
Error [ERR_WORKER_OUT_OF_MEMORY]: Worker terminated due to reaching memory limit: JS heap out of memory
    ... throw er; // Unhandled 'error' event
  code: 'ERR_WORKER_OUT_OF_MEMORY'
```

Cause: a function that namespace-imports huge, non-tree-shakeable libraries (`import * as aws from "aws-sdk"`, `import * as google from "googleapis"`) makes rollup hold the whole dependency graph + bundle + sourcemap in the **bundler worker's heap**, which OOMs in a memory-limited container. And `RollupWorkerHost` listened for the worker's `message`/`exit` but **not `error`** — a `Worker` is an `EventEmitter`, so an `'error'` with no listener is rethrown by node and **takes the whole API down** instead of failing the one build.

Fix: add an `'error'` listener that **logs**, **drops the worker reference** (next build respawns a fresh one), and **rejects the in-flight build** with a `BUNDLER_WORKER_CRASH` diagnostic — which the controller already turns into a **422**, so the user sees the failure on their save instead of a dead server.

## 2. Let a legitimately heavy build succeed

`--function-builder-max-memory` (MB), threaded through `SchedulingOptions → Scheduler → RollupBuilder → RollupWorkerHost`, sets the worker's `resourceLimits.maxOldGenerationSizeMb`. Worker `execArgv` rejects V8 flags like `--max-old-space-size`, so `resourceLimits` is the mechanism. Left unset, node's default applies — behaviour unchanged unless an operator opts in (a hardcoded high default would risk the kernel OOM-killing the whole pod). Caveat: a `--max-old-space-size` on the api process itself is a hard ceiling this can't exceed; production usually leaves it container-sized, so the knob governs.

## Reproduced, before and after

Built the exact failing function (aws-sdk + googleapis + rxjs + axios, 238 MB of deps) through the real `RollupBuilder` at a container-sized worker heap:

- **Before (#1):** the exact production `ERR_WORKER_OUT_OF_MEMORY` unhandled-`error` trace; host process dies.
- **After #1:** host survives and exits cleanly; logs `Bundler worker crashed: Worker terminated due to reaching memory limit`; build rejects with the diagnostic (→ 422); the next build succeeds on a respawned worker.
- **#2:** same function OOMs a 256 MB worker but **builds fine at 4096 MB**.

## Tests

Two regression tests via a fake worker that throws on message — asserting the build rejects with a worker-failure diagnostic rather than crashing the process (the test *completing* is itself the guard: pre-fix the unhandled `error` crashes the jest process). The diagnostic *code* isn't asserted — a dying worker races `error` vs `exit`, both valid "build failed → 422" outcomes. Rollup suite 14/14, scheduler 68/68. The heap knob is verified by the manual reproduction above (a deterministic unit test would need a real heavy OOM, too heavy/flaky for CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)