### PR TITLE
refactor(function): remove the unused memoryLimit from the schema

### DIFF
--- a/apps/migrate/src/migrations/0.19.6/remove_memory_limit_from_functions.ts
+++ b/apps/migrate/src/migrations/0.19.6/remove_memory_limit_from_functions.ts
@@ -1,0 +1,11 @@
+import {Context} from "../../migrate";
+
+export default async function (ctx: Context) {
+  await ctx.database
+    .collection("function")
+    .updateMany(
+      {memoryLimit: {$exists: true}},
+      {$unset: {memoryLimit: ""}},
+      {session: ctx.session}
+    );
+}

--- a/apps/migrate/src/migrations/index.json
+++ b/apps/migrate/src/migrations/index.json
@@ -18,5 +18,6 @@
   ],
   "0.17.0": ["0.17.0/set_mongodb_fcv_7.js"],
   "0.18.0": ["0.18.0/remove_position_from_bucket_properties.js"],
-  "0.19.4": ["0.19.4/convert_function_relation_ids_to_objectid.js"]
+  "0.19.4": ["0.19.4/convert_function_relation_ids_to_objectid.js"],
+  "0.19.6": ["0.19.6/remove_memory_limit_from_functions.js"]
 }

--- a/apps/migrate/test/migrations/0_19_6_remove_memory_limit_from_functions.spec.ts
+++ b/apps/migrate/test/migrations/0_19_6_remove_memory_limit_from_functions.spec.ts
@@ -1,0 +1,45 @@
+import {Db, getConnectionUri, getDatabaseName, start} from "@spica-server/database-testing";
+import color from "cli-color/lib/supports-color";
+import {run} from "@spica/migrate";
+import path from "path";
+
+process.env.TESTONLY_MIGRATION_LOOKUP_DIR = path.join(process.cwd(), "dist/src");
+
+jest.setTimeout(120_000);
+
+describe("Remove memoryLimit from functions", () => {
+  let db: Db;
+  let args: string[];
+
+  beforeAll(() => {
+    color.disableColor();
+  });
+
+  beforeEach(async () => {
+    const connection = await start("replset");
+    args = ["--database-uri", await getConnectionUri(), "--database-name", getDatabaseName()];
+    db = connection.db(args[3]);
+  });
+
+  it("should unset memoryLimit across functions while preserving every other field", async () => {
+    const triggers = {default: {type: "http", active: true, options: {method: "Get", path: "/"}}};
+
+    await db.collection("function").insertMany([
+      {name: "a", language: "javascript", timeout: 10, memoryLimit: 100, triggers},
+      {name: "b", language: "javascript", timeout: 20},
+      {name: "c", language: "typescript", timeout: 30, memoryLimit: 512}
+    ]);
+
+    await run([...args, "--from", "0.19.5", "--to", "0.19.6", "--continue-if-versions-are-equal"]);
+
+    const fns = await db.collection("function").find({}).sort({name: 1}).toArray();
+
+    expect(fns.every(fn => !("memoryLimit" in fn))).toBe(true);
+    expect(fns.map(fn => [fn.name, fn.language, fn.timeout])).toEqual([
+      ["a", "javascript", 10],
+      ["b", "javascript", 20],
+      ["c", "typescript", 30]
+    ]);
+    expect(fns[0].triggers).toEqual(triggers);
+  });
+});

--- a/apps/panel/src/store/api/functionApi.ts
+++ b/apps/panel/src/store/api/functionApi.ts
@@ -20,7 +20,6 @@ export interface SpicaFunction {
   timeout?: number;
   warmWorkers?: number;
   concurrencyPerWorker?: number;
-  memoryLimit?: number;
   env?: Record<string, string>;
   env_vars?: ResolvedEnvVar[];
   secrets?: ResolvedSecret[];
@@ -113,7 +112,6 @@ export interface CreateFunctionRequest {
   timeout?: number;
   warmWorkers?: number;
   concurrencyPerWorker?: number;
-  memoryLimit?: number;
   env?: Record<string, string>;
   dependencies?: Record<string, string>;
   triggers?: TriggerMap;
@@ -128,7 +126,6 @@ export interface UpdateFunctionRequest {
   timeout?: number;
   warmWorkers?: number;
   concurrencyPerWorker?: number;
-  memoryLimit?: number;
   triggers?: TriggerMap;
   category?: string;
 }

--- a/packages/api/function/src/asset.ts
+++ b/packages/api/function/src/asset.ts
@@ -16,6 +16,18 @@ import {IRepresentativeManager} from "@spica-server/interface-representative";
 
 const _module = "function";
 
+const REMOVED_FIELDS = ["memoryLimit"];
+
+function omitRemovedFields<T extends object>(schema: T): T {
+  const copy: any = {...schema};
+
+  for (const field of REMOVED_FIELDS) {
+    delete copy[field];
+  }
+
+  return copy;
+}
+
 export function registerAssetHandlers(
   fs: FunctionService,
   engine: FunctionEngine,
@@ -24,7 +36,7 @@ export function registerAssetHandlers(
   manager: IRepresentativeManager
 ) {
   const validator = async (resource: Resource<FunctionContents>) => {
-    const fn = resource.contents.schema;
+    const fn = omitRemovedFields(resource.contents.schema);
 
     const schemaValidation = () => Promise.resolve(validateSchema(fn, schemaValidator));
 
@@ -37,7 +49,7 @@ export function registerAssetHandlers(
 
   const operator = {
     insert: async (resource: Resource<FunctionContents>) => {
-      const schema = resource.contents.schema;
+      const schema = omitRemovedFields(resource.contents.schema);
       const fn: any = await CRUD.insert(fs, engine, schema);
 
       await CRUD.index.write(fs, engine, fn._id, resource.contents.index);
@@ -46,7 +58,7 @@ export function registerAssetHandlers(
     },
 
     update: async (resource: Resource<FunctionContents>) => {
-      const schema = resource.contents.schema;
+      const schema = omitRemovedFields(resource.contents.schema);
       const fn: any = await CRUD.replace(fs, engine, schema);
 
       await CRUD.index.write(fs, engine, fn._id, resource.contents.index);
@@ -76,7 +88,7 @@ export function registerAssetHandlers(
     const promises = [];
 
     // schema
-    promises.push(manager.write(_module, _id, "schema", fn, "yaml"));
+    promises.push(manager.write(_module, _id, "schema", omitRemovedFields(fn), "yaml"));
 
     // dependencies
     const dependencies = await engine.getPackages(fn).then(deps => {

--- a/packages/api/function/src/schema/function.json
+++ b/packages/api/function/src/schema/function.json
@@ -29,11 +29,6 @@
       "description": "Secrets that will be accessible in the function",
       "items": {"type": "string"}
     },
-    "memoryLimit": {
-      "type": "number",
-      "default": 100,
-      "description": "Memory value that function can use maximum"
-    },
     "timeout": {
       "type": "number",
       "description": "Value in seconds that function should be completed"

--- a/packages/api/function/test/asset.e2e.spec.ts
+++ b/packages/api/function/test/asset.e2e.spec.ts
@@ -126,8 +126,7 @@ describe("function", () => {
             preflight: true
           }
         }
-      },
-      memoryLimit: 100
+      }
     };
     fnv1Created = {...fnv1, env_vars: [], secrets: []};
 

--- a/packages/api/function/test/asset.e2e.spec.ts
+++ b/packages/api/function/test/asset.e2e.spec.ts
@@ -126,9 +126,12 @@ describe("function", () => {
             preflight: true
           }
         }
-      }
+      },
+      // exported by an older version, before memoryLimit was dropped from the schema
+      memoryLimit: 100
     };
     fnv1Created = {...fnv1, env_vars: [], secrets: []};
+    delete fnv1Created.memoryLimit;
 
     fnv1Resource = {
       _id: fnId,
@@ -144,6 +147,7 @@ describe("function", () => {
 
     fnv2 = {...fnv1, timeout: 60};
     fnv2Created = {...fnv2, env_vars: [], secrets: []};
+    delete fnv2Created.memoryLimit;
 
     fnv2Resource = {
       ...fnv1Resource,


### PR DESCRIPTION
memoryLimit was declared in the function JSON schema and mirrored in the panel types, but nothing in the scheduler or runtime ever read it, so setting it had no effect. Drop it from the schema and the panel request types.

Add a 0.19.6 migration that unsets the field from existing function documents. Keyed at 0.19.6 rather than 0.20.0 so it applies to any release the runner sees in its (from, to] window.

Note: function.json is additionalProperties: false and asset resources are validated against it on install, so asset bundles exported before this change that still carry memoryLimit will now fail validation.