### PR TITLE
fix(api): pin express to one copy in the built image

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -2,6 +2,9 @@
   "name": "@spica/server",
   "version": "0.0.0-PLACEHOLDER",
   "type": "module",
+  "resolutions": {
+    "express": "4.22.1"
+  },
   "dependencies": {
     "@nestjs/common": "^10.4.22",
     "@nestjs/core": "^10.4.22",


### PR DESCRIPTION
## Symptom

Every Spica function reports the same route in metrics:

```
http_route = "/fn-execute"        # not /fn-execute/leader-board
```

In Mimir that collapses every function in a tenant into one series, so `http_server_duration` can't be broken down per function. Bucket and passport endpoints are fine (`/bucket/:bucketId/data`), which is what makes it look like the functions router is a catch-all mount. It isn't — `subscribe()` registers real Express routes (`http.ts:229`).

## Cause

`spicaengine/api:0.19.3` ships **two copies of express**:

```
/app/node_modules/express                                              4.22.1
/app/node_modules/@spica-server/function-enqueuer/node_modules/express 4.22.2
```

`@nestjs/platform-express` uses the first, `HttpEnqueuer` the second.

The OpenTelemetry operator patches express through a **CommonJS require hook** (`NODE_OPTIONS=--require .../autoinstrumentation.js`; the bundle registers no ESM loader hook). Only the copy Nest pulls in is ever loaded that way. So nothing registered on the enqueuer's router is instrumented — confirmed in a production trace, which contains:

```
middleware - query
middleware - expressInit
router - /fn-execute          ← the app.use() mount layer, on Nest's patched copy
```

and **no** `middleware - raw` for the enqueuer's bodyParser and **no** `request handler - …` span. Compare a bucket request, which does have `request handler - /bucket/:bucketId/data`. Only the mount layer contributes a path, so the route stops at `/fn-execute`.

## Why it only happens in the image

The workspace is fine — `yarn.lock` resolves every express range to a single 4.22.1. The duplication is created at image build time:

- `scripts/prune.mjs` emits `package.json` + `dist/` with **no lockfile**
- `apps/api/Dockerfile` runs a bare `yarn install --production`, re-resolving every range from the registry
- Yarn classic resolves the `file:` dependency's own `"express": "^4.21.2"` independently of the tree it's installed into, and nests the newer 4.22.2 under it

## Fix

`resolutions` is the lever that survives that install: `prune.mjs` copies this manifest to the image root verbatim (it only rewrites `workspace:` refs and drops `devDependencies`), and yarn classic applies root resolutions to nested `file:` dependencies.

Reproduced against `node:22-slim` with a minimal tree mirroring the pruned layout:

```
before:  /app/node_modules/express                 4.22.1
         /app/node_modules/pkg/node_modules/express 4.22.2
after:   /app/node_modules/express                 4.22.1     ← single copy
```

The field is **inert for local development** — yarn only honours `resolutions` in the root manifest, and this is a workspace member. It exists solely for the pruned install inside the image. `yarn workspaces list` parses cleanly.

## What to expect after deploy

- `/fn-execute` traces gain a `request handler - <trigger path>` span
- `http_route` becomes `/fn-execute/<trigger path>`, and functions with parameterised trigger paths report templates (`/fn-execute/user/:id`), not one series per id

## Maintenance

Keep the pin in step with `yarn.lock` when express is upgraded — a mismatch silently reintroduces the second copy rather than failing the build.

## Not addressed here

The operator injects no ESM loader hook, so any dependency loaded **only** via ESM `import` is invisible to auto-instrumentation. `@nestjs/core` and `amqplib` are candidates — neither produces spans in production despite being instrumentable and imported. That's a separate change (a `NODE_OPTIONS` addition on the Instrumentation CR), not a code change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)