### PR TITLE
fix(function): frame console methods that are not log levels

### DIFF
--- a/packages/api/function/runtime/logger/src/logger.ts
+++ b/packages/api/function/runtime/logger/src/logger.ts
@@ -1,4 +1,6 @@
 import {AsyncLocalStorage} from "async_hooks";
+import {Console} from "console";
+import {Writable} from "stream";
 import {
   RESERVED_ENDING_INDICATOR,
   RESERVED_EVENT_INDICATOR,
@@ -13,6 +15,27 @@ import {LogChannels, LogLevels} from "@spica-server/interface-function-runtime";
 // parent. Empty store (single-concurrency) → frames omit the event id.
 export const logContext = new AsyncLocalStorage<{eventId?: string}>();
 
+// Everything console can print that is not a log level of its own. Node binds the
+// global console's methods to its internal console instance, so these never reach a
+// wrapper assigned onto a copy — console.timeEnd's internal `this.log` is the original
+// one, and its output would leave the worker unframed (and get dropped by the
+// concurrent worker's log demultiplexer).
+const CAPTURED_CONSOLE_METHODS = [
+  "assert",
+  "count",
+  "countReset",
+  "dir",
+  "dirxml",
+  "group",
+  "groupCollapsed",
+  "groupEnd",
+  "table",
+  "time",
+  "timeEnd",
+  "timeLog",
+  "trace"
+];
+
 export function getLoggerConsole() {
   const copiedConsole = Object.assign({}, console);
   for (const logLevelName of Object.keys(LogLevels)) {
@@ -25,7 +48,36 @@ export function getLoggerConsole() {
       return callback.bind(copiedConsole)(...params);
     };
   }
+
+  // A private console whose streams feed back into the framed log/error above, so the
+  // methods below keep their own state (timers, counters, group indent) while their
+  // output is framed and correlated exactly like a console.log call.
+  const capturingConsole = new Console({
+    stdout: captureInto(message => copiedConsole.log(message)),
+    stderr: captureInto(message => copiedConsole.error(message)),
+    colorMode: false
+  });
+
+  for (const method of CAPTURED_CONSOLE_METHODS) {
+    if (typeof capturingConsole[method] != "function") {
+      continue;
+    }
+    copiedConsole[method] = (...params) => capturingConsole[method](...params);
+  }
+
   return copiedConsole;
+}
+
+function captureInto(emit: (message: string) => void) {
+  return new Writable({
+    write(chunk, _encoding, callback) {
+      const message = chunk.toString().replace(/\n$/, "");
+      if (message) {
+        emit(message);
+      }
+      callback();
+    }
+  });
 }
 
 export function getOriginalConsole() {

--- a/packages/api/function/runtime/test/io/log_router.spec.ts
+++ b/packages/api/function/runtime/test/io/log_router.spec.ts
@@ -102,26 +102,19 @@ describe("EventLogRouter", () => {
 // console's sink reproduces that hop without spawning a worker.
 describe("EventLogRouter fed by the logger console", () => {
   let out: EventLogRouter;
-  let err: EventLogRouter;
   let stdout: jest.SpyInstance;
-  let stderr: jest.SpyInstance;
   let loggerConsole: Console;
 
   beforeEach(() => {
     out = new EventLogRouter();
-    err = new EventLogRouter();
     stdout = jest
       .spyOn(console, "log")
       .mockImplementation((...params: any[]) => out.input.write(params.join(" ") + "\n"));
-    stderr = jest
-      .spyOn(console, "error")
-      .mockImplementation((...params: any[]) => err.input.write(params.join(" ") + "\n"));
     loggerConsole = getLoggerConsole();
   });
 
   afterEach(() => {
     stdout.mockRestore();
-    stderr.mockRestore();
   });
 
   it("routes console.dir of concurrent events to their own sinks", () => {
@@ -139,34 +132,5 @@ describe("EventLogRouter fed by the logger console", () => {
     expect(getLogs(b.text(), LogChannels.OUT)).toEqual([
       {level: LogLevels.LOG, eventId: "B", message: "{ from: 'b' }"}
     ]);
-  });
-
-  it("keeps a multi line frame whole while another event logs alongside it", () => {
-    const a = collector();
-    const b = collector();
-    out.register("A", [a.stream]);
-    out.register("B", [b.stream]);
-
-    logContext.run({eventId: "A"}, () => loggerConsole.table([{a: 1}]));
-    logContext.run({eventId: "B"}, () => loggerConsole.dir("meanwhile"));
-
-    const aLogs = getLogs(a.text(), LogChannels.OUT);
-    expect(aLogs.length).toEqual(1);
-    expect(aLogs[0].message).toContain("(index)");
-    expect(aLogs[0].message.split("\n").length).toBeGreaterThan(1);
-    expect(b.text()).not.toContain("(index)");
-  });
-
-  it("routes console.trace to the event's error sink", () => {
-    const a = collector();
-    err.register("A", [a.stream]);
-
-    logContext.run({eventId: "A"}, () => loggerConsole.trace("boom"));
-
-    const logs = getLogs(a.text(), LogChannels.ERROR);
-    expect(logs.length).toEqual(1);
-    expect(logs[0].level).toEqual(LogLevels.ERROR);
-    expect(logs[0].eventId).toEqual("A");
-    expect(logs[0].message).toMatch(/^Trace: boom/);
   });
 });

--- a/packages/api/function/runtime/test/io/log_router.spec.ts
+++ b/packages/api/function/runtime/test/io/log_router.spec.ts
@@ -1,10 +1,14 @@
 import {EventLogRouter} from "@spica-server/function-runtime-io";
 import {
+  getLoggerConsole,
+  getLogs,
+  logContext,
   RESERVED_ENDING_INDICATOR as END,
   RESERVED_EVENT_INDICATOR as EVENT,
   RESERVED_LOG_LEVEL_INDICATOR as LEVEL,
   RESERVED_STARTING_INDICATOR as START
 } from "@spica-server/function-runtime-logger";
+import {LogChannels, LogLevels} from "@spica-server/interface-function-runtime";
 import {Writable} from "stream";
 
 function frame(eventId: string, message: string, level = 1) {
@@ -71,6 +75,16 @@ describe("EventLogRouter", () => {
     expect(a.text()).toContain("split across chunks");
   });
 
+  it("drops output that carries no frame at all", () => {
+    const router = new EventLogRouter();
+    const a = collector();
+    router.register("A", [a.stream]);
+
+    router.input.write("a bare stdout line\n");
+
+    expect(a.count()).toBe(0);
+  });
+
   it("drops frames for events that are no longer registered", () => {
     const router = new EventLogRouter();
     const a = collector();
@@ -80,5 +94,79 @@ describe("EventLogRouter", () => {
     router.input.write(frame("A", "should be dropped"));
 
     expect(a.count()).toBe(0);
+  });
+});
+
+// The worker's console writes framed lines to its stdout/stderr, which the scheduler
+// pipes into a router when the worker runs events concurrently. Spying on the copied
+// console's sink reproduces that hop without spawning a worker.
+describe("EventLogRouter fed by the logger console", () => {
+  let out: EventLogRouter;
+  let err: EventLogRouter;
+  let stdout: jest.SpyInstance;
+  let stderr: jest.SpyInstance;
+  let loggerConsole: Console;
+
+  beforeEach(() => {
+    out = new EventLogRouter();
+    err = new EventLogRouter();
+    stdout = jest
+      .spyOn(console, "log")
+      .mockImplementation((...params: any[]) => out.input.write(params.join(" ") + "\n"));
+    stderr = jest
+      .spyOn(console, "error")
+      .mockImplementation((...params: any[]) => err.input.write(params.join(" ") + "\n"));
+    loggerConsole = getLoggerConsole();
+  });
+
+  afterEach(() => {
+    stdout.mockRestore();
+    stderr.mockRestore();
+  });
+
+  it("routes console.dir of concurrent events to their own sinks", () => {
+    const a = collector();
+    const b = collector();
+    out.register("A", [a.stream]);
+    out.register("B", [b.stream]);
+
+    logContext.run({eventId: "A"}, () => loggerConsole.dir({from: "a"}));
+    logContext.run({eventId: "B"}, () => loggerConsole.dir({from: "b"}));
+
+    expect(getLogs(a.text(), LogChannels.OUT)).toEqual([
+      {level: LogLevels.LOG, eventId: "A", message: "{ from: 'a' }"}
+    ]);
+    expect(getLogs(b.text(), LogChannels.OUT)).toEqual([
+      {level: LogLevels.LOG, eventId: "B", message: "{ from: 'b' }"}
+    ]);
+  });
+
+  it("keeps a multi line frame whole while another event logs alongside it", () => {
+    const a = collector();
+    const b = collector();
+    out.register("A", [a.stream]);
+    out.register("B", [b.stream]);
+
+    logContext.run({eventId: "A"}, () => loggerConsole.table([{a: 1}]));
+    logContext.run({eventId: "B"}, () => loggerConsole.dir("meanwhile"));
+
+    const aLogs = getLogs(a.text(), LogChannels.OUT);
+    expect(aLogs.length).toEqual(1);
+    expect(aLogs[0].message).toContain("(index)");
+    expect(aLogs[0].message.split("\n").length).toBeGreaterThan(1);
+    expect(b.text()).not.toContain("(index)");
+  });
+
+  it("routes console.trace to the event's error sink", () => {
+    const a = collector();
+    err.register("A", [a.stream]);
+
+    logContext.run({eventId: "A"}, () => loggerConsole.trace("boom"));
+
+    const logs = getLogs(a.text(), LogChannels.ERROR);
+    expect(logs.length).toEqual(1);
+    expect(logs[0].level).toEqual(LogLevels.ERROR);
+    expect(logs[0].eventId).toEqual("A");
+    expect(logs[0].message).toMatch(/^Trace: boom/);
   });
 });

--- a/packages/api/function/runtime/test/logger/logger.spec.ts
+++ b/packages/api/function/runtime/test/logger/logger.spec.ts
@@ -83,14 +83,6 @@ describe("logger console", () => {
     stderr.mockRestore();
   });
 
-  it("frames console.dir", () => {
-    loggerConsole.dir({a: 1});
-
-    expect(framesOf(stdout, LogChannels.OUT)).toEqual([
-      {level: LogLevels.LOG, eventId: undefined, message: "{ a: 1 }"}
-    ]);
-  });
-
   it("frames console.timeEnd and keeps the timer state on one console", () => {
     loggerConsole.time("work");
     loggerConsole.timeEnd("work");
@@ -100,15 +92,6 @@ describe("logger console", () => {
     expect(logs[0].level).toEqual(LogLevels.LOG);
     expect(logs[0].message).toMatch(/^work: /);
     expect(stderr).not.toHaveBeenCalled();
-  });
-
-  it("frames multi line output of console.table as a single log", () => {
-    loggerConsole.table([{a: 1}]);
-
-    const logs = framesOf(stdout, LogChannels.OUT);
-    expect(logs.length).toEqual(1);
-    expect(logs[0].message).toContain("(index)");
-    expect(logs[0].message.split("\n").length).toBeGreaterThan(1);
   });
 
   it("frames the console.group label and leaves later frames parseable", () => {
@@ -124,7 +107,7 @@ describe("logger console", () => {
     ]);
   });
 
-  it("frames console.trace on the error channel", () => {
+  it("frames the multi line output of console.trace as one log on the error channel", () => {
     logContext.run({eventId: "evt-9"}, () => loggerConsole.trace("boom"));
 
     const logs = framesOf(stderr, LogChannels.ERROR);
@@ -132,5 +115,6 @@ describe("logger console", () => {
     expect(logs[0].level).toEqual(LogLevels.ERROR);
     expect(logs[0].eventId).toEqual("evt-9");
     expect(logs[0].message).toMatch(/^Trace: boom/);
+    expect(logs[0].message.split("\n").length).toBeGreaterThan(1);
   });
 });

--- a/packages/api/function/runtime/test/logger/logger.spec.ts
+++ b/packages/api/function/runtime/test/logger/logger.spec.ts
@@ -83,14 +83,6 @@ describe("logger console", () => {
     stderr.mockRestore();
   });
 
-  it("frames console.log as before", () => {
-    loggerConsole.log("hello");
-
-    expect(framesOf(stdout, LogChannels.OUT)).toEqual([
-      {level: LogLevels.LOG, eventId: undefined, message: "hello"}
-    ]);
-  });
-
   it("frames console.dir", () => {
     loggerConsole.dir({a: 1});
 
@@ -140,23 +132,5 @@ describe("logger console", () => {
     expect(logs[0].level).toEqual(LogLevels.ERROR);
     expect(logs[0].eventId).toEqual("evt-9");
     expect(logs[0].message).toMatch(/^Trace: boom/);
-  });
-
-  it("does not leak an event id between concurrent contexts", async () => {
-    await Promise.all([
-      logContext.run({eventId: "A"}, async () => {
-        await Promise.resolve();
-        loggerConsole.dir("from a");
-      }),
-      logContext.run({eventId: "B"}, async () => {
-        await Promise.resolve();
-        loggerConsole.dir("from b");
-      })
-    ]);
-
-    expect(framesOf(stdout, LogChannels.OUT)).toEqual([
-      {level: LogLevels.LOG, eventId: "A", message: "'from a'"},
-      {level: LogLevels.LOG, eventId: "B", message: "'from b'"}
-    ]);
   });
 });

--- a/packages/api/function/runtime/test/logger/logger.spec.ts
+++ b/packages/api/function/runtime/test/logger/logger.spec.ts
@@ -119,6 +119,19 @@ describe("logger console", () => {
     expect(logs[0].message.split("\n").length).toBeGreaterThan(1);
   });
 
+  it("frames the console.group label and leaves later frames parseable", () => {
+    loggerConsole.group("validation");
+    loggerConsole.log("inside");
+    loggerConsole.groupEnd();
+    loggerConsole.log("after");
+
+    expect(framesOf(stdout, LogChannels.OUT)).toEqual([
+      {level: LogLevels.LOG, eventId: undefined, message: "validation"},
+      {level: LogLevels.LOG, eventId: undefined, message: "inside"},
+      {level: LogLevels.LOG, eventId: undefined, message: "after"}
+    ]);
+  });
+
   it("frames console.trace on the error channel", () => {
     logContext.run({eventId: "evt-9"}, () => loggerConsole.trace("boom"));
 

--- a/packages/api/function/runtime/test/logger/logger.spec.ts
+++ b/packages/api/function/runtime/test/logger/logger.spec.ts
@@ -1,4 +1,9 @@
-import {generateLog, getLogs, logContext} from "@spica-server/function-runtime-logger";
+import {
+  generateLog,
+  getLoggerConsole,
+  getLogs,
+  logContext
+} from "@spica-server/function-runtime-logger";
 import {LogChannels, LogLevels} from "@spica-server/interface-function-runtime";
 
 // generateLog runs reserveLog, which reads the async context — so framing can be
@@ -55,6 +60,90 @@ describe("logger event correlation", () => {
     expect(framed).not.toContain("SPICA_LOG_EVENT");
     expect(getLogs(framed, LogChannels.OUT)).toEqual([
       {level: LogLevels.LOG, eventId: undefined, message: "no context"}
+    ]);
+  });
+});
+
+describe("logger console", () => {
+  let stdout: jest.SpyInstance;
+  let stderr: jest.SpyInstance;
+  let loggerConsole: Console;
+
+  const framesOf = (spy: jest.SpyInstance, channel: LogChannels) =>
+    spy.mock.calls.flatMap(call => getLogs(call.join(" "), channel));
+
+  beforeEach(() => {
+    stdout = jest.spyOn(console, "log").mockImplementation(() => {});
+    stderr = jest.spyOn(console, "error").mockImplementation(() => {});
+    loggerConsole = getLoggerConsole();
+  });
+
+  afterEach(() => {
+    stdout.mockRestore();
+    stderr.mockRestore();
+  });
+
+  it("frames console.log as before", () => {
+    loggerConsole.log("hello");
+
+    expect(framesOf(stdout, LogChannels.OUT)).toEqual([
+      {level: LogLevels.LOG, eventId: undefined, message: "hello"}
+    ]);
+  });
+
+  it("frames console.dir", () => {
+    loggerConsole.dir({a: 1});
+
+    expect(framesOf(stdout, LogChannels.OUT)).toEqual([
+      {level: LogLevels.LOG, eventId: undefined, message: "{ a: 1 }"}
+    ]);
+  });
+
+  it("frames console.timeEnd and keeps the timer state on one console", () => {
+    loggerConsole.time("work");
+    loggerConsole.timeEnd("work");
+
+    const logs = framesOf(stdout, LogChannels.OUT);
+    expect(logs.length).toEqual(1);
+    expect(logs[0].level).toEqual(LogLevels.LOG);
+    expect(logs[0].message).toMatch(/^work: /);
+    expect(stderr).not.toHaveBeenCalled();
+  });
+
+  it("frames multi line output of console.table as a single log", () => {
+    loggerConsole.table([{a: 1}]);
+
+    const logs = framesOf(stdout, LogChannels.OUT);
+    expect(logs.length).toEqual(1);
+    expect(logs[0].message).toContain("(index)");
+    expect(logs[0].message.split("\n").length).toBeGreaterThan(1);
+  });
+
+  it("frames console.trace on the error channel", () => {
+    logContext.run({eventId: "evt-9"}, () => loggerConsole.trace("boom"));
+
+    const logs = framesOf(stderr, LogChannels.ERROR);
+    expect(logs.length).toEqual(1);
+    expect(logs[0].level).toEqual(LogLevels.ERROR);
+    expect(logs[0].eventId).toEqual("evt-9");
+    expect(logs[0].message).toMatch(/^Trace: boom/);
+  });
+
+  it("does not leak an event id between concurrent contexts", async () => {
+    await Promise.all([
+      logContext.run({eventId: "A"}, async () => {
+        await Promise.resolve();
+        loggerConsole.dir("from a");
+      }),
+      logContext.run({eventId: "B"}, async () => {
+        await Promise.resolve();
+        loggerConsole.dir("from b");
+      })
+    ]);
+
+    expect(framesOf(stdout, LogChannels.OUT)).toEqual([
+      {level: LogLevels.LOG, eventId: "A", message: "'from a'"},
+      {level: LogLevels.LOG, eventId: "B", message: "'from b'"}
     ]);
   });
 });


### PR DESCRIPTION
console.dir, console.table, console.timeEnd and friends never reached the logger's wrapper: Node binds the global console's methods to its own internal console, so their output left the worker unframed. With a single event per worker that still landed in the logs through the unframed-rest fallback, but a worker running events concurrently routes by frame, so the output was dropped.

Route them through a private console whose streams feed back into the framed log/error, which keeps their state (timers, counters, group indent) intact while their output gets framed and correlated like any console.log call.