### PR TITLE
fix(charts): make replica set bootstrap and credentials robust

### DIFF
--- a/apps/mongoreplicationcontroller/src/main.ts
+++ b/apps/mongoreplicationcontroller/src/main.ts
@@ -84,15 +84,17 @@ function authenticateForMongo(username, password, authenticationDatabase) {
   debug(
     "Assuming mongodb started with --auth flag and credentals will be provided for each connection."
   );
-  mongoCommand = `${mongoCommand} --username '${username}' --password '${password}' --authenticationDatabase '${authenticationDatabase}'`;
+  mongoCommand = `${mongoCommand} --username='${username}' --password='${password}' --authenticationDatabase='${authenticationDatabase}'`;
+}
+
+function mongoAddress(host: string) {
+  return `"mongodb://${host}/admin?directConnection=true"`;
 }
 
 async function findPrimaryNode(nodes: string[]) {
   for (const node of nodes) {
     try {
-      const {stdout} = await execMongo(
-        `admin --host "${node}" --eval "JSON.stringify(db.hello())"`
-      );
+      const {stdout} = await execMongo(`${mongoAddress(node)} --eval "JSON.stringify(db.hello())"`);
       debug(stdout);
       const result = JSON.parse(stdout);
       if (result.isWritablePrimary === true) {
@@ -113,7 +115,9 @@ async function findPrimaryNode(nodes: string[]) {
 async function initiateReplication(nodes: string[], reinitiate = false) {
   let statusResult;
   try {
-    const {stdout} = await execMongo(`--host "${nodes[0]}" --eval 'JSON.stringify(rs.status())'`);
+    const {stdout} = await execMongo(
+      `${mongoAddress(nodes[0])} --eval 'JSON.stringify(rs.status())'`
+    );
     statusResult = JSON.parse(stdout);
   } catch (error) {
     debug(error);
@@ -121,7 +125,7 @@ async function initiateReplication(nodes: string[], reinitiate = false) {
 
   if (!statusResult || (statusResult.ok !== 1 && statusResult.codeName === "NotYetInitialized")) {
     const {stdout} = await execMongo(
-      `--host ${nodes[0]} --eval 'JSON.stringify(rs.initiate({"_id": "${
+      `${mongoAddress(nodes[0])} --eval 'JSON.stringify(rs.initiate({"_id": "${
         options["replica-set"]
       }", "members": ${JSON.stringify(nodes.map((host, _id) => ({_id, host})))}}))'`
     );
@@ -147,7 +151,7 @@ async function initiateReplication(nodes: string[], reinitiate = false) {
       "return { ok: 1 }"
     ];
     const {stdout} = await execMongo(
-      `admin --host "${primary}" --eval 'JSON.stringify((function() { ${script.join(";")} })())'`
+      `${mongoAddress(primary)} --eval 'JSON.stringify((function() { ${script.join(";")} })())'`
     );
     debug(stdout);
     const result = JSON.parse(stdout);
@@ -159,7 +163,7 @@ async function initiateReplication(nodes: string[], reinitiate = false) {
 
 async function addAsSecondary(primaryHost: string, secondaryHost: string, index: number) {
   const {stdout} = await execMongo(
-    `admin --host "${primaryHost}" --eval 'JSON.stringify(rs.config())'`
+    `${mongoAddress(primaryHost)} --eval 'JSON.stringify(rs.config())'`
   );
   debug(stdout);
   const config = JSON.parse(stdout);
@@ -172,7 +176,7 @@ async function addAsSecondary(primaryHost: string, secondaryHost: string, index:
       "return { ok: 1 }"
     ];
     const {stdout} = await execMongo(
-      `admin --host "${primaryHost}" --eval 'JSON.stringify((function() { ${conf.join(";")} })())'`
+      `${mongoAddress(primaryHost)} --eval 'JSON.stringify((function() { ${conf.join(";")} })())'`
     );
     debug(stdout);
     const result = JSON.parse(stdout);

--- a/charts/spica/templates/_helpers.tpl
+++ b/charts/spica/templates/_helpers.tpl
@@ -22,6 +22,12 @@
 {{- end -}}
 
 
+{{- define "database.primaryNode" -}}
+{{- $name := printf "%s-database" .Release.Name -}}
+{{- printf "%s-0.%s.%s.svc.cluster.local" $name $name .Release.Namespace -}}
+{{- end -}}
+
+
 {{- define "generateReplicaSetMembers" -}}
 {{- $replicaCount := (.Values.database.replicas | int) -}}
 {{- $uri := "" -}}
@@ -38,14 +44,16 @@
 
 
 {{- define "generatePassword" -}}
-  {{- $specialChars := list "!" "@" "#" "$" "%" "^" "&" "*" "-" "_" -}} 
-  {{- $password := list 
+  {{- $specialChars := list "!" "@" "#" "$" "%" "^" "&" "*" "-" "_" -}}
+  {{- $body := list
         (randAlpha 2)
         (randNumeric 2)
         (index $specialChars (randInt 0 (len $specialChars)))
         (index $specialChars (randInt 0 (len $specialChars)))
         (randAlphaNum 6)
-      | join "" | shuffle 
+      | join "" | shuffle
   -}}
-  {{- $password -}}
+  {{- /* Leading char is kept alphabetic: a password starting with "-" is parsed as a flag by
+         mongosh and yargs, which silently breaks every --password consumer in this chart. */ -}}
+  {{- printf "%s%s" (randAlpha 1) $body -}}
 {{- end -}}

--- a/charts/spica/templates/database.yaml
+++ b/charts/spica/templates/database.yaml
@@ -78,6 +78,8 @@ spec:
                 secretKeyRef:
                   name: {{ .Release.Name }}-database-root-credentials
                   key: rootPassword
+            - name: RS_PRIMARY_HOST
+              value: {{ template "database.primaryNode" . }}
       containers:
         - name: mongo
           image: mongo:{{ .Values.database.version }}
@@ -94,12 +96,9 @@ spec:
             exec:
               command:
                 - mongosh
-                - --username
-                - $(ROOT_USERNAME)
-                - --password
-                - $(ROOT_PASSWORD)
-                - --authenticationDatabase
-                - admin
+                - --username=$(ROOT_USERNAME)
+                - --password=$(ROOT_PASSWORD)
+                - --authenticationDatabase=admin
                 - --eval
                 - "db.adminCommand('ping')"
             initialDelaySeconds: {{ .Values.database.startupProbeInitialDelaySeconds }}

--- a/charts/spica/templates/databasereplication.yaml
+++ b/charts/spica/templates/databasereplication.yaml
@@ -25,10 +25,8 @@ spec:
             "false",
             "--nodes",
             {{ template "database.nodes" . }},
-            "--username",
-            "$(ROOT_USERNAME)",
-            "--password",
-            "$(ROOT_PASSWORD)"
+            "--username=$(ROOT_USERNAME)",
+            "--password=$(ROOT_PASSWORD)"
           ]
           env:
             - name: ROOT_USERNAME

--- a/charts/spica/templates/initdb.yaml
+++ b/charts/spica/templates/initdb.yaml
@@ -49,9 +49,12 @@ data:
     retry_command mongosh --quiet --eval "db.runCommand({ ping: 1 })"
     echo "Ping succeeded!"
 
-    # Initiate replicaset (idempotent: code 23 = AlreadyInitialized, safe to skip)
+    # Initiate with an explicit FQDN member: an argument-less initiate derives the member host
+    # from `hostname`, which resolves only inside this pod, so every client that discovers the
+    # replica set would then be handed an unreachable address.
+    # Idempotent: code 23 = AlreadyInitialized.
     echo "Trying to initiate replicaset.."
-    mongosh --eval "try { rs.initiate(); print('RS initiated.') } catch(e) { if (e.code != 23) throw e; print('RS already initialized, skipping.') }"
+    mongosh --eval "try { rs.initiate({_id: 'rs0', members: [{_id: 0, host: '$RS_PRIMARY_HOST'}]}); print('RS initiated.') } catch(e) { if (e.code != 23) throw e; print('RS already initialized, skipping.') }"
     echo "Replicaset initiation succeeded!"
 
     # Insert root user if not exist
@@ -118,8 +121,7 @@ data:
     echo "Ping succeeded!"
 
     echo "Setting Profiling level: $PROFILING_LEVEL, Slowms: $PROFILING_SLOWMS on the $DATABASE_NAME database.."
-    mongosh --authenticationDatabase "admin" -u "$ROOT_USERNAME" -p "$ROOT_PASSWORD" --eval <<EOF
-      use $DATABASE_NAME
-      db.setProfilingLevel($PROFILING_LEVEL,{ slowms: $PROFILING_SLOWMS})
-    EOF
+    mongosh "mongodb://127.0.0.1:27017/$DATABASE_NAME?directConnection=true" \
+      --authenticationDatabase="admin" --username="$ROOT_USERNAME" --password="$ROOT_PASSWORD" \
+      --eval "db.setProfilingLevel($PROFILING_LEVEL, { slowms: $PROFILING_SLOWMS })"
     echo "Set Profiling level!"

--- a/charts/spica/tests/database_test.yaml
+++ b/charts/spica/tests/database_test.yaml
@@ -132,6 +132,19 @@ tests:
           path: spec.template.spec.containers[0].args[0]
           pattern: "--auth"
 
+  - it: should pass the resolvable primary node FQDN to the init container
+    template: templates/database.yaml
+    documentSelector:
+      path: kind
+      value: StatefulSet
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: RS_PRIMARY_HOST
+            value: release-name-database-0.release-name-database.default.svc.cluster.local
+          any: true
+
   - it: should include RS_MEMBERS env var when replicas equals 1
     template: templates/database.yaml
     documentSelector:

--- a/charts/spica/tests/databasereplication_test.yaml
+++ b/charts/spica/tests/databasereplication_test.yaml
@@ -99,10 +99,10 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--username"
+          content: "--username=$(ROOT_USERNAME)"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--password"
+          content: "--password=$(ROOT_PASSWORD)"
 
   - it: should read ROOT_USERNAME from database root credentials secret
     asserts:

--- a/charts/spica/tests/initdb_test.yaml
+++ b/charts/spica/tests/initdb_test.yaml
@@ -46,6 +46,15 @@ tests:
           path: data["init-users.sh"]
           pattern: rs\.initiate
 
+  - it: init-users.sh should initiate with the pod FQDN, never the bare hostname
+    asserts:
+      - matchRegex:
+          path: data["init-users.sh"]
+          pattern: "rs\\.initiate\\(\\{_id: 'rs0', members: \\[\\{_id: 0, host: '\\$RS_PRIMARY_HOST'\\}\\]\\}\\)"
+      - notMatchRegex:
+          path: data["init-users.sh"]
+          pattern: "rs\\.initiate\\(\\)"
+
   - it: set-profiling-level.sh should reference setProfilingLevel
     asserts:
       - matchRegex:


### PR DESCRIPTION
## Problem

A Spica install can come up with a healthy MongoDB pod that no client can reach. The API and the migrate job both fail with:

```
MongoServerSelectionError: getaddrinfo ENOTFOUND <release>-database-0
  reason: TopologyDescription { type: 'ReplicaSetNoPrimary', setName: 'rs0',
    servers: Map(1) { '<release>-database-0:27017' => [ServerDescription] } }
```

Two independent defects combine to produce it.

**1. The replica set is bootstrapped with an unresolvable host.** `init-users.sh` called an argument-less `rs.initiate()`, so MongoDB derived the member host from `hostname` — a bare pod name that resolves only inside the database pod itself. Clients connect to the correct FQDN seed, run `hello`, are handed `<release>-database-0:27017` by SDAM, discard the good seed for it, and fail. `mongod` itself stays healthy and `PRIMARY` throughout, which makes this look like a networking problem rather than a config one.

Recovering depended entirely on the replication controller landing a reconfig afterwards.

**2. That recovery path breaks on roughly 1 install in 60.** `generatePassword` shuffles a charset containing `-`. When `-` lands first, the password is parsed as a *flag* rather than a value by both mongosh and yargs:

```
Error parsing command line: unrecognized option: -kYpQ0!8TTsC
```

Every `--password` consumer in the chart is affected: the replication controller, the startup probe, and `set-profiling-level.sh`. In the controller this error matches neither `connection attempt failed` nor `ENOTFOUND`, so it re-throws immediately and burns `backoffLimit: 25` without ever reconfiguring — leaving defect 1 permanently uncorrected.

Observed across 7 namespaces on one cluster: the single namespace whose root password began with `-` was the single namespace whose controller job failed and whose replica set was still on the bare hostname.

## Changes

- **`initdb.yaml`** — initiate with an explicit FQDN member from a new `RS_PRIMARY_HOST` env. The config is now correct at creation and no longer depends on the controller. Correct for single-node, and the right seed for multi-node where the controller still adds secondaries.
- **`_helpers.tpl`** — new `database.primaryNode` helper; `generatePassword` keeps its first character alphabetic.
- **Credentials passed as `--flag=value`** in the controller, the startup probe, the controller job args, and `set-profiling-level.sh`. This is what actually makes the chart immune, since existing installs keep their password via `lookup`.
- **`set-profiling-level.sh`** additionally used `--eval` with no argument followed by a heredoc, so profiling was never applied.
- **`main.ts`** — besides the credential form, all calls go through `mongoAddress()` with an explicit `directConnection=true`. This one is **behaviour-neutral today** and is not fixing a live bug: mongosh already resolves a lone `--host` to a `Single` (direct) topology, verified against a live instance. It pins that implicit default, which has changed across driver majors, for a tool whose whole job is addressing one specific node. Happy to drop it if you'd rather keep the PR minimal.

## Verification

- 159/159 helm-unittest tests pass; `helm lint`, `tsc`, and Prettier clean.
- New regression tests: `init-users.sh` uses the FQDN and never an argument-less initiate; the init container receives `RS_PRIMARY_HOST`.
- Password generator: 60/60 renders produce an alphabetic first character.
- Both command shapes exercised against a live affected database, using the actual `-`-leading password that caused the outage:

```
OLD:  Error parsing command line: unrecognized option: -kYpQ0!8TTsC
NEW:  {"status":1,"primary":true,"host":"...svc.cluster.local:27017"}
```

## Note

`rs0` is hardcoded in `mongod --replSet` while `.Values.database.replicaSetName` exists and is consumed only by the application, so setting that value to anything else is already broken. This PR matches the hardcode rather than widen scope — worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

