### PR TITLE
perf(storage): build the gcs media link instead of fetching it

### DIFF
--- a/packages/api/storage/src/strategy/gcloud.ts
+++ b/packages/api/storage/src/strategy/gcloud.ts
@@ -11,11 +11,13 @@ export class GCloud extends BaseStrategy {
   private readonly logger = new Logger(GCloud.name);
   private storage: Storage;
   private bucket: Bucket;
+  private bucketName: string;
 
   constructor(serviceAccountPath: string, bucketName: string, resumableUploadExpiresIn: number) {
     super(resumableUploadExpiresIn);
     process.env.GOOGLE_APPLICATION_CREDENTIALS = serviceAccountPath;
     this.storage = new Storage();
+    this.bucketName = bucketName;
     this.bucket = this.storage.bucket(bucketName);
 
     this.initializeTusServer();
@@ -73,11 +75,10 @@ export class GCloud extends BaseStrategy {
   }
 
   url(id: string) {
-    return this.getMetadata(id).then(res => {
-      const url = new URL(res.mediaLink);
-      url.searchParams.delete("generation");
-      return url.toString();
-    });
+    const name = encodeURIComponent(id);
+    return Promise.resolve(
+      `https://storage.googleapis.com/download/storage/v1/b/${this.bucketName}/o/${name}?alt=media`
+    );
   }
 
   async proxyRead(

--- a/packages/api/storage/test/strategy/gcloud.spec.ts
+++ b/packages/api/storage/test/strategy/gcloud.spec.ts
@@ -44,6 +44,7 @@ describe("GCloud", () => {
 
   beforeEach(() => {
     mediaLink = "http://insteadof?generation=123123";
+    File.getMetadata.mockImplementation(() => Promise.resolve([{mediaLink}]));
 
     service = new GCloud("test_path", "test_bucket", 0);
 
@@ -91,23 +92,39 @@ describe("GCloud", () => {
     expect(Bucket.deleteFiles).toHaveBeenCalledWith({prefix: "test_file"});
   });
 
-  it("should get url without generation param", async () => {
-    const url = await service.url("test_file");
+  describe("url", () => {
+    it("should build the media link of a simple object name", async () => {
+      const url = await service.url("test_file");
 
-    expect(Bucket.file).toHaveBeenCalledTimes(1);
-    expect(Bucket.file).toHaveBeenCalledWith("test_file");
+      expect(url).toEqual(
+        "https://storage.googleapis.com/download/storage/v1/b/test_bucket/o/test_file?alt=media"
+      );
+    });
 
-    expect(File.getMetadata).toHaveBeenCalledTimes(1);
+    it("should percent encode the slashes of a nested object name", async () => {
+      const url = await service.url("a/b/c.png");
 
-    expect(url).toEqual("http://insteadof/");
-  });
+      expect(url).toEqual(
+        "https://storage.googleapis.com/download/storage/v1/b/test_bucket/o/a%2Fb%2Fc.png?alt=media"
+      );
+    });
 
-  it("should get url even if it has no generation param", async () => {
-    mediaLink = "http://insteadof";
+    it("should not perform any network call", async () => {
+      await service.url("test_file");
 
-    const url = await service.url("test_file");
+      expect(Bucket.file).not.toHaveBeenCalled();
+      expect(File.getMetadata).not.toHaveBeenCalled();
+    });
 
-    expect(url).toEqual("http://insteadof/");
+    it("should resolve for a name that does not exist in the bucket", async () => {
+      File.getMetadata.mockImplementation(() =>
+        Promise.reject(new Error("No such object: missing_file"))
+      );
+
+      await expect(service.url("missing_file")).resolves.toEqual(
+        "https://storage.googleapis.com/download/storage/v1/b/test_bucket/o/missing_file?alt=media"
+      );
+    });
   });
 
   describe("writeStream", () => {


### PR DESCRIPTION
GCloud.url() called getMetadata() just to read mediaLink, so listing a bucket fired one HTTPS request per object through the unbounded Promise.all in StorageService.putUrls(). A few thousand objects meant a few thousand concurrent requests, and a single object missing from GCS rejected the whole listing.

mediaLink is deterministic, so build it from the bucket and the encoded object name. This is byte-for-byte what url() returned before, once the generation param was stripped, and it makes GCS behave like the default and awss3 strategies: zero I/O.