### PR TITLE
fix(migrate): convert function secret and env var ids to ObjectId

### DIFF
--- a/apps/migrate/src/migrations/0.19.4/convert_function_relation_ids_to_objectid.ts
+++ b/apps/migrate/src/migrations/0.19.4/convert_function_relation_ids_to_objectid.ts
@@ -1,0 +1,47 @@
+import {ObjectId} from "mongodb";
+import {Context} from "../../migrate";
+
+const RELATION_FIELDS = ["secrets", "env_vars"];
+
+function normalize(values: unknown[]) {
+  const unique = new Map<string, unknown>();
+
+  for (const value of values) {
+    const id =
+      typeof value == "string" && ObjectId.isValid(value) ? new ObjectId(value) : value;
+    unique.set(String(id), id);
+  }
+
+  return Array.from(unique.values());
+}
+
+export default async function (ctx: Context) {
+  const coll = ctx.database.collection("function");
+
+  const fns = await coll
+    .find(
+      {$or: RELATION_FIELDS.map(field => ({[field]: {$elemMatch: {$type: "string"}}}))},
+      {session: ctx.session}
+    )
+    .toArray();
+
+  const bulkOps = [];
+
+  for (const fn of fns) {
+    const update = {};
+
+    for (const field of RELATION_FIELDS) {
+      if (Array.isArray(fn[field])) {
+        update[field] = normalize(fn[field]);
+      }
+    }
+
+    if (Object.keys(update).length) {
+      bulkOps.push({updateOne: {filter: {_id: fn._id}, update: {$set: update}}});
+    }
+  }
+
+  if (bulkOps.length) {
+    await coll.bulkWrite(bulkOps, {session: ctx.session});
+  }
+}

--- a/apps/migrate/src/migrations/index.json
+++ b/apps/migrate/src/migrations/index.json
@@ -17,5 +17,6 @@
     "0.16.0/migrate_identity_attributes_to_bucket.js"
   ],
   "0.17.0": ["0.17.0/set_mongodb_fcv_7.js"],
-  "0.18.0": ["0.18.0/remove_position_from_bucket_properties.js"]
+  "0.18.0": ["0.18.0/remove_position_from_bucket_properties.js"],
+  "0.19.4": ["0.19.4/convert_function_relation_ids_to_objectid.js"]
 }

--- a/apps/migrate/test/migrations/0_19_4_convert_function_relation_ids_to_objectid.spec.ts
+++ b/apps/migrate/test/migrations/0_19_4_convert_function_relation_ids_to_objectid.spec.ts
@@ -1,0 +1,165 @@
+import {Db, getConnectionUri, getDatabaseName, start} from "@spica-server/database-testing";
+import {ObjectId} from "mongodb";
+import color from "cli-color/lib/supports-color";
+import {run} from "@spica/migrate";
+import path from "path";
+
+process.env.TESTONLY_MIGRATION_LOOKUP_DIR = path.join(process.cwd(), "dist/src");
+
+jest.setTimeout(120_000);
+
+describe("Convert function relation ids to ObjectId", () => {
+  let db: Db;
+  let args: string[];
+
+  const migrate = () =>
+    run([...args, "--from", "0.19.3", "--to", "0.19.4", "--continue-if-versions-are-equal"]);
+
+  beforeAll(() => {
+    color.disableColor();
+  });
+
+  beforeEach(async () => {
+    const connection = await start("replset");
+    args = ["--database-uri", await getConnectionUri(), "--database-name", getDatabaseName()];
+    db = connection.db(args[3]);
+  });
+
+  it("should convert string secret and env var ids to ObjectId", async () => {
+    const secretId = new ObjectId();
+    const envVarId = new ObjectId();
+
+    await db.collection("function").insertOne({
+      name: "fn",
+      language: "javascript",
+      timeout: 60,
+      secrets: [secretId.toHexString()],
+      env_vars: [envVarId.toHexString()]
+    });
+
+    await migrate();
+
+    const fn = await db.collection("function").findOne({name: "fn"});
+
+    expect(fn.secrets[0]).toBeInstanceOf(ObjectId);
+    expect(fn.secrets[0].toHexString()).toEqual(secretId.toHexString());
+    expect(fn.env_vars[0]).toBeInstanceOf(ObjectId);
+    expect(fn.env_vars[0].toHexString()).toEqual(envVarId.toHexString());
+  });
+
+  it("should collapse a string and ObjectId pair of the same id", async () => {
+    const secretId = new ObjectId();
+
+    await db.collection("function").insertOne({
+      name: "fn",
+      language: "javascript",
+      timeout: 60,
+      secrets: [secretId.toHexString(), secretId]
+    });
+
+    await migrate();
+
+    const fn = await db.collection("function").findOne({name: "fn"});
+
+    expect(fn.secrets).toHaveLength(1);
+    expect(fn.secrets[0]).toBeInstanceOf(ObjectId);
+    expect(fn.secrets[0].toHexString()).toEqual(secretId.toHexString());
+  });
+
+  it("should leave already converted documents untouched", async () => {
+    const secretId = new ObjectId();
+    const envVarId = new ObjectId();
+
+    await db.collection("function").insertOne({
+      name: "fn",
+      language: "javascript",
+      timeout: 60,
+      secrets: [secretId],
+      env_vars: [envVarId]
+    });
+
+    await migrate();
+
+    const fn = await db.collection("function").findOne({name: "fn"});
+
+    expect(fn.secrets).toEqual([secretId]);
+    expect(fn.env_vars).toEqual([envVarId]);
+  });
+
+  it("should keep values that are not valid ids", async () => {
+    const secretId = new ObjectId();
+
+    await db.collection("function").insertOne({
+      name: "fn",
+      language: "javascript",
+      timeout: 60,
+      secrets: ["not-an-object-id", secretId.toHexString()]
+    });
+
+    await migrate();
+
+    const fn = await db.collection("function").findOne({name: "fn"});
+
+    expect(fn.secrets).toHaveLength(2);
+    expect(fn.secrets[0]).toEqual("not-an-object-id");
+    expect(fn.secrets[1]).toBeInstanceOf(ObjectId);
+  });
+
+  it("should not touch functions without relation fields", async () => {
+    await db.collection("function").insertOne({
+      name: "fn",
+      language: "javascript",
+      timeout: 60
+    });
+
+    await migrate();
+
+    const fn = await db.collection("function").findOne({name: "fn"});
+
+    expect(fn.secrets).toBeUndefined();
+    expect(fn.env_vars).toBeUndefined();
+  });
+
+  it("should convert every affected function", async () => {
+    const first = new ObjectId();
+    const second = new ObjectId();
+
+    await db.collection("function").insertMany([
+      {name: "fn1", language: "javascript", timeout: 60, secrets: [first.toHexString()]},
+      {name: "fn2", language: "javascript", timeout: 60, env_vars: [second.toHexString()]},
+      {name: "fn3", language: "javascript", timeout: 60, secrets: [first]}
+    ]);
+
+    await migrate();
+
+    const fns = await db.collection("function").find({}).sort({name: 1}).toArray();
+
+    expect(fns[0].secrets[0]).toBeInstanceOf(ObjectId);
+    expect(fns[1].env_vars[0]).toBeInstanceOf(ObjectId);
+    expect(fns[2].secrets).toEqual([first]);
+  });
+
+  it("should leave no string entries behind", async () => {
+    await db.collection("function").insertMany([
+      {
+        name: "fn1",
+        language: "javascript",
+        timeout: 60,
+        secrets: [new ObjectId().toHexString()],
+        env_vars: [new ObjectId().toHexString()]
+      },
+      {name: "fn2", language: "javascript", timeout: 60, secrets: [new ObjectId()]}
+    ]);
+
+    await migrate();
+
+    const remaining = await db.collection("function").countDocuments({
+      $or: [
+        {secrets: {$elemMatch: {$type: "string"}}},
+        {env_vars: {$elemMatch: {$type: "string"}}}
+      ]
+    });
+
+    expect(remaining).toEqual(0);
+  });
+});

--- a/packages/api/function/src/crud.ts
+++ b/packages/api/function/src/crud.ts
@@ -15,10 +15,46 @@ import {FunctionPipelineBuilder} from "./pipeline.builder.js";
 import fs from "fs";
 import * as readline from "readline";
 
+const RELATION_FIELDS = ["env_vars", "secrets"] as const;
+
+function toRelationId(value: unknown) {
+  if (value instanceof ObjectId) {
+    return value;
+  }
+
+  if (!ObjectId.isValid(value as string)) {
+    throw new BadRequestException(`${value} is not a valid id.`);
+  }
+
+  return new ObjectId(value as string);
+}
+
+function normalizeRelations(fn: Function) {
+  for (const field of RELATION_FIELDS) {
+    const values = fn[field];
+
+    if (!Array.isArray(values)) {
+      continue;
+    }
+
+    const unique = new Map<string, ObjectId>();
+    for (const value of values) {
+      const id = toRelationId(value);
+      unique.set(id.toHexString(), id);
+    }
+
+    fn[field] = Array.from(unique.values());
+  }
+
+  return fn;
+}
+
 async function insertWithChanges(fs: FunctionService, engine: FunctionEngine, fn: Function) {
   if (fn._id) {
     fn._id = new ObjectId(fn._id);
   }
+
+  normalizeRelations(fn);
 
   try {
     const r = await fs.insertOne(fn);
@@ -134,6 +170,8 @@ export async function replace(fs: FunctionService, engine: FunctionEngine, fn: F
   // not sure that is necessary
   delete fn._id;
   delete fn.language;
+
+  normalizeRelations(fn);
 
   const preFn = await fs.findOneAndUpdate({_id}, {$set: fn});
   if (!preFn) {

--- a/packages/api/function/src/schema/function.json
+++ b/packages/api/function/src/schema/function.json
@@ -22,12 +22,12 @@
     "env_vars": {
       "type": "array",
       "description": "Environment variables that will be accesible globally in the function",
-      "items": {"type": "string"}
+      "items": {"type": "string", "format": "objectid"}
     },
     "secrets": {
       "type": "array",
       "description": "Secrets that will be accessible in the function",
-      "items": {"type": "string"}
+      "items": {"type": "string", "format": "objectid"}
     },
     "memoryLimit": {
       "type": "number",

--- a/packages/api/function/test/controller.spec.ts
+++ b/packages/api/function/test/controller.spec.ts
@@ -393,6 +393,24 @@ describe("Function Controller", () => {
       expect(raw.secrets).toHaveLength(1);
     });
 
+    it("should deduplicate repeated relation ids", async () => {
+      const secretId = new ObjectId().toHexString();
+      const envVarId = new ObjectId().toHexString();
+
+      const fn = await request
+        .post("/function", {
+          ...fnSchema,
+          secrets: [secretId, secretId],
+          env_vars: [envVarId, envVarId, envVarId]
+        })
+        .then(r => r.body);
+
+      const raw = await rawFunction(fn._id);
+
+      expect(raw.secrets).toHaveLength(1);
+      expect(raw.env_vars).toHaveLength(1);
+    });
+
     it("should reject a malformed secret id with 400", async () => {
       const res = await request.post("/function", {...fnSchema, secrets: ["not-an-object-id"]});
 

--- a/packages/api/function/test/controller.spec.ts
+++ b/packages/api/function/test/controller.spec.ts
@@ -6,6 +6,7 @@ import path from "path";
 import {INestApplication} from "@nestjs/common";
 import {CoreTestingModule, Request} from "@spica-server/core-testing";
 import {DatabaseTestingModule, ObjectId} from "@spica-server/database-testing";
+import {DatabaseService} from "@spica-server/database";
 import {SchemaModule} from "@spica-server/core-schema";
 import {OBJECTID_STRING, OBJECT_ID} from "@spica-server/core-schema";
 import {PassportTestingModule} from "@spica-server/passport-testing";
@@ -15,6 +16,7 @@ import {SecretModule} from "@spica-server/secret";
 describe("Function Controller", () => {
   let app: INestApplication;
   let request: Request;
+  let database: DatabaseService;
 
   const assetsPath = fs.mkdtempSync(path.join(os.tmpdir(), "spica-fn-assets-"));
   const fnSchema = {
@@ -78,6 +80,7 @@ describe("Function Controller", () => {
     }).compile();
 
     request = module.get(Request);
+    database = module.get(DatabaseService);
     app = module.createNestApplication();
     await app.listen(request.socket);
   });
@@ -278,6 +281,130 @@ describe("Function Controller", () => {
       const secrets = found.secrets.map(({updated_at, ...rest}) => rest);
       expect(secrets).toEqual([{_id: secret._id, key: "MY_SECRET"}]);
       expect(found.secrets[0].value).toBeUndefined();
+    });
+  });
+
+  describe("body-supplied relations", () => {
+    async function rawFunction(id: string) {
+      return database.collection("function").findOne({_id: new ObjectId(id)});
+    }
+
+    it("should persist body-supplied secret ids as ObjectId", async () => {
+      const secret = await request
+        .post("/secret", {key: "MY_SECRET", value: "super-secret-value"})
+        .then(r => r.body);
+
+      const fn = await request
+        .post("/function", {...fnSchema, secrets: [secret._id]})
+        .then(r => r.body);
+
+      const raw = await rawFunction(fn._id);
+
+      expect(raw.secrets).toHaveLength(1);
+      expect(raw.secrets[0]).toBeInstanceOf(ObjectId);
+      expect(raw.secrets[0].toHexString()).toEqual(secret._id);
+    });
+
+    it("should resolve body-supplied secrets on read", async () => {
+      const secret = await request
+        .post("/secret", {key: "MY_SECRET", value: "super-secret-value"})
+        .then(r => r.body);
+
+      const fn = await request
+        .post("/function", {...fnSchema, secrets: [secret._id]})
+        .then(r => r.body);
+
+      const found = await request.get(`/function/${fn._id}`).then(r => r.body);
+
+      expect(found.secrets).toHaveLength(1);
+      expect(found.secrets[0]._id).toEqual(secret._id);
+      expect(found.secrets[0].key).toEqual("MY_SECRET");
+      expect(found.secrets[0].value).toBeUndefined();
+    });
+
+    it("should persist body-supplied env var ids as ObjectId", async () => {
+      const envVarId = new ObjectId().toHexString();
+
+      const fn = await request
+        .post("/function", {...fnSchema, env_vars: [envVarId]})
+        .then(r => r.body);
+
+      const raw = await rawFunction(fn._id);
+
+      expect(raw.env_vars).toHaveLength(1);
+      expect(raw.env_vars[0]).toBeInstanceOf(ObjectId);
+      expect(raw.env_vars[0].toHexString()).toEqual(envVarId);
+    });
+
+    it("should persist body-supplied relation ids as ObjectId on PUT", async () => {
+      const secretId = new ObjectId().toHexString();
+      const envVarId = new ObjectId().toHexString();
+
+      const fn = await request.post("/function", fnSchema).then(r => r.body);
+
+      const res = await request.put(`/function/${fn._id}`, {
+        ...fnSchema,
+        secrets: [secretId],
+        env_vars: [envVarId]
+      });
+      expect(res.statusCode).toEqual(200);
+
+      const raw = await rawFunction(fn._id);
+
+      expect(raw.secrets[0]).toBeInstanceOf(ObjectId);
+      expect(raw.env_vars[0]).toBeInstanceOf(ObjectId);
+    });
+
+    it("should not corrupt an injected secret on a subsequent PUT", async () => {
+      const secret = await request
+        .post("/secret", {key: "MY_SECRET", value: "super-secret-value"})
+        .then(r => r.body);
+
+      const fn = await request.post("/function", fnSchema).then(r => r.body);
+      await request.put(`/function/${fn._id}/secret/${secret._id}`);
+
+      await request.put(`/function/${fn._id}`, {
+        ...fnSchema,
+        name: "renamed",
+        secrets: [secret._id]
+      });
+
+      const raw = await rawFunction(fn._id);
+
+      expect(raw.secrets).toHaveLength(1);
+      expect(raw.secrets[0]).toBeInstanceOf(ObjectId);
+
+      const found = await request.get(`/function/${fn._id}`).then(r => r.body);
+      expect(found.secrets).toHaveLength(1);
+    });
+
+    it("should not duplicate a secret when body and inject paths are mixed", async () => {
+      const secret = await request
+        .post("/secret", {key: "MY_SECRET", value: "super-secret-value"})
+        .then(r => r.body);
+
+      const fn = await request
+        .post("/function", {...fnSchema, secrets: [secret._id]})
+        .then(r => r.body);
+
+      await request.put(`/function/${fn._id}/secret/${secret._id}`);
+
+      const raw = await rawFunction(fn._id);
+      expect(raw.secrets).toHaveLength(1);
+    });
+
+    it("should reject a malformed secret id with 400", async () => {
+      const res = await request.post("/function", {...fnSchema, secrets: ["not-an-object-id"]});
+
+      expect(res.statusCode).toEqual(400);
+      expect(res.body.message).toContain("secrets");
+    });
+
+    it("should reject a malformed env var id with 400", async () => {
+      const res = await request.post("/function", {...fnSchema, env_vars: ["not-an-object-id"]});
+
+      expect(res.statusCode).toEqual(400);
+      expect(res.body.message).toContain("env_vars");
     });
   });
 

--- a/packages/api/function/test/crud.spec.ts
+++ b/packages/api/function/test/crud.spec.ts
@@ -1,0 +1,147 @@
+import {Test, TestingModule} from "@nestjs/testing";
+import {DatabaseService, ObjectId} from "@spica-server/database";
+import {DatabaseTestingModule} from "@spica-server/database-testing";
+import {FunctionService} from "@spica-server/function-services";
+import {EnvVarService, EnvVarChangeDispatcher} from "@spica-server/env_var-services";
+import {SecretService, SecretChangeDispatcher} from "@spica-server/secret-services";
+import * as CRUD from "@spica-server/function/src/crud";
+import {Function} from "@spica-server/interface-function";
+
+describe("Function CRUD relation normalization", () => {
+  let module: TestingModule;
+  let database: DatabaseService;
+  let fs: FunctionService;
+  let engine: any;
+
+  const baseFn = () =>
+    ({
+      name: "test",
+      language: "javascript",
+      timeout: 10
+    }) as Function;
+
+  function rawFunction(id: ObjectId) {
+    return database.collection("function").findOne({_id: id});
+  }
+
+  beforeEach(async () => {
+    module = await Test.createTestingModule({
+      imports: [DatabaseTestingModule.replicaSet()]
+    }).compile();
+
+    database = module.get(DatabaseService);
+
+    const evs = new EnvVarService(database, new EnvVarChangeDispatcher());
+    const ss = new SecretService(database, "test-encryption-secret", new SecretChangeDispatcher());
+    fs = new FunctionService(database, evs, ss, {} as any);
+
+    engine = {
+      applyChangePlan: jest.fn().mockResolvedValue(undefined),
+      storeAssets: jest.fn().mockResolvedValue(undefined)
+    };
+  });
+
+  afterEach(async () => module.close());
+
+  describe("insert", () => {
+    it("should convert string relation ids to ObjectId", async () => {
+      const secretId = new ObjectId().toHexString();
+      const envVarId = new ObjectId().toHexString();
+
+      const fn = await CRUD.insert(fs, engine, {
+        ...baseFn(),
+        secrets: [secretId],
+        env_vars: [envVarId]
+      } as any);
+
+      const raw = await rawFunction(fn._id);
+
+      expect(raw.secrets[0]).toBeInstanceOf(ObjectId);
+      expect(raw.secrets[0].toHexString()).toEqual(secretId);
+      expect(raw.env_vars[0]).toBeInstanceOf(ObjectId);
+      expect(raw.env_vars[0].toHexString()).toEqual(envVarId);
+    });
+
+    it("should keep ObjectId relation ids untouched", async () => {
+      const secretId = new ObjectId();
+
+      const fn = await CRUD.insert(fs, engine, {
+        ...baseFn(),
+        secrets: [secretId]
+      } as any);
+
+      const raw = await rawFunction(fn._id);
+
+      expect(raw.secrets).toHaveLength(1);
+      expect(raw.secrets[0].toHexString()).toEqual(secretId.toHexString());
+    });
+
+    it("should deduplicate mixed string and ObjectId representations", async () => {
+      const secretId = new ObjectId();
+
+      const fn = await CRUD.insert(fs, engine, {
+        ...baseFn(),
+        secrets: [secretId.toHexString(), secretId]
+      } as any);
+
+      const raw = await rawFunction(fn._id);
+
+      expect(raw.secrets).toHaveLength(1);
+      expect(raw.secrets[0]).toBeInstanceOf(ObjectId);
+    });
+
+    it("should leave absent relation fields absent", async () => {
+      const fn = await CRUD.insert(fs, engine, baseFn());
+
+      const raw = await rawFunction(fn._id);
+
+      expect(raw.secrets).toBeUndefined();
+      expect(raw.env_vars).toBeUndefined();
+    });
+
+    it("should reject a malformed relation id", async () => {
+      await expect(
+        CRUD.insert(fs, engine, {...baseFn(), secrets: ["not-an-object-id"]} as any)
+      ).rejects.toThrow("not-an-object-id is not a valid id.");
+    });
+  });
+
+  describe("replace", () => {
+    it("should convert string relation ids to ObjectId", async () => {
+      const inserted = await CRUD.insert(fs, engine, baseFn());
+      const secretId = new ObjectId().toHexString();
+
+      await CRUD.replace(fs, engine, {
+        ...baseFn(),
+        _id: inserted._id,
+        secrets: [secretId]
+      } as any);
+
+      const raw = await rawFunction(new ObjectId(inserted._id));
+
+      expect(raw.secrets[0]).toBeInstanceOf(ObjectId);
+      expect(raw.secrets[0].toHexString()).toEqual(secretId);
+    });
+
+    it("should not downgrade an existing ObjectId relation to a string", async () => {
+      const secretId = new ObjectId();
+      const inserted = await CRUD.insert(fs, engine, {
+        ...baseFn(),
+        secrets: [secretId]
+      } as any);
+
+      await CRUD.replace(fs, engine, {
+        ...baseFn(),
+        _id: inserted._id,
+        name: "renamed",
+        secrets: [secretId.toHexString()]
+      } as any);
+
+      const raw = await rawFunction(new ObjectId(inserted._id));
+
+      expect(raw.name).toEqual("renamed");
+      expect(raw.secrets).toHaveLength(1);
+      expect(raw.secrets[0]).toBeInstanceOf(ObjectId);
+    });
+  });
+});

--- a/packages/core/schema/test/validator.spec.ts
+++ b/packages/core/schema/test/validator.spec.ts
@@ -2,6 +2,8 @@ import {Format} from "@spica-server/interface-core";
 import {Validator} from "@spica-server/core-schema/src/validator";
 import {JSONSchema7} from "json-schema";
 import {BehaviorSubject, Observable} from "rxjs";
+import {OBJECT_ID} from "@spica-server/core-schema";
+import {ObjectId} from "mongodb";
 
 describe("schema validator", () => {
   let validator: Validator;
@@ -323,6 +325,77 @@ describe("schema validator", () => {
         expect(coerceSpy.mock.calls[0][0]).toBe("formatted");
         expect(validateSpy).toHaveBeenCalledTimes(1);
         expect(validateSpy.mock.calls[0][0]).toBe("formatted");
+      });
+
+      it("should coerce custom format inside array items", async () => {
+        const coerceSpy = jest.fn(val => "test " + val);
+        const validateSpy = jest.fn(data => data == "formatted");
+        const format: Format = {
+          name: "myformat",
+          type: "string",
+          coerce: coerceSpy,
+          validate: validateSpy
+        };
+        const validator = new Validator({formats: [format]});
+        const data = {
+          test: ["formatted", "formatted"]
+        };
+        const schema = {
+          type: "object",
+          properties: {
+            test: {
+              type: "array",
+              items: {
+                type: "string",
+                format: "myformat"
+              }
+            }
+          }
+        };
+
+        await expect(validator.validate(schema, data)).resolves.toBeUndefined();
+        expect(data.test).toEqual(["test formatted", "test formatted"]);
+        expect(coerceSpy).toHaveBeenCalledTimes(2);
+      });
+
+      it("should coerce objectid format inside array items", async () => {
+        const validator = new Validator({formats: [OBJECT_ID]});
+        const id = new ObjectId().toHexString();
+        const data = {ids: [id]};
+        const schema = {
+          type: "object",
+          properties: {
+            ids: {
+              type: "array",
+              items: {
+                type: "string",
+                format: "objectid"
+              }
+            }
+          }
+        };
+
+        await expect(validator.validate(schema, data)).resolves.toBeUndefined();
+        expect(data.ids[0]).toBeInstanceOf(ObjectId);
+        expect((data.ids[0] as unknown as ObjectId).toHexString()).toBe(id);
+      });
+
+      it("should reject a malformed objectid inside array items", async () => {
+        const validator = new Validator({formats: [OBJECT_ID]});
+        const schema = {
+          type: "object",
+          properties: {
+            ids: {
+              type: "array",
+              items: {
+                type: "string",
+                format: "objectid"
+              }
+            }
+          }
+        };
+
+        await expect(validator.validate(schema, {ids: ["not-an-object-id"]})).rejects.toBeDefined();
       });
     });
   });


### PR DESCRIPTION
Instances that wrote the relation through POST/PUT /function hold BSON strings in function.secrets and function.env_vars. Those entries are invisible to the $lookup, the change-stream watcher and the $pull eject, so the code fix alone does not recover them.

Rewrite the string entries as ObjectId and collapse documents that ended up holding both representations of the same id. Values that are not valid ids are left as they are.

Registered under 0.19.4 rather than the next minor so the migration runs on the first upgrade past 0.19.3 whatever that release turns out to be.