### PR TITLE
fix(passport): respond with 429 when login attempt limit is reached

### DIFF
--- a/packages/api/passport/identity/src/identity.service.ts
+++ b/packages/api/passport/identity/src/identity.service.ts
@@ -1,4 +1,4 @@
-import {Injectable, Inject, UnauthorizedException} from "@nestjs/common";
+import {Injectable, Inject, HttpException, HttpStatus} from "@nestjs/common";
 import {BaseCollection, DatabaseService} from "@spica-server/database";
 import {
   Identity,
@@ -280,10 +280,15 @@ export class IdentityService extends BaseCollection<Identity>("identity") {
   checkIdentityIsBlocked(identity: Identity) {
     if (this.isIdentityBlocked(identity)) {
       const remainingBlockedSeconds = this.getRemainingBlockedSeconds(identity);
-      throw new UnauthorizedException(
-        `Too many failed login attempts. Try again after ${this.formatRemainingDuration(
-          remainingBlockedSeconds
-        )}.`
+      throw new HttpException(
+        {
+          statusCode: HttpStatus.TOO_MANY_REQUESTS,
+          message: `Too many failed login attempts. Try again after ${this.formatRemainingDuration(
+            remainingBlockedSeconds
+          )}.`,
+          error: "Too Many Requests"
+        },
+        HttpStatus.TOO_MANY_REQUESTS
       );
     }
   }

--- a/packages/api/passport/test/e2e.spec.ts
+++ b/packages/api/passport/test/e2e.spec.ts
@@ -1201,8 +1201,8 @@ describe("E2E Tests", () => {
 
       const responseWithBlockedError = responses[responses.length - 1];
 
-      expect(responseWithBlockedError.statusCode).toEqual(401);
-      expect(responseWithBlockedError.statusText).toEqual("Unauthorized");
+      expect(responseWithBlockedError.statusCode).toEqual(429);
+      expect(responseWithBlockedError.statusText).toEqual("Too Many Requests");
       expect(responseWithBlockedError.body.message).toEqual(
         "Too many failed login attempts. Try again after 10 minutes."
       );

--- a/packages/api/passport/user/src/user.service.ts
+++ b/packages/api/passport/user/src/user.service.ts
@@ -1,4 +1,11 @@
-import {Injectable, Inject, UnauthorizedException, BadRequestException} from "@nestjs/common";
+import {
+  Injectable,
+  Inject,
+  UnauthorizedException,
+  BadRequestException,
+  HttpException,
+  HttpStatus
+} from "@nestjs/common";
 import {BaseCollection, DatabaseService, ObjectId} from "@spica-server/database";
 import {
   User,
@@ -293,10 +300,15 @@ export class UserService extends BaseCollection<User>("user") {
   checkUserIsBlocked(user: User) {
     if (this.isUserBlocked(user)) {
       const remainingBlockedSeconds = this.getRemainingBlockedSeconds(user);
-      throw new UnauthorizedException(
-        `Too many failed login attempts. Try again after ${this.formatRemainingDuration(
-          remainingBlockedSeconds
-        )}.`
+      throw new HttpException(
+        {
+          statusCode: HttpStatus.TOO_MANY_REQUESTS,
+          message: `Too many failed login attempts. Try again after ${this.formatRemainingDuration(
+            remainingBlockedSeconds
+          )}.`,
+          error: "Too Many Requests"
+        },
+        HttpStatus.TOO_MANY_REQUESTS
       );
     }
   }


### PR DESCRIPTION
Both identity and user login threw UnauthorizedException once the failed login attempt limit was reached, so a blocked account was indistinguishable from a wrong password. Throw 429 Too Many Requests instead, with the same payload shape the rate limit guard already uses.