### PR TITLE
fix(charts): loosen api liveness and readiness probes

### DIFF
--- a/charts/spica/tests/application_test.yaml
+++ b/charts/spica/tests/application_test.yaml
@@ -190,19 +190,19 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[1].livenessProbe.periodSeconds
-          value: 15
+          value: 30
       - equal:
           path: spec.template.spec.containers[1].livenessProbe.timeoutSeconds
-          value: 5
+          value: 10
       - equal:
           path: spec.template.spec.containers[1].livenessProbe.failureThreshold
-          value: 3
+          value: 6
 
   - it: should reflect custom liveness probe values from values.yaml
     set:
-      application.apiLivenessProbePeriodSeconds: 30
-      application.apiLivenessProbeTimeoutSeconds: 10
-      application.apiLivenessProbeFailureThreshold: 5
+      application.apiLivenessProbePeriodSeconds: 60
+      application.apiLivenessProbeTimeoutSeconds: 20
+      application.apiLivenessProbeFailureThreshold: 10
     template: templates/application.yaml
     documentSelector:
       path: kind
@@ -210,13 +210,13 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[1].livenessProbe.periodSeconds
-          value: 30
+          value: 60
       - equal:
           path: spec.template.spec.containers[1].livenessProbe.timeoutSeconds
-          value: 10
+          value: 20
       - equal:
           path: spec.template.spec.containers[1].livenessProbe.failureThreshold
-          value: 5
+          value: 10
 
   - it: should configure readiness probe on the api container
     template: templates/application.yaml
@@ -239,10 +239,10 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[1].readinessProbe.periodSeconds
-          value: 5
+          value: 10
       - equal:
           path: spec.template.spec.containers[1].readinessProbe.timeoutSeconds
-          value: 5
+          value: 10
       - equal:
           path: spec.template.spec.containers[1].readinessProbe.failureThreshold
           value: 6

--- a/charts/spica/values.yaml
+++ b/charts/spica/values.yaml
@@ -82,12 +82,12 @@ application:
   apiStartupProbeTimeoutSeconds: 3
   apiStartupProbeFailureThreshold: 24
   # liveness
-  apiLivenessProbePeriodSeconds: 15
-  apiLivenessProbeTimeoutSeconds: 5
-  apiLivenessProbeFailureThreshold: 3
+  apiLivenessProbePeriodSeconds: 30
+  apiLivenessProbeTimeoutSeconds: 10
+  apiLivenessProbeFailureThreshold: 6
   # readiness
-  apiReadinessProbePeriodSeconds: 5
-  apiReadinessProbeTimeoutSeconds: 5
+  apiReadinessProbePeriodSeconds: 10
+  apiReadinessProbeTimeoutSeconds: 10
   apiReadinessProbeFailureThreshold: 6
 ingress:
   hosts: []


### PR DESCRIPTION
Restarting the pod is more expensive than waiting out a temporary slowdown. The liveness endpoint only fails when the event loop is blocked, so a load spike was enough to trip it and get the container killed even though it would have recovered on its own.

Liveness now tolerates ~180s instead of ~45s and readiness ~60s instead of ~30s, keeping traffic shedding well ahead of a restart.