### PR TITLE
fix(function): coerce secret and env var ids to ObjectId at the schema boundary

### DIFF
--- a/packages/api/function/src/schema/function.json
+++ b/packages/api/function/src/schema/function.json
@@ -22,12 +22,12 @@
     "env_vars": {
       "type": "array",
       "description": "Environment variables that will be accesible globally in the function",
-      "items": {"type": "string"}
+      "items": {"type": "string", "format": "objectid"}
     },
     "secrets": {
       "type": "array",
       "description": "Secrets that will be accessible in the function",
-      "items": {"type": "string"}
+      "items": {"type": "string", "format": "objectid"}
     },
     "memoryLimit": {
       "type": "number",

--- a/packages/api/function/test/controller.spec.ts
+++ b/packages/api/function/test/controller.spec.ts
@@ -6,6 +6,7 @@ import path from "path";
 import {INestApplication} from "@nestjs/common";
 import {CoreTestingModule, Request} from "@spica-server/core-testing";
 import {DatabaseTestingModule, ObjectId} from "@spica-server/database-testing";
+import {DatabaseService} from "@spica-server/database";
 import {SchemaModule} from "@spica-server/core-schema";
 import {OBJECTID_STRING, OBJECT_ID} from "@spica-server/core-schema";
 import {PassportTestingModule} from "@spica-server/passport-testing";
@@ -15,6 +16,7 @@ import {SecretModule} from "@spica-server/secret";
 describe("Function Controller", () => {
   let app: INestApplication;
   let request: Request;
+  let database: DatabaseService;
 
   const assetsPath = fs.mkdtempSync(path.join(os.tmpdir(), "spica-fn-assets-"));
   const fnSchema = {
@@ -78,6 +80,7 @@ describe("Function Controller", () => {
     }).compile();
 
     request = module.get(Request);
+    database = module.get(DatabaseService);
     app = module.createNestApplication();
     await app.listen(request.socket);
   });
@@ -278,6 +281,130 @@ describe("Function Controller", () => {
       const secrets = found.secrets.map(({updated_at, ...rest}) => rest);
       expect(secrets).toEqual([{_id: secret._id, key: "MY_SECRET"}]);
       expect(found.secrets[0].value).toBeUndefined();
+    });
+  });
+
+  describe("body-supplied relations", () => {
+    async function rawFunction(id: string) {
+      return database.collection("function").findOne({_id: new ObjectId(id)});
+    }
+
+    it("should persist body-supplied secret ids as ObjectId", async () => {
+      const secret = await request
+        .post("/secret", {key: "MY_SECRET", value: "super-secret-value"})
+        .then(r => r.body);
+
+      const fn = await request
+        .post("/function", {...fnSchema, secrets: [secret._id]})
+        .then(r => r.body);
+
+      const raw = await rawFunction(fn._id);
+
+      expect(raw.secrets).toHaveLength(1);
+      expect(raw.secrets[0]).toBeInstanceOf(ObjectId);
+      expect(raw.secrets[0].toHexString()).toEqual(secret._id);
+    });
+
+    it("should resolve body-supplied secrets on read", async () => {
+      const secret = await request
+        .post("/secret", {key: "MY_SECRET", value: "super-secret-value"})
+        .then(r => r.body);
+
+      const fn = await request
+        .post("/function", {...fnSchema, secrets: [secret._id]})
+        .then(r => r.body);
+
+      const found = await request.get(`/function/${fn._id}`).then(r => r.body);
+
+      expect(found.secrets).toHaveLength(1);
+      expect(found.secrets[0]._id).toEqual(secret._id);
+      expect(found.secrets[0].key).toEqual("MY_SECRET");
+      expect(found.secrets[0].value).toBeUndefined();
+    });
+
+    it("should persist body-supplied env var ids as ObjectId", async () => {
+      const envVarId = new ObjectId().toHexString();
+
+      const fn = await request
+        .post("/function", {...fnSchema, env_vars: [envVarId]})
+        .then(r => r.body);
+
+      const raw = await rawFunction(fn._id);
+
+      expect(raw.env_vars).toHaveLength(1);
+      expect(raw.env_vars[0]).toBeInstanceOf(ObjectId);
+      expect(raw.env_vars[0].toHexString()).toEqual(envVarId);
+    });
+
+    it("should persist body-supplied relation ids as ObjectId on PUT", async () => {
+      const secretId = new ObjectId().toHexString();
+      const envVarId = new ObjectId().toHexString();
+
+      const fn = await request.post("/function", fnSchema).then(r => r.body);
+
+      const res = await request.put(`/function/${fn._id}`, {
+        ...fnSchema,
+        secrets: [secretId],
+        env_vars: [envVarId]
+      });
+      expect(res.statusCode).toEqual(200);
+
+      const raw = await rawFunction(fn._id);
+
+      expect(raw.secrets[0]).toBeInstanceOf(ObjectId);
+      expect(raw.env_vars[0]).toBeInstanceOf(ObjectId);
+    });
+
+    it("should not corrupt an injected secret on a subsequent PUT", async () => {
+      const secret = await request
+        .post("/secret", {key: "MY_SECRET", value: "super-secret-value"})
+        .then(r => r.body);
+
+      const fn = await request.post("/function", fnSchema).then(r => r.body);
+      await request.put(`/function/${fn._id}/secret/${secret._id}`);
+
+      await request.put(`/function/${fn._id}`, {
+        ...fnSchema,
+        name: "renamed",
+        secrets: [secret._id]
+      });
+
+      const raw = await rawFunction(fn._id);
+
+      expect(raw.secrets).toHaveLength(1);
+      expect(raw.secrets[0]).toBeInstanceOf(ObjectId);
+
+      const found = await request.get(`/function/${fn._id}`).then(r => r.body);
+      expect(found.secrets).toHaveLength(1);
+    });
+
+    it("should not duplicate a secret when body and inject paths are mixed", async () => {
+      const secret = await request
+        .post("/secret", {key: "MY_SECRET", value: "super-secret-value"})
+        .then(r => r.body);
+
+      const fn = await request
+        .post("/function", {...fnSchema, secrets: [secret._id]})
+        .then(r => r.body);
+
+      await request.put(`/function/${fn._id}/secret/${secret._id}`);
+
+      const raw = await rawFunction(fn._id);
+      expect(raw.secrets).toHaveLength(1);
+    });
+
+    it("should reject a malformed secret id with 400", async () => {
+      const res = await request.post("/function", {...fnSchema, secrets: ["not-an-object-id"]});
+
+      expect(res.statusCode).toEqual(400);
+      expect(res.body.message).toContain("secrets");
+    });
+
+    it("should reject a malformed env var id with 400", async () => {
+      const res = await request.post("/function", {...fnSchema, env_vars: ["not-an-object-id"]});
+
+      expect(res.statusCode).toEqual(400);
+      expect(res.body.message).toContain("env_vars");
     });
   });
 

--- a/packages/core/schema/test/validator.spec.ts
+++ b/packages/core/schema/test/validator.spec.ts
@@ -2,6 +2,8 @@ import {Format} from "@spica-server/interface-core";
 import {Validator} from "@spica-server/core-schema/src/validator";
 import {JSONSchema7} from "json-schema";
 import {BehaviorSubject, Observable} from "rxjs";
+import {OBJECT_ID} from "@spica-server/core-schema";
+import {ObjectId} from "mongodb";
 
 describe("schema validator", () => {
   let validator: Validator;
@@ -323,6 +325,77 @@ describe("schema validator", () => {
         expect(coerceSpy.mock.calls[0][0]).toBe("formatted");
         expect(validateSpy).toHaveBeenCalledTimes(1);
         expect(validateSpy.mock.calls[0][0]).toBe("formatted");
+      });
+
+      it("should coerce custom format inside array items", async () => {
+        const coerceSpy = jest.fn(val => "test " + val);
+        const validateSpy = jest.fn(data => data == "formatted");
+        const format: Format = {
+          name: "myformat",
+          type: "string",
+          coerce: coerceSpy,
+          validate: validateSpy
+        };
+        const validator = new Validator({formats: [format]});
+        const data = {
+          test: ["formatted", "formatted"]
+        };
+        const schema = {
+          type: "object",
+          properties: {
+            test: {
+              type: "array",
+              items: {
+                type: "string",
+                format: "myformat"
+              }
+            }
+          }
+        };
+
+        await expect(validator.validate(schema, data)).resolves.toBeUndefined();
+        expect(data.test).toEqual(["test formatted", "test formatted"]);
+        expect(coerceSpy).toHaveBeenCalledTimes(2);
+      });
+
+      it("should coerce objectid format inside array items", async () => {
+        const validator = new Validator({formats: [OBJECT_ID]});
+        const id = new ObjectId().toHexString();
+        const data = {ids: [id]};
+        const schema = {
+          type: "object",
+          properties: {
+            ids: {
+              type: "array",
+              items: {
+                type: "string",
+                format: "objectid"
+              }
+            }
+          }
+        };
+
+        await expect(validator.validate(schema, data)).resolves.toBeUndefined();
+        expect(data.ids[0]).toBeInstanceOf(ObjectId);
+        expect((data.ids[0] as unknown as ObjectId).toHexString()).toBe(id);
+      });
+
+      it("should reject a malformed objectid inside array items", async () => {
+        const validator = new Validator({formats: [OBJECT_ID]});
+        const schema = {
+          type: "object",
+          properties: {
+            ids: {
+              type: "array",
+              items: {
+                type: "string",
+                format: "objectid"
+              }
+            }
+          }
+        };
+
+        await expect(validator.validate(schema, {ids: ["not-an-object-id"]})).rejects.toBeDefined();
       });
     });
   });


### PR DESCRIPTION
The function schema declared secrets and env_vars as plain string arrays, so the objectid format coercion never fired and POST/PUT /function persisted the relation ids as BSON strings. The $lookup that resolves those relations is type-strict, so the join returned nothing and secrets never reached the worker env. PUT also overwrote correctly typed ObjectIds written by the inject endpoint.

Add "format": "objectid" to both item schemas. Coercion already mutates parentData[parentDataProperty] in place, which covers array items.