### PR TITLE
feat(function): pass the api-resolved client ip into functions

### DIFF
--- a/packages/api/function/enqueuer/src/http.ts
+++ b/packages/api/function/enqueuer/src/http.ts
@@ -137,16 +137,16 @@ export class HttpEnqueuer extends Enqueuer<HttpOptions> {
         }
       }
 
-      if (options.rateLimit) {
-        const ip = req.ip;
+      const clientIp = req.ip;
 
-        if (!ip) {
+      if (options.rateLimit) {
+        if (!clientIp) {
           console.warn(
             "Could not determine client IP address for rate limiting. Allowing request by default."
           );
         } else {
           const groupKey = `${target.cwd}:${target.handler}`;
-          const rateLimitResult = this.rateLimitService.checkLimit(groupKey, ip);
+          const rateLimitResult = this.rateLimitService.checkLimit(groupKey, clientIp);
 
           if (rateLimitResult.limit > 0) {
             res.setHeader("X-RateLimit-Limit", rateLimitResult.limit);
@@ -179,7 +179,8 @@ export class HttpEnqueuer extends Enqueuer<HttpOptions> {
         statusCode: req.statusCode,
         statusMessage: req.statusMessage,
         query: JSON.stringify(req.query),
-        body: new Uint8Array(req.body)
+        body: new Uint8Array(req.body),
+        ip: clientIp
       });
       request.params = Object.keys(req.params).reduce((acc, key) => {
         const param = new Http.Param();

--- a/packages/api/function/enqueuer/test/http.spec.ts
+++ b/packages/api/function/enqueuer/test/http.spec.ts
@@ -1006,17 +1006,23 @@ describe("http enqueuer client ip", () => {
 
   it("should hand the function the ip the api resolved", async () => {
     const fixture = await createFixture(true);
-    const headers = {"X-Forwarded-For": "1.2.3.4"};
+    // A chain, so the resolved ip is only the leftmost hop and the raw header differs from it.
+    const forwardedFor = "1.2.3.4, 5.6.7.8";
+    const headers = {"X-Forwarded-For": forwardedFor};
 
     await fixture.request.get("/fn-execute/ip", undefined, headers);
     const apiIp = await fixture.request
       .get<{ip: string}>("/api-ip", undefined, headers)
       .then(response => response.body.ip);
 
-    const enqueuedIp = fixture.httpQueue.enqueue.mock.calls[0][1].ip;
+    const request = fixture.httpQueue.enqueue.mock.calls[0][1];
+    const forwardedHeader = request.headers.find(h => h.key == "x-forwarded-for");
 
-    expect(enqueuedIp).toBeDefined();
-    expect(enqueuedIp).toBe(apiIp);
+    expect(request.ip).toBeDefined();
+    expect(request.ip).toBe(apiIp);
+    // The header keeps travelling on its own channel, untouched by the ip we now carry.
+    expect(forwardedHeader.value).toBe(forwardedFor);
+    expect(forwardedHeader.value).not.toBe(request.ip);
   });
 
   it("should leave the ip unset when the api cannot resolve one", async () => {

--- a/packages/api/function/enqueuer/test/http.spec.ts
+++ b/packages/api/function/enqueuer/test/http.spec.ts
@@ -1,11 +1,12 @@
 import express from "express";
+import http from "http";
 import {INestApplication} from "@nestjs/common";
 import {NestExpressApplication} from "@nestjs/platform-express";
 import {Test} from "@nestjs/testing";
 import {CoreTestingModule, Request} from "@spica-server/core-testing";
 import {HttpEnqueuer} from "@spica-server/function-enqueuer";
 import {EventQueue, HttpQueue} from "@spica-server/function-queue";
-import {event} from "@spica-server/function-queue-proto";
+import {event, Http} from "@spica-server/function-queue-proto";
 import {HttpMethod} from "@spica-server/interface-function-enqueuer";
 import {IGuardService} from "@spica-server/interface-passport-guard";
 
@@ -951,4 +952,191 @@ describe("http enqueuer with rate limiting", () => {
 
     httpEnqueuer.unsubscribe(noopTarget);
   });
+});
+describe("http enqueuer client ip", () => {
+  let apps: INestApplication[] = [];
+
+  const corsOptions = {
+    allowCredentials: true,
+    allowedHeaders: ["*"],
+    allowedMethods: ["*"],
+    allowedOrigins: ["*"]
+  };
+
+  interface Fixture {
+    port: number;
+    enqueuer: HttpEnqueuer;
+    httpQueue: {enqueue: jest.Mock; dequeue: jest.Mock};
+  }
+
+  /**
+   * Listens over TCP instead of a unix socket so that express can resolve a real
+   * `req.socket.remoteAddress` (127.0.0.1) and apply the "trust proxy" setting on top of it.
+   */
+  async function createFixture(trustProxy: any): Promise<Fixture> {
+    const module = await Test.createTestingModule({
+      imports: [CoreTestingModule]
+    }).compile();
+
+    const app = module.createNestApplication<NestExpressApplication>();
+    const instance = app.getHttpAdapter().getInstance();
+    instance.set("trust proxy", trustProxy);
+
+    // Mirrors how the api itself derives the client ip, so both sides can be compared.
+    instance.get("/api-ip", (req, res) => res.json({ip: req.ip}));
+
+    await app.listen(0, "127.0.0.1");
+    apps.push(app);
+
+    const httpQueue = {enqueue: jest.fn(), dequeue: jest.fn()};
+    httpQueue.enqueue.mockImplementation((id, req, res) => res.end());
+
+    const enqueuer = new HttpEnqueuer(
+      {enqueue: jest.fn(), dequeue: jest.fn()} as any,
+      httpQueue as any,
+      instance,
+      corsOptions,
+      createNoopGuardService()
+    );
+
+    enqueuer.subscribe(createTarget(), {
+      method: HttpMethod.Get,
+      path: "/ip",
+      preflight: false
+    });
+
+    return {port: (app.getHttpServer().address() as any).port, enqueuer, httpQueue};
+  }
+
+  /**
+   * Listens over a unix socket, where there is no `req.socket.remoteAddress` at all, so the api
+   * cannot resolve a client ip even though a proxy header is present.
+   */
+  async function createUnixFixture() {
+    const module = await Test.createTestingModule({
+      imports: [CoreTestingModule]
+    }).compile();
+
+    const app = module.createNestApplication<NestExpressApplication>();
+    const instance = app.getHttpAdapter().getInstance();
+    instance.set("trust proxy", false);
+
+    const req = module.get(Request);
+    await app.listen(req.socket);
+    apps.push(app);
+
+    const httpQueue = {enqueue: jest.fn(), dequeue: jest.fn()};
+    httpQueue.enqueue.mockImplementation((id, request, res) => res.end());
+
+    const enqueuer = new HttpEnqueuer(
+      {enqueue: jest.fn(), dequeue: jest.fn()} as any,
+      httpQueue as any,
+      instance,
+      corsOptions,
+      createNoopGuardService()
+    );
+
+    enqueuer.subscribe(createTarget(), {
+      method: HttpMethod.Get,
+      path: "/ip",
+      preflight: false
+    });
+
+    return {req, httpQueue};
+  }
+
+  function send(port: number, path: string, headers: Record<string, string> = {}) {
+    return new Promise<{statusCode: number; body: string}>((resolve, reject) => {
+      const request = http.request({host: "127.0.0.1", port, path, method: "GET", headers}, res => {
+        let body = "";
+        res.on("data", chunk => (body += chunk));
+        res.on("end", () => resolve({statusCode: res.statusCode, body}));
+      });
+      request.on("error", reject);
+      request.end();
+    });
+  }
+
+  async function enqueuedIp(fixture: Fixture, headers?: Record<string, string>) {
+    await send(fixture.port, "/fn-execute/ip", headers);
+    const calls = fixture.httpQueue.enqueue.mock.calls;
+    return calls[calls.length - 1][1].ip;
+  }
+
+  async function apiIp(fixture: Fixture, headers?: Record<string, string>) {
+    const response = await send(fixture.port, "/api-ip", headers);
+    return JSON.parse(response.body).ip;
+  }
+
+  afterEach(async () => {
+    await Promise.all(apps.map(app => app.close()));
+    apps = [];
+  });
+
+  it("should forward the socket address when there is no proxy header", async () => {
+    const fixture = await createFixture(true);
+    expect(await enqueuedIp(fixture)).toBe("127.0.0.1");
+  });
+
+  it("should ignore a forged x-forwarded-for when trust proxy is disabled", async () => {
+    const fixture = await createFixture(false);
+    const headers = {"x-forwarded-for": "1.2.3.4"};
+
+    expect(await enqueuedIp(fixture, headers)).toBe("127.0.0.1");
+    expect(await apiIp(fixture, headers)).toBe("127.0.0.1");
+  });
+
+  it("should keep the forged header intact while ignoring it for the ip", async () => {
+    const fixture = await createFixture(false);
+
+    await send(fixture.port, "/fn-execute/ip", {"x-forwarded-for": "1.2.3.4"});
+
+    const request = fixture.httpQueue.enqueue.mock.calls[0][1];
+    const forwardedHeader = request.headers.find(h => h.key == "x-forwarded-for");
+
+    expect(forwardedHeader.value).toBe("1.2.3.4");
+    expect(request.ip).toBe("127.0.0.1");
+  });
+
+  it("should not let an arbitrary header override the resolved ip", async () => {
+    const fixture = await createFixture(true);
+    expect(await enqueuedIp(fixture, {ip: "6.6.6.6"})).toBe("127.0.0.1");
+  });
+
+  it("should leave the ip unset when the api cannot resolve one", async () => {
+    const fixture = await createUnixFixture();
+
+    await fixture.req.get("/fn-execute/ip", undefined, {"X-Forwarded-For": "1.2.3.4"});
+
+    const request = fixture.httpQueue.enqueue.mock.calls[0][1];
+
+    expect(request.ip).toBeUndefined();
+    expect(request.headers.find(h => h.key == "x-forwarded-for").value).toBe("1.2.3.4");
+    // An unset field must not reach the wire at all.
+    expect(Http.Request.deserialize(request.serialize()).ip).toBeUndefined();
+  });
+
+  it("should resolve the leftmost address when every hop is trusted", async () => {
+    const fixture = await createFixture(true);
+    expect(await enqueuedIp(fixture, {"x-forwarded-for": "9.9.9.9, 8.8.8.8"})).toBe("9.9.9.9");
+  });
+
+  it.each([
+    ["true", true, "9.9.9.9, 8.8.8.8", "9.9.9.9"],
+    ["false", false, "9.9.9.9, 8.8.8.8", "127.0.0.1"],
+    ["a single hop", 1, "9.9.9.9, 8.8.8.8", "8.8.8.8"],
+    ["two hops", 2, "9.9.9.9, 8.8.8.8", "9.9.9.9"],
+    ["a list of trusted ips", ["127.0.0.1"], "9.9.9.9, 8.8.8.8", "8.8.8.8"],
+    ["a list covering the whole chain", ["127.0.0.1", "8.8.8.8"], "9.9.9.9, 8.8.8.8", "9.9.9.9"],
+    ["a predefined subnet name", "loopback", "9.9.9.9, 8.8.8.8", "8.8.8.8"]
+  ])(
+    "should resolve the same ip as the api when trust proxy is %s",
+    async (_, trustProxy, forwardedFor, expected) => {
+      const fixture = await createFixture(trustProxy);
+      const headers = {"x-forwarded-for": forwardedFor as string};
+
+      expect(await enqueuedIp(fixture, headers)).toBe(expected);
+      expect(await apiIp(fixture, headers)).toBe(expected);
+    }
+  );
 });

--- a/packages/api/function/enqueuer/test/http.spec.ts
+++ b/packages/api/function/enqueuer/test/http.spec.ts
@@ -1,5 +1,4 @@
 import express from "express";
-import http from "http";
 import {INestApplication} from "@nestjs/common";
 import {NestExpressApplication} from "@nestjs/platform-express";
 import {Test} from "@nestjs/testing";
@@ -953,6 +952,7 @@ describe("http enqueuer with rate limiting", () => {
     httpEnqueuer.unsubscribe(noopTarget);
   });
 });
+
 describe("http enqueuer client ip", () => {
   let apps: INestApplication[] = [];
 
@@ -963,21 +963,7 @@ describe("http enqueuer client ip", () => {
     allowedOrigins: ["*"]
   };
 
-  interface Fixture {
-    httpQueue: {enqueue: jest.Mock; dequeue: jest.Mock};
-    port?: number;
-    unixRequest?: Request;
-  }
-
-  /**
-   * The tcp transport gives express a real `req.socket.remoteAddress` (127.0.0.1) to apply the
-   * "trust proxy" setting on top of. The unix transport has no remote address at all, which is
-   * how the api ends up unable to resolve a client ip even when a proxy header is present.
-   */
-  async function createFixture(
-    trustProxy: any,
-    transport: "tcp" | "unix" = "tcp"
-  ): Promise<Fixture> {
+  async function createFixture(trustProxy: any) {
     const module = await Test.createTestingModule({
       imports: [CoreTestingModule]
     }).compile();
@@ -989,12 +975,12 @@ describe("http enqueuer client ip", () => {
     // Mirrors how the api itself derives the client ip, so both sides can be compared.
     instance.get("/api-ip", (req, res) => res.json({ip: req.ip}));
 
-    const unixRequest = module.get(Request);
-    await (transport == "tcp" ? app.listen(0, "127.0.0.1") : app.listen(unixRequest.socket));
+    const request = module.get(Request);
+    await app.listen(request.socket);
     apps.push(app);
 
     const httpQueue = {enqueue: jest.fn(), dequeue: jest.fn()};
-    httpQueue.enqueue.mockImplementation((id, request, res) => res.end());
+    httpQueue.enqueue.mockImplementation((id, req, res) => res.end());
 
     const enqueuer = new HttpEnqueuer(
       {enqueue: jest.fn(), dequeue: jest.fn()} as any,
@@ -1010,34 +996,7 @@ describe("http enqueuer client ip", () => {
       preflight: false
     });
 
-    const address = app.getHttpServer().address();
-
-    return {httpQueue, unixRequest, port: typeof address == "object" ? address.port : undefined};
-  }
-
-  // The shared core-testing Request helper only speaks unix sockets, where there is no socket
-  // address for express to resolve; the tcp cases need a real peer, hence a local client.
-  function send(port: number, path: string, headers: Record<string, string> = {}) {
-    return new Promise<{statusCode: number; body: string}>((resolve, reject) => {
-      const request = http.request({host: "127.0.0.1", port, path, method: "GET", headers}, res => {
-        let body = "";
-        res.on("data", chunk => (body += chunk));
-        res.on("end", () => resolve({statusCode: res.statusCode, body}));
-      });
-      request.on("error", reject);
-      request.end();
-    });
-  }
-
-  async function enqueuedIp(fixture: Fixture, headers?: Record<string, string>) {
-    await send(fixture.port, "/fn-execute/ip", headers);
-    const calls = fixture.httpQueue.enqueue.mock.calls;
-    return calls[calls.length - 1][1].ip;
-  }
-
-  async function apiIp(fixture: Fixture, headers?: Record<string, string>) {
-    const response = await send(fixture.port, "/api-ip", headers);
-    return JSON.parse(response.body).ip;
+    return {request, httpQueue};
   }
 
   afterEach(async () => {
@@ -1047,74 +1006,28 @@ describe("http enqueuer client ip", () => {
 
   it("should hand the function the ip the api resolved", async () => {
     const fixture = await createFixture(true);
+    const headers = {"X-Forwarded-For": "1.2.3.4"};
 
-    const ip = await enqueuedIp(fixture);
+    await fixture.request.get("/fn-execute/ip", undefined, headers);
+    const apiIp = await fixture.request
+      .get<{ip: string}>("/api-ip", undefined, headers)
+      .then(response => response.body.ip);
 
-    expect(ip).toBeDefined();
-    expect(ip).toBe(await apiIp(fixture));
-  });
+    const enqueuedIp = fixture.httpQueue.enqueue.mock.calls[0][1].ip;
 
-  it("should not let a forged x-forwarded-for reach the function", async () => {
-    const fixture = await createFixture(false);
-    const headers = {"x-forwarded-for": "1.2.3.4"};
-
-    const ip = await enqueuedIp(fixture, headers);
-
-    expect(ip).toBeDefined();
-    expect(ip).not.toBe("1.2.3.4");
-    expect(ip).toBe(await apiIp(fixture, headers));
-  });
-
-  it("should keep the forged header intact while ignoring it for the ip", async () => {
-    const fixture = await createFixture(false);
-
-    await send(fixture.port, "/fn-execute/ip", {"x-forwarded-for": "1.2.3.4"});
-
-    const request = fixture.httpQueue.enqueue.mock.calls[0][1];
-    const forwardedHeader = request.headers.find(h => h.key == "x-forwarded-for");
-
-    expect(forwardedHeader.value).toBe("1.2.3.4");
-    expect(request.ip).toBeDefined();
-    expect(request.ip).not.toBe("1.2.3.4");
-  });
-
-  it("should not let an arbitrary header override the resolved ip", async () => {
-    const fixture = await createFixture(true);
-    const headers = {ip: "6.6.6.6"};
-
-    const ip = await enqueuedIp(fixture, headers);
-
-    expect(ip).toBeDefined();
-    expect(ip).not.toBe("6.6.6.6");
-    expect(ip).toBe(await apiIp(fixture, headers));
+    expect(enqueuedIp).toBeDefined();
+    expect(enqueuedIp).toBe(apiIp);
   });
 
   it("should leave the ip unset when the api cannot resolve one", async () => {
-    const fixture = await createFixture(false, "unix");
+    const fixture = await createFixture(false);
 
-    await fixture.unixRequest.get("/fn-execute/ip", undefined, {"X-Forwarded-For": "1.2.3.4"});
+    await fixture.request.get("/fn-execute/ip");
 
     const request = fixture.httpQueue.enqueue.mock.calls[0][1];
 
     expect(request.ip).toBeUndefined();
-    expect(request.headers.find(h => h.key == "x-forwarded-for").value).toBe("1.2.3.4");
     // An unset field must not reach the wire at all.
     expect(Http.Request.deserialize(request.serialize()).ip).toBeUndefined();
-  });
-
-  // Which address express settles on for a given trust proxy value is express's contract, not
-  // ours. Ours is that the function is handed that exact value instead of resolving its own.
-  it.each([
-    ["trusts every hop", true],
-    ["trusts no hop", false],
-    ["trusts a single hop", 1]
-  ])("should stay in sync with the api when it %s", async (_, trustProxy) => {
-    const fixture = await createFixture(trustProxy);
-    const headers = {"x-forwarded-for": "9.9.9.9, 8.8.8.8"};
-
-    const ip = await enqueuedIp(fixture, headers);
-
-    expect(ip).toBeDefined();
-    expect(ip).toBe(await apiIp(fixture, headers));
   });
 });

--- a/packages/api/function/enqueuer/test/http.spec.ts
+++ b/packages/api/function/enqueuer/test/http.spec.ts
@@ -964,16 +964,20 @@ describe("http enqueuer client ip", () => {
   };
 
   interface Fixture {
-    port: number;
-    enqueuer: HttpEnqueuer;
     httpQueue: {enqueue: jest.Mock; dequeue: jest.Mock};
+    port?: number;
+    unixRequest?: Request;
   }
 
   /**
-   * Listens over TCP instead of a unix socket so that express can resolve a real
-   * `req.socket.remoteAddress` (127.0.0.1) and apply the "trust proxy" setting on top of it.
+   * The tcp transport gives express a real `req.socket.remoteAddress` (127.0.0.1) to apply the
+   * "trust proxy" setting on top of. The unix transport has no remote address at all, which is
+   * how the api ends up unable to resolve a client ip even when a proxy header is present.
    */
-  async function createFixture(trustProxy: any): Promise<Fixture> {
+  async function createFixture(
+    trustProxy: any,
+    transport: "tcp" | "unix" = "tcp"
+  ): Promise<Fixture> {
     const module = await Test.createTestingModule({
       imports: [CoreTestingModule]
     }).compile();
@@ -985,44 +989,8 @@ describe("http enqueuer client ip", () => {
     // Mirrors how the api itself derives the client ip, so both sides can be compared.
     instance.get("/api-ip", (req, res) => res.json({ip: req.ip}));
 
-    await app.listen(0, "127.0.0.1");
-    apps.push(app);
-
-    const httpQueue = {enqueue: jest.fn(), dequeue: jest.fn()};
-    httpQueue.enqueue.mockImplementation((id, req, res) => res.end());
-
-    const enqueuer = new HttpEnqueuer(
-      {enqueue: jest.fn(), dequeue: jest.fn()} as any,
-      httpQueue as any,
-      instance,
-      corsOptions,
-      createNoopGuardService()
-    );
-
-    enqueuer.subscribe(createTarget(), {
-      method: HttpMethod.Get,
-      path: "/ip",
-      preflight: false
-    });
-
-    return {port: (app.getHttpServer().address() as any).port, enqueuer, httpQueue};
-  }
-
-  /**
-   * Listens over a unix socket, where there is no `req.socket.remoteAddress` at all, so the api
-   * cannot resolve a client ip even though a proxy header is present.
-   */
-  async function createUnixFixture() {
-    const module = await Test.createTestingModule({
-      imports: [CoreTestingModule]
-    }).compile();
-
-    const app = module.createNestApplication<NestExpressApplication>();
-    const instance = app.getHttpAdapter().getInstance();
-    instance.set("trust proxy", false);
-
-    const req = module.get(Request);
-    await app.listen(req.socket);
+    const unixRequest = module.get(Request);
+    await (transport == "tcp" ? app.listen(0, "127.0.0.1") : app.listen(unixRequest.socket));
     apps.push(app);
 
     const httpQueue = {enqueue: jest.fn(), dequeue: jest.fn()};
@@ -1042,9 +1010,13 @@ describe("http enqueuer client ip", () => {
       preflight: false
     });
 
-    return {req, httpQueue};
+    const address = app.getHttpServer().address();
+
+    return {httpQueue, unixRequest, port: typeof address == "object" ? address.port : undefined};
   }
 
+  // The shared core-testing Request helper only speaks unix sockets, where there is no socket
+  // address for express to resolve; the tcp cases need a real peer, hence a local client.
   function send(port: number, path: string, headers: Record<string, string> = {}) {
     return new Promise<{statusCode: number; body: string}>((resolve, reject) => {
       const request = http.request({host: "127.0.0.1", port, path, method: "GET", headers}, res => {
@@ -1073,17 +1045,24 @@ describe("http enqueuer client ip", () => {
     apps = [];
   });
 
-  it("should forward the socket address when there is no proxy header", async () => {
+  it("should hand the function the ip the api resolved", async () => {
     const fixture = await createFixture(true);
-    expect(await enqueuedIp(fixture)).toBe("127.0.0.1");
+
+    const ip = await enqueuedIp(fixture);
+
+    expect(ip).toBeDefined();
+    expect(ip).toBe(await apiIp(fixture));
   });
 
-  it("should ignore a forged x-forwarded-for when trust proxy is disabled", async () => {
+  it("should not let a forged x-forwarded-for reach the function", async () => {
     const fixture = await createFixture(false);
     const headers = {"x-forwarded-for": "1.2.3.4"};
 
-    expect(await enqueuedIp(fixture, headers)).toBe("127.0.0.1");
-    expect(await apiIp(fixture, headers)).toBe("127.0.0.1");
+    const ip = await enqueuedIp(fixture, headers);
+
+    expect(ip).toBeDefined();
+    expect(ip).not.toBe("1.2.3.4");
+    expect(ip).toBe(await apiIp(fixture, headers));
   });
 
   it("should keep the forged header intact while ignoring it for the ip", async () => {
@@ -1095,18 +1074,25 @@ describe("http enqueuer client ip", () => {
     const forwardedHeader = request.headers.find(h => h.key == "x-forwarded-for");
 
     expect(forwardedHeader.value).toBe("1.2.3.4");
-    expect(request.ip).toBe("127.0.0.1");
+    expect(request.ip).toBeDefined();
+    expect(request.ip).not.toBe("1.2.3.4");
   });
 
   it("should not let an arbitrary header override the resolved ip", async () => {
     const fixture = await createFixture(true);
-    expect(await enqueuedIp(fixture, {ip: "6.6.6.6"})).toBe("127.0.0.1");
+    const headers = {ip: "6.6.6.6"};
+
+    const ip = await enqueuedIp(fixture, headers);
+
+    expect(ip).toBeDefined();
+    expect(ip).not.toBe("6.6.6.6");
+    expect(ip).toBe(await apiIp(fixture, headers));
   });
 
   it("should leave the ip unset when the api cannot resolve one", async () => {
-    const fixture = await createUnixFixture();
+    const fixture = await createFixture(false, "unix");
 
-    await fixture.req.get("/fn-execute/ip", undefined, {"X-Forwarded-For": "1.2.3.4"});
+    await fixture.unixRequest.get("/fn-execute/ip", undefined, {"X-Forwarded-For": "1.2.3.4"});
 
     const request = fixture.httpQueue.enqueue.mock.calls[0][1];
 
@@ -1116,27 +1102,19 @@ describe("http enqueuer client ip", () => {
     expect(Http.Request.deserialize(request.serialize()).ip).toBeUndefined();
   });
 
-  it("should resolve the leftmost address when every hop is trusted", async () => {
-    const fixture = await createFixture(true);
-    expect(await enqueuedIp(fixture, {"x-forwarded-for": "9.9.9.9, 8.8.8.8"})).toBe("9.9.9.9");
-  });
-
+  // Which address express settles on for a given trust proxy value is express's contract, not
+  // ours. Ours is that the function is handed that exact value instead of resolving its own.
   it.each([
-    ["true", true, "9.9.9.9, 8.8.8.8", "9.9.9.9"],
-    ["false", false, "9.9.9.9, 8.8.8.8", "127.0.0.1"],
-    ["a single hop", 1, "9.9.9.9, 8.8.8.8", "8.8.8.8"],
-    ["two hops", 2, "9.9.9.9, 8.8.8.8", "9.9.9.9"],
-    ["a list of trusted ips", ["127.0.0.1"], "9.9.9.9, 8.8.8.8", "8.8.8.8"],
-    ["a list covering the whole chain", ["127.0.0.1", "8.8.8.8"], "9.9.9.9, 8.8.8.8", "9.9.9.9"],
-    ["a predefined subnet name", "loopback", "9.9.9.9, 8.8.8.8", "8.8.8.8"]
-  ])(
-    "should resolve the same ip as the api when trust proxy is %s",
-    async (_, trustProxy, forwardedFor, expected) => {
-      const fixture = await createFixture(trustProxy);
-      const headers = {"x-forwarded-for": forwardedFor as string};
+    ["trusts every hop", true],
+    ["trusts no hop", false],
+    ["trusts a single hop", 1]
+  ])("should stay in sync with the api when it %s", async (_, trustProxy) => {
+    const fixture = await createFixture(trustProxy);
+    const headers = {"x-forwarded-for": "9.9.9.9, 8.8.8.8"};
 
-      expect(await enqueuedIp(fixture, headers)).toBe(expected);
-      expect(await apiIp(fixture, headers)).toBe(expected);
-    }
-  );
+    const ip = await enqueuedIp(fixture, headers);
+
+    expect(ip).toBeDefined();
+    expect(ip).toBe(await apiIp(fixture, headers));
+  });
 });

--- a/packages/api/function/queue/node/src/http.ts
+++ b/packages/api/function/queue/node/src/http.ts
@@ -89,6 +89,7 @@ export class Request {
   params: Record<string, string> = {};
   cookies = new Map<string, string>();
   body: Array<unknown> | object | Uint8Array | undefined;
+  ip: string | undefined;
 
   constructor(req: Http.Request) {
     this.statusCode = req.statusCode;
@@ -96,6 +97,7 @@ export class Request {
     this.method = req.method;
     this.url = req.url;
     this.path = req.path;
+    this.ip = req.ip;
 
     if (req.headers) {
       req.headers.forEach(h => this.headers.set(h.key, h.value));

--- a/packages/api/function/queue/proto/src/http.proto
+++ b/packages/api/function/queue/proto/src/http.proto
@@ -43,6 +43,10 @@ message Request {
 
     bytes body = 9;
 
+    // Client ip resolved by the api from the connection and its "trust-proxy" setting.
+    // Functions must read this instead of the client-controlled x-forwarded-for header.
+    string ip = 10;
+
     // cookies?
 
     message Pop {

--- a/packages/api/function/queue/proto/src/http.ts
+++ b/packages/api/function/queue/proto/src/http.ts
@@ -351,6 +351,7 @@ export namespace Http {
             headers?: Header[];
             params?: Param[];
             body?: Uint8Array;
+            ip?: string;
           }
     ) {
       super();
@@ -365,6 +366,7 @@ export namespace Http {
         this.headers = data.headers;
         this.params = data.params;
         this.body = data.body;
+        this.ip = data.ip;
       }
     }
     get statusCode(): number | undefined {
@@ -421,6 +423,12 @@ export namespace Http {
     set body(value: Uint8Array) {
       pb_1.Message.setField(this, 9, value);
     }
+    get ip(): string | undefined {
+      return pb_1.Message.getFieldWithDefault(this, 10, undefined) as string | undefined;
+    }
+    set ip(value: string) {
+      pb_1.Message.setField(this, 10, value);
+    }
     toObject() {
       return {
         statusCode: this.statusCode,
@@ -431,7 +439,8 @@ export namespace Http {
         query: this.query,
         headers: this.headers.map((item: Header) => item.toObject()),
         params: this.params.map((item: Param) => item.toObject()),
-        body: this.body
+        body: this.body,
+        ip: this.ip
       };
     }
     serialize(w?: pb_1.BinaryWriter): Uint8Array | undefined {
@@ -447,6 +456,7 @@ export namespace Http {
       if (this.params !== undefined)
         writer.writeRepeatedMessage(8, this.params, (item: Param) => item.serialize(writer));
       if (this.body !== undefined) writer.writeBytes(9, this.body);
+      if (this.ip !== undefined) writer.writeString(10, this.ip);
       if (!w) return writer.getResultBuffer();
     }
     static deserialize(bytes: Uint8Array | pb_1.BinaryReader): Request {
@@ -485,6 +495,9 @@ export namespace Http {
             break;
           case 9:
             message.body = reader.readBytes();
+            break;
+          case 10:
+            message.ip = reader.readString();
             break;
           default:
             reader.skipField();

--- a/packages/api/function/queue/test/node/http.spec.ts
+++ b/packages/api/function/queue/test/node/http.spec.ts
@@ -116,20 +116,6 @@ describe("Http", () => {
       const request = new Request(Http.Request.deserialize(new Http.Request().serialize()));
       expect(request.ip).toBeUndefined();
     });
-
-    it("should not derive the ip from the x-forwarded-for header", () => {
-      const forwarded = new Http.Header();
-      forwarded.key = "x-forwarded-for";
-      forwarded.value = "6.6.6.6";
-
-      const req = new Http.Request();
-      req.headers = [forwarded];
-      req.ip = "1.2.3.4";
-
-      const request = new Request(Http.Request.deserialize(req.serialize()));
-      expect(request.ip).toBe("1.2.3.4");
-      expect(request.headers.get("x-forwarded-for")).toBe("6.6.6.6");
-    });
   });
 
   describe("Response", () => {

--- a/packages/api/function/queue/test/node/http.spec.ts
+++ b/packages/api/function/queue/test/node/http.spec.ts
@@ -103,6 +103,33 @@ describe("Http", () => {
       const request = new Request(req);
       expect(request.params.id).toBe("42");
     });
+
+    it("should map the ip resolved by the api", () => {
+      const req = new Http.Request();
+      req.ip = "1.2.3.4";
+      // We test integrity of the data here. leave it as is.
+      const request = new Request(Http.Request.deserialize(req.serialize()));
+      expect(request.ip).toBe("1.2.3.4");
+    });
+
+    it("should leave ip undefined when the api did not resolve one", () => {
+      const request = new Request(Http.Request.deserialize(new Http.Request().serialize()));
+      expect(request.ip).toBeUndefined();
+    });
+
+    it("should not derive the ip from the x-forwarded-for header", () => {
+      const forwarded = new Http.Header();
+      forwarded.key = "x-forwarded-for";
+      forwarded.value = "6.6.6.6";
+
+      const req = new Http.Request();
+      req.headers = [forwarded];
+      req.ip = "1.2.3.4";
+
+      const request = new Request(Http.Request.deserialize(req.serialize()));
+      expect(request.ip).toBe("1.2.3.4");
+      expect(request.headers.get("x-forwarded-for")).toBe("6.6.6.6");
+    });
   });
 
   describe("Response", () => {

--- a/packages/api/function/runtime/test/node/entrypoint.spec.ts
+++ b/packages/api/function/runtime/test/node/entrypoint.spec.ts
@@ -552,6 +552,38 @@ describe("Entrypoint", () => {
       expect(exitCode).toBe(4);
     });
 
+    it("should pass the ip resolved by the api to fn", async () => {
+      await initializeFn(`
+      export default function(req) {
+        if ( req.ip == '1.2.3.4' && req.headers.get('x-forwarded-for') == '6.6.6.6' ) {
+          process.exit(4);
+        }
+      }`);
+
+      const ev = new event.Event({
+        type: event.Type.HTTP,
+        target: new event.Target({
+          cwd: meta.cwd,
+          handler: "default",
+          context: new event.SchedulingContext({
+            env: [],
+            timeout: 60
+          })
+        })
+      });
+
+      queue.enqueue(ev);
+
+      const request = new Http.Request({
+        ip: "1.2.3.4",
+        headers: [new Http.Header({key: "x-forwarded-for", value: "6.6.6.6"})]
+      });
+      httpQueue.enqueue(ev.id, request, undefined);
+
+      const exitCode = await spawn().catch(e => e);
+      expect(exitCode).toBe(4);
+    });
+
     it("should pass response to fn", async () => {
       await initializeFn(`
       export default function(req, res) {


### PR DESCRIPTION
The api resolves the client ip through express with the configured trust-proxy setting, but functions only received the raw headers, so a function had to parse x-forwarded-for itself — a value the client fully controls and one that could disagree with what the api saw.

Carry the already-resolved req.ip over the internal grpc event channel as a first-class Http.Request field and expose it as request.ip in the node runtime. The enqueuer resolves it once and reuses it for rate limiting, so there is a single ip resolution and trust-proxy behaviour is unchanged.

The raw header still reaches functions untouched, and there is deliberately no x-forwarded-for fallback: falling back whenever the ip cannot be resolved would reopen the spoofable path this closes.