### PR TITLE
fix(function): resolve esm builds that hide behind a node condition

### DIFF
--- a/packages/api/function/builder/rollup/src/rollup_worker.ts
+++ b/packages/api/function/builder/rollup/src/rollup_worker.ts
@@ -125,13 +125,22 @@ function writeTsconfig(meta: BuildMeta) {
 
 function createOptions(language: string, meta: BuildMeta, diagnostics: BuildDiagnostic[]) {
   /*
-    Two resolvers, tried in order, instead of one with every condition active. A dual package
-    that lists "require" before "import" in its exports map would otherwise resolve to its
-    commonjs build, which barely tree-shakes: date-fns costs 689KB that way and 89KB as esm.
-    The second resolver only sees packages the first one could not resolve, i.e. commonjs-only
-    ones, which keep being bundled as before.
+    Resolvers tried in order, instead of one with every condition active, so a package's esm
+    build wins over its commonjs one — commonjs goes through plugin-commonjs as an opaque
+    namespace and barely tree-shakes (date-fns costs 689KB that way and 89KB as esm).
+
+    The first pass deliberately omits "node": a condition matches by the *package's* key order,
+    and packages like rxjs list "node" -> ./dist/cjs before their esm entry, so keeping "node"
+    active pulls in the commonjs build and every unused operator with it. Without it rxjs
+    resolves to ./dist/esm and drops from 314KB to tree-shaken.
+
+    The short condition list is an optimisation, not a correctness mechanism: "default" always
+    matches regardless of what is listed here, so a package using some alias we do not name
+    still resolves through it (typically to the same esm build, occasionally an older target).
+    Missing an alias costs bundle size, never correctness — which is why this list stays small.
   */
   const resolvers = [
+    ["import", "module", "es2015"],
     ["node", "import", "default"],
     ["node", "require", "default"]
   ].map(exportConditions =>

--- a/packages/api/function/builder/rollup/test/rollup.builder.spec.ts
+++ b/packages/api/function/builder/rollup/test/rollup.builder.spec.ts
@@ -104,6 +104,43 @@ describe("RollupBuilder", () => {
       expect(await readBundle(meta)).toContain("from the esm build");
     });
 
+    // Shaped like rxjs: "node" points at the commonjs build and is listed *before* the esm
+    // entry, so keeping "node" active in the resolver pulls in commonjs — which plugin-commonjs
+    // wraps whole, defeating tree shaking and dragging every unused export along.
+    it("should inline the esm build of a package whose node condition points at commonjs", async () => {
+      installPackage(meta, "node-cjs-package", {
+        "package.json": `{
+          "name": "node-cjs-package",
+          "version": "1.0.0",
+          "exports": {".": {
+            "node": "./cjs.js",
+            "require": "./cjs.js",
+            "es2015": "./esm.mjs",
+            "default": "./esm.mjs"
+          }}
+        }`,
+        "cjs.js": `exports.used = () => "from the commonjs build";
+                   exports.unused = () => "UNUSED_COMMONJS_EXPORT";`,
+        "esm.mjs": `export const used = () => "from the esm build";
+                    export const unused = () => "UNUSED_ESM_EXPORT";`
+      });
+      await writeFile(
+        meta,
+        "index.mjs",
+        `import {used} from "node-cjs-package";
+         export default function() { return used(); }`
+      );
+
+      await builder.build(meta);
+
+      const bundle = await readBundle(meta);
+      expect(bundle).toContain("from the esm build");
+      expect(bundle).not.toContain("from the commonjs build");
+      // the esm build is tree-shakeable, so the export the entrypoint never uses is dropped
+      expect(bundle).not.toContain("UNUSED_ESM_EXPORT");
+      expect(bundle).not.toContain("UNUSED_COMMONJS_EXPORT");
+    });
+
     it("should keep never bundled packages external", async () => {
       await writeFile(
         meta,


### PR DESCRIPTION
Reported on master: a function importing **only** `switchMap` from rxjs shipped the entire library — `debounceTime`, `throttleTime`, `bufferToggle`, `windowWhen`, `auditTime` and the rest. Debugged against the live master engine.

## Diagnosis

Bundle composition of the reported function (`@aws-sdk/client-s3` + `axios` + `rxjs`), from its sourcemap on the pod:

| package | build used | size |
|---|---|---|
| **rxjs** | **`dist/cjs/`** ← CommonJS | **314 KB** (largest) |
| @smithy/core | `dist-es/` ESM ✓ | 271 KB |
| axios | `lib/` ESM ✓ | 214 KB |
| @aws-sdk/client-s3 | `dist-es/` ESM ✓ | 191 KB |

223 CommonJS files inlined (861 `hasRequired` wrappers) — essentially all of rxjs. **Only rxjs resolved to CommonJS**; aws-sdk and axios were already fine. A CommonJS module goes through `@rollup/plugin-commonjs` as an opaque namespace, so tree shaking can't drop anything from it.

**Why:** export conditions match by the **package's own key order**, and rxjs lists:

```json
"node":    "./dist/cjs/index.js",   ← matched first → CommonJS
"require": "./dist/cjs/index.js",
"es2015":  "./dist/esm/index.js",
"default": "./dist/esm5/index.js"
```

The esm-first resolver added in #1910 only dropped `"require"`, on the assumption that would force ESM. It doesn't — **`"node"` itself can point at CommonJS**, which is exactly what rxjs does.

## Fix

Add a first resolver pass that omits `"node"` entirely and matches only explicit ESM conditions, ahead of the existing node-ESM and CommonJS passes:

```
["import", "module", "es2015"]      ← rxjs matches es2015 → dist/esm
["node", "import", "default"]       ← node ESM (previous behaviour)
["node", "require", "default"]      ← commonjs fallback
```

## Measured (real builder, reproduction of the reported function)

| | before | after |
|---|---|---|
| bundle | 1549 KB (prod) / 1513 KB (local) | **1178 KB** |
| rxjs build | `dist/cjs` | **`dist/esm`** |
| inlined CommonJS files | 223 | **0** |
| unused rxjs operators | present | **none** |

aws-sdk and axios are unchanged (already ESM), and I explicitly checked the risk that dropping `"node"` swaps in browser builds: **no new browser-variant sources** — the 7 `*.browser.js` files from `@smithy/core` are present identically before and after (pre-existing). Output executes correctly.

## On the condition list

It stays deliberately short, and it is an **optimisation, not a correctness mechanism**: `"default"` always matches regardless of what's listed, so a package using an alias we don't name still resolves through it — typically to the same ESM build, occasionally an older target (rxjs `default` → `esm5` is 1187 KB vs `es2015` → `esm` 1178 KB, a 9 KB difference). Missing an alias costs bundle size, never correctness. Condition names are arbitrary strings with no registry, so enumerating them all is neither possible nor necessary.

## Tests

A regression test with a package shaped exactly like rxjs (`"node"` → CommonJS listed before the ESM entry) asserts the ESM build is inlined, the CommonJS one isn't, and the unused export is tree-shaken. Verified it fails with the fix reverted and passes with it. Suite 16/16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)