### PR TITLE
fix(charts): never generate a password starting with "-"

### DIFF
--- a/charts/spica/templates/_helpers.tpl
+++ b/charts/spica/templates/_helpers.tpl
@@ -37,15 +37,26 @@
 {{- end -}}
 
 
+{{- /*
+Generated passwords reach mongosh and yargs as CLI flag values, and are embedded into
+single-quoted shell strings and JS string literals. Two invariants keep that safe:
+
+  - the first character stays alphanumeric, because a value opening with "-" is parsed as
+    the start of another flag rather than as the value of the preceding one
+  - $specialChars must never contain "'" or "\", which terminate the surrounding string
+    literal or introduce an escape sequence
+
+Every other punctuation character here survives all of those contexts unaltered.
+*/ -}}
 {{- define "generatePassword" -}}
-  {{- $specialChars := list "!" "@" "#" "$" "%" "^" "&" "*" "-" "_" -}} 
-  {{- $password := list 
-        (randAlpha 2)
+  {{- $specialChars := list "!" "@" "#" "$" "%" "^" "&" "*" "-" "_" -}}
+  {{- $body := list
+        (randAlpha 1)
         (randNumeric 2)
         (index $specialChars (randInt 0 (len $specialChars)))
         (index $specialChars (randInt 0 (len $specialChars)))
         (randAlphaNum 6)
-      | join "" | shuffle 
+      | join "" | shuffle
   -}}
-  {{- $password -}}
+  {{- printf "%s%s" (randAlphaNum 1) $body -}}
 {{- end -}}


### PR DESCRIPTION
## Problem

`generatePassword` shuffles a charset containing `-`, so a generated password can begin with one. Measured over 150 renders of `master`: **2 began with `-`** (~1.3%, consistent with the ~1-in-60 the composition predicts), and 24 began with some non-alphanumeric character.

A value starting with `-` is read as the beginning of another flag rather than as the value of the preceding one, by both mongosh and yargs:

```
Error parsing command line: unrecognized option: -kYpQ0!8TTsC
```

Every consumer of that credential then fails at argument parsing. The replication controller is one of them — and when it cannot run, a freshly installed replica set is never reconfigured off the bare pod hostname that `rs.initiate()` gave it. That address resolves only inside the database pod, so the API and the migrate job fail with `ENOTFOUND` while `mongod` itself sits healthy and `PRIMARY`, which makes it read as a networking fault rather than a credential one.

Seen on a live cluster across 7 namespaces: the one namespace whose root password began with `-` was the one whose replication controller job had failed and whose replica set was still on the bare hostname. The other six were fine.

## Fix

Keep the first character alphanumeric. That covers `-` and any other prefix-sensitive character, without constraining the rest of the password. Length (12) and character-class composition (alpha, numeric, two specials) are unchanged.

Also documented, as a comment on the helper, why `'` and `\` must never be added to `$specialChars`. Neither is present today, so this is a guard rail rather than a change.

## Why no restart

`databasesecrets.yaml` preserves existing credentials via `lookup`, so `generatePassword` is not called on an upgrade of an installed release. Rendering `master` and this branch with credentials already supplied — the same code path `lookup` takes — produces **byte-identical output**, including the `checksum/secret` annotation the database StatefulSet is annotated with. Existing installs see no pod template change and no MongoDB restart.

## Verification

| | master | this branch |
|---|---|---|
| non-alphanumeric first char | 24 / 150 | **0 / 150** |
| leading `-` | 2 / 150 | **0 / 150** |
| password length | 12 | 12 |

Character hazards were measured rather than assumed, by round-tripping each candidate through both contexts the password is embedded in — a single-quoted shell string (`exec` in the replication controller) and a bash heredoc into a JS string literal (`init-users.sh`):

- `'` — breaks both
- `\` — corrupts the JS string literal via escape sequence
- `$ & ` " ; | ! @ # % ^ * - _` — all survive both unaltered

So only the leading-`-` case is a live defect; the charset itself is already safe.

157/157 helm-unittest tests pass; `helm lint` clean. No chart unit test asserts the invariant directly, since helm-unittest cannot base64-decode the Secret value — it is covered by the render sampling above.

## Scope

Deliberately narrow: this is the only defect that caused the outage, and it ships without restarting any database.

Two related items are **not** included here, both of which would force a MongoDB rolling restart via the StatefulSet's `checksum/initdb` annotation and pod template:

- **`init-users.sh` bootstraps the replica set with a bare hostname**, relying on the replication controller to repair it afterwards. That repair does normally succeed, so this is latent fragility rather than an active bug — but it is what turns any controller failure into a full outage instead of a degraded one.
- **Credentials passed as `--flag value` rather than `--flag=value`** in the controller and its Job. The `=` form is immune to any password content, which matters for already-installed releases that keep a `-`-leading password through `lookup`. These touch only a Job and are restart-free, but they belong with the bootstrap change.

Happy to open those as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
