### PR TITLE
feat(api): allow setting arbitrary response headers without a release

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -37,6 +37,7 @@ const HEADER_NAME = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
 
 function parseResponseHeaders(values: string[]) {
   const headers: Record<string, string> = {};
+  const names = new Map<string, string>();
 
   for (const pair of values) {
     const separator = pair.indexOf(":");
@@ -52,6 +53,12 @@ function parseResponseHeaders(values: string[]) {
       throw new Error(`Response header '${name}' has an illegal name or value.`);
     }
 
+    const previous = names.get(name.toLowerCase());
+    if (previous != undefined) {
+      delete headers[previous];
+    }
+
+    names.set(name.toLowerCase(), name);
     headers[name] = value;
   }
 
@@ -1052,11 +1059,19 @@ if (args["cert-file"] && args["key-file"]) {
   };
 }
 
-const responseHeaders = {
-  "Cache-Control": args["cache-control-header"],
-  "X-Frame-Options": args["x-frame-options-header"],
-  ...args["response-header"]
-};
+const responseHeaders: Record<string, string> = {...args["response-header"]};
+const configuredNames = new Set(Object.keys(responseHeaders).map(name => name.toLowerCase()));
+
+const deprecatedHeaders: [string, string][] = [
+  ["Cache-Control", args["cache-control-header"]],
+  ["X-Frame-Options", args["x-frame-options-header"]]
+];
+
+for (const [name, value] of deprecatedHeaders) {
+  if (value && !configuredNames.has(name.toLowerCase())) {
+    responseHeaders[name] = value;
+  }
+}
 
 NestFactory.create(RootModule, {
   httpsOptions,

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -33,6 +33,31 @@ import cookieParser from "cookie-parser";
 import {ConfigModule} from "@spica-server/config";
 import {deriveKey} from "@spica-server/core-encryption";
 
+const HEADER_NAME = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+
+function parseResponseHeaders(values: string[]) {
+  const headers: Record<string, string> = {};
+
+  for (const pair of values) {
+    const separator = pair.indexOf(":");
+
+    if (separator < 1) {
+      throw new Error(`Response header '${pair}' is malformed, expected 'Name: value'.`);
+    }
+
+    const name = pair.slice(0, separator).trim();
+    const value = pair.slice(separator + 1).trim();
+
+    if (!HEADER_NAME.test(name) || /[\r\n]/.test(value)) {
+      throw new Error(`Response header '${name}' has an illegal name or value.`);
+    }
+
+    headers[name] = value;
+  }
+
+  return headers;
+}
+
 const yargsInstance = yargs(process.argv.slice(2)) as any;
 
 const args = yargsInstance
@@ -554,14 +579,33 @@ const args = yargsInstance
   })
   /* Additional Header Options */
   .option({
+    "response-header": {
+      array: true,
+      description: 'Headers to attach to every response, as "Name: value" pairs.',
+      default: [],
+      coerce: parseResponseHeaders
+    },
     "cache-control-header": {
       string: true,
-      description: "Cache-Control"
+      description: "Cache-Control. Deprecated, use --response-header instead."
     },
     "x-frame-options-header": {
       string: true,
-      description: "X-Frame-Option"
+      description: "X-Frame-Options. Deprecated, use --response-header instead."
     }
+  })
+  .check(() => {
+    const occurrences = process.argv.filter(
+      arg => arg == "--response-header" || arg.startsWith("--response-header=")
+    ).length;
+
+    if (occurrences > 1) {
+      throw new Error(
+        "--response-header can not be repeated, pass every header to a single --response-header."
+      );
+    }
+
+    return true;
   })
   /* Common Options */
   .option("payload-size-limit", {
@@ -1008,6 +1052,12 @@ if (args["cert-file"] && args["key-file"]) {
   };
 }
 
+const responseHeaders = {
+  "Cache-Control": args["cache-control-header"],
+  "X-Frame-Options": args["x-frame-options-header"],
+  ...args["response-header"]
+};
+
 NestFactory.create(RootModule, {
   httpsOptions,
   bodyParser: false
@@ -1016,10 +1066,7 @@ NestFactory.create(RootModule, {
   console.log("PROXY at main.ts", app.getHttpAdapter().getInstance().get("trust proxy"));
   app.useWebSocketAdapter(new WsAdapter(app));
   app.use(
-    Middlewares.Headers({
-      "Cache-Control": args["cache-control-header"],
-      "X-Frame-Options": args["x-frame-options-header"]
-    }),
+    Middlewares.Headers(responseHeaders),
     Middlewares.Preflight({
       allowedOrigins: args["cors-allowed-origins"],
       allowedMethods: args["cors-allowed-methods"],

--- a/charts/spica/templates/application.yaml
+++ b/charts/spica/templates/application.yaml
@@ -101,6 +101,12 @@ spec:
             {{ . | quote }},
 {{- end }}
 {{end}}
+{{- if .Values.application.responseHeaders }}
+            --response-header,
+{{- range $name, $value := .Values.application.responseHeaders }}
+            {{ printf "%s: %v" $name $value | quote }},
+{{- end }}
+{{- end }}
             --port, "4300", 
             --database-uri, {{ template "database.connection-uri" . }},
             --database-replica-set,  {{ .Values.database.replicaSetName }},

--- a/charts/spica/tests/application_test.yaml
+++ b/charts/spica/tests/application_test.yaml
@@ -335,6 +335,27 @@ tests:
           path: spec.template.spec.containers[1].args[1]
           value: "custom-value"
 
+  - it: should pass every application.responseHeaders entry to a single --response-header arg
+    set:
+      application.responseHeaders:
+        Cache-Control: "public, max-age=60"
+        X-Frame-Options: "DENY"
+    template: templates/application.yaml
+    documentSelector:
+      path: kind
+      value: StatefulSet
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: "--response-header"
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: "Cache-Control: public, max-age=60"
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: "X-Frame-Options: DENY"
+
   - it: should include checksum annotation on Pod template
     template: templates/application.yaml
     documentSelector:

--- a/charts/spica/values.yaml
+++ b/charts/spica/values.yaml
@@ -72,6 +72,11 @@ application:
   apiResources: {}
   webResources: {}
   args: []
+  # extra headers attached to every api response, eg:
+  # responseHeaders:
+  #   Cache-Control: "no-store"
+  #   X-Frame-Options: "DENY"
+  responseHeaders: {}
   diskAccessMode: ReadWriteOnce
   serviceAccountName: default
   podAnnotations: {}

--- a/packages/core/src/middlewares.ts
+++ b/packages/core/src/middlewares.ts
@@ -37,14 +37,13 @@ export namespace Middlewares {
     return (req, res, next) => json({type: "application/merge-patch+json", limit})(req, res, next);
   }
 
-  export function Headers(options: object) {
+  export function Headers(options: Record<string, string | undefined>) {
     return (req, res, next) => {
       Object.entries(options).forEach(([key, value]) => {
-        const headerSet = res.headers && res.headers[key];
-        const isNullish = value == null;
-        if (!headerSet && !isNullish) {
-          res.set(key, value);
+        if (value == null || res.getHeader(key) != undefined) {
+          return;
         }
+        res.set(key, value);
       });
       next();
     };

--- a/packages/core/test/middlewares.spec.ts
+++ b/packages/core/test/middlewares.spec.ts
@@ -141,6 +141,38 @@ describe("MiddleWare", () => {
     });
   });
 
+  describe("Headers", () => {
+    let res;
+    let next: jest.Mock;
+
+    beforeEach(() => {
+      const headers = {};
+      res = {
+        getHeader: (key: string) => headers[key.toLowerCase()],
+        set: jest.fn((key: string, value: string) => (headers[key.toLowerCase()] = value))
+      };
+      next = jest.fn();
+    });
+
+    it("should set every given header", () => {
+      Middlewares.Headers({"Cache-Control": "no-store", "X-Frame-Options": "DENY"})({}, res, next);
+      expect(res.getHeader("cache-control")).toEqual("no-store");
+      expect(res.getHeader("x-frame-options")).toEqual("DENY");
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not override an already set header", () => {
+      res.set("Cache-Control", "no-cache");
+      res.set.mockClear();
+
+      Middlewares.Headers({"Cache-Control": "no-store"})({}, res, next);
+
+      expect(res.set).not.toHaveBeenCalled();
+      expect(res.getHeader("cache-control")).toEqual("no-cache");
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("getMatchedValue", () => {
     it("should return matched value when pattern matched", () => {
       expect(getMatchedValue("test123", ["test*"])).toEqual("test123");


### PR DESCRIPTION
Adding a response header required a dedicated yargs option and a new entry in the Middlewares.Headers map, so every header meant a code change and a new version. A single --response-header option now accepts any number of "Name: value" pairs, validated at startup so a malformed header fails the boot instead of every request.

--cache-control-header and --x-frame-options-header keep working and are marked deprecated; --response-header wins when both set the same header.

The chart exposes the same through application.responseHeaders and renders them into one --response-header arg, since the parser runs with duplicate-arguments-array disabled and would drop all but the last flag. Repeating the flag on the command line is rejected for the same reason.

Middlewares.Headers guarded against overwriting with res.headers[key], which is always undefined on an express response, so the guard never ran.