### PR TITLE
fix(cli): stop sync reporting function changes that do not exist

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -26,6 +26,10 @@
     "./src/function/triggers": {
       "types": "./src/function/triggers/index.ts",
       "default": "./dist/src/function/triggers/index.js"
+    },
+    "./src/http": {
+      "types": "./src/http.ts",
+      "default": "./dist/src/http.js"
     }
   },
   "publishConfig": {

--- a/apps/cli/src/http.ts
+++ b/apps/cli/src/http.ts
@@ -27,15 +27,23 @@ export namespace httpService {
         if (!error.response) {
           return Promise.reject(error);
         }
+        const status = error.response.status;
         const data = error.response.data || error.response;
+        // Keep the HTTP status (and the axios error code) on the rejected error so
+        // callers can tell a 404 apart from a throttled or failed request.
         if (data instanceof Error) {
-          return Promise.reject(data);
+          const known = data as Error & {status?: number};
+          if (known.status === undefined) {
+            known.status = status;
+          }
+          return Promise.reject(known);
         }
         const message =
-          typeof data === "string"
-            ? data
-            : data?.message || data?.error || JSON.stringify(data);
-        return Promise.reject(new Error(message));
+          typeof data === "string" ? data : data?.message || data?.error || JSON.stringify(data);
+        const rejection = new Error(message) as Error & {status?: number; code?: string};
+        rejection.status = status;
+        rejection.code = error.code;
+        return Promise.reject(rejection);
       }
     );
     instance.defaults.headers.common["Authorization"] = authorization;

--- a/apps/cli/test/http.spec.ts
+++ b/apps/cli/test/http.spec.ts
@@ -1,0 +1,60 @@
+import {httpService} from "@spica/cli/src/http";
+
+function clientRejectingWith(rejection: unknown) {
+  const client = httpService.create({
+    baseUrl: "http://localhost",
+    authorization: "APIKEY test"
+  }) as any;
+  client.defaults.adapter = () => Promise.reject(rejection);
+  return client;
+}
+
+describe("httpService", () => {
+  // The rejected error is the only thing callers get to inspect; dropping the
+  // status made it impossible to tell a 404 apart from a throttled request.
+  it("keeps the response status on the rejected error", async () => {
+    const client = clientRejectingWith(
+      Object.assign(new Error("Request failed"), {
+        response: {status: 404, data: {message: "Not Found"}}
+      })
+    );
+
+    const error = await client.get("function/fn1/index").catch(e => e);
+    expect(error.message).toBe("Not Found");
+    expect(error.status).toBe(404);
+  });
+
+  it("keeps the axios error code on the rejected error", async () => {
+    const client = clientRejectingWith(
+      Object.assign(new Error("Request failed"), {
+        code: "ECONNABORTED",
+        response: {status: 503, data: "Service Unavailable"}
+      })
+    );
+
+    const error = await client.get("function").catch(e => e);
+    expect(error.status).toBe(503);
+    expect(error.code).toBe("ECONNABORTED");
+  });
+
+  it("annotates an error body that is already an Error without overwriting its status", async () => {
+    const alreadyStatused = Object.assign(new Error("Gone"), {status: 410});
+    const client = clientRejectingWith(
+      Object.assign(new Error("Request failed"), {
+        response: {status: 500, data: alreadyStatused}
+      })
+    );
+
+    const error = await client.get("function").catch(e => e);
+    expect(error).toBe(alreadyStatused);
+    expect(error.status).toBe(410);
+  });
+
+  it("rejects with the original error when there is no response", async () => {
+    const networkError = Object.assign(new Error("connect ECONNREFUSED"), {code: "ECONNREFUSED"});
+    const client = clientRejectingWith(networkError);
+
+    const error = await client.get("function").catch(e => e);
+    expect(error).toBe(networkError);
+  });
+});

--- a/packages/sync/src/modules/function.ts
+++ b/packages/sync/src/modules/function.ts
@@ -4,7 +4,7 @@ import yaml from "yaml";
 import isEqual from "lodash/isEqual.js";
 import {bold, cyan, green, red, yellow} from "colorette";
 import {SyncHttpClient} from "../http";
-import {buildUnifiedDiff, diffObjectFields} from "../planner";
+import {buildUnifiedDiff, diffObjectFields, formatError} from "../planner";
 import {
   ensureDir,
   listFolders,
@@ -68,19 +68,81 @@ function normalizeSchema(schema: FunctionSchema): FunctionSchema {
   return normalized;
 }
 
-function isNotFoundError(error: unknown): boolean {
-  if (!error || typeof error !== "object") return false;
+function errorStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== "object") return undefined;
   const c = error as {
     status?: number;
     statusCode?: number;
     response?: {status?: number; statusCode?: number};
   };
-  return (
-    c.status === 404 ||
-    c.statusCode === 404 ||
-    c.response?.status === 404 ||
-    c.response?.statusCode === 404
-  );
+  const status = c.status ?? c.statusCode ?? c.response?.status ?? c.response?.statusCode;
+  return typeof status === "number" ? status : undefined;
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return errorStatus(error) === 404;
+}
+
+// ─── Remote detail fetching ──────────────────────────────────────────────────
+// `readRemote` needs two extra requests per function (index + dependencies). On
+// an instance with many functions, firing them all at once gets requests
+// throttled or dropped, and a dropped request used to be read as "remote is
+// empty" — which surfaced as a change that does not exist. So: bound the
+// concurrency, retry what is worth retrying, and refuse to guess otherwise.
+
+const DEFAULT_FETCH_CONCURRENCY = 5;
+const DEFAULT_FETCH_RETRIES = 3;
+const RETRY_BASE_DELAY_MS = 300;
+
+function positiveEnvNumber(name: string, fallback: number): number {
+  const raw = Number(process.env[name]);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : fallback;
+}
+
+/** Transport errors (no status), throttling and server errors are worth a retry. */
+function isRetryableError(error: unknown): boolean {
+  const status = errorStatus(error);
+  if (status === undefined) return true;
+  return status === 408 || status === 425 || status === 429 || status >= 500;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function retryRequest<T>(op: () => Promise<T>, retries: number): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await op();
+    } catch (error) {
+      lastError = error;
+      if (!isRetryableError(error) || attempt === retries) throw error;
+      await delay(RETRY_BASE_DELAY_MS * 2 ** attempt);
+    }
+  }
+  throw lastError;
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  worker: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+
+  const runner = async () => {
+    while (true) {
+      const index = cursor++;
+      if (index >= items.length) return;
+      results[index] = await worker(items[index], index);
+    }
+  };
+
+  const runners = Math.max(1, Math.min(limit, items.length));
+  await Promise.all(Array.from({length: runners}, runner));
+  return results;
 }
 
 // ─── Extended interface with granular read/write operations ──────────────────
@@ -145,36 +207,69 @@ export const functionModule: FunctionModule = {
   },
 
   async readRemote(http) {
-    const res = await http.get<FunctionSchema[] | {data: FunctionSchema[]}>("function");
+    const concurrency = positiveEnvNumber("SPICA_SYNC_CONCURRENCY", DEFAULT_FETCH_CONCURRENCY);
+    const retries = positiveEnvNumber("SPICA_SYNC_RETRIES", DEFAULT_FETCH_RETRIES);
+
+    const res = await retryRequest(
+      () => http.get<FunctionSchema[] | {data: FunctionSchema[]}>("function"),
+      retries
+    );
     const fns = unwrapList(res);
 
-    return Promise.all(
-      fns.map(async fn => {
-        const id = fn._id!;
+    const failures: string[] = [];
 
-        const [indexRes, depsRes] = await Promise.all([
-          http.get<{index: string}>(`function/${id}/index`).catch(() => ({index: ""})),
-          http
-            .get<RemoteDependency[]>(`function/${id}/dependencies`)
-            .catch(() => [] as RemoteDependency[])
-        ]);
+    const resources = await mapWithConcurrency(fns, concurrency, async fn => {
+      const id = fn._id!;
 
-        const dependencies: Record<string, string> = {};
-        for (const dep of depsRes) {
-          dependencies[dep.name] = dep.version;
-        }
-
-        return {
-          slug: sanitizeSlug(fn.name),
-          id,
-          data: {
-            schema: normalizeSchema(fn),
-            index: indexRes.index ?? "",
-            dependencies
+      const [indexRes, depsRes] = await Promise.all([
+        retryRequest(() => http.get<{index: string}>(`function/${id}/index`), retries).catch(
+          error => {
+            // A function that has no source yet really is empty; anything else
+            // is a failed read we must not mistake for one.
+            if (isNotFoundError(error)) return {index: ""};
+            failures.push(`${fn.name}: index (${formatError(error)})`);
+            return undefined;
           }
-        };
-      })
-    );
+        ),
+        retryRequest(
+          () => http.get<RemoteDependency[]>(`function/${id}/dependencies`),
+          retries
+        ).catch(error => {
+          if (isNotFoundError(error)) return [] as RemoteDependency[];
+          failures.push(`${fn.name}: dependencies (${formatError(error)})`);
+          return undefined;
+        })
+      ]);
+
+      if (indexRes === undefined || depsRes === undefined) return undefined;
+
+      const dependencies: Record<string, string> = {};
+      for (const dep of depsRes) {
+        dependencies[dep.name] = dep.version;
+      }
+
+      return {
+        slug: sanitizeSlug(fn.name),
+        id,
+        data: {
+          schema: normalizeSchema(fn),
+          index: indexRes.index ?? "",
+          dependencies
+        }
+      };
+    });
+
+    if (failures.length) {
+      throw new Error(
+        `Could not read ${failures.length} remote function detail(s) after ${retries} retries, ` +
+          `aborting instead of reporting changes that may not exist:\n  - ` +
+          `${failures.join("\n  - ")}\n` +
+          `Retry, or lower the request concurrency with SPICA_SYNC_CONCURRENCY ` +
+          `(current: ${concurrency}).`
+      );
+    }
+
+    return resources.filter((r): r is RemoteResource<FunctionData> => r !== undefined);
   },
 
   async create(http, local) {

--- a/packages/sync/src/planner.ts
+++ b/packages/sync/src/planner.ts
@@ -519,7 +519,7 @@ async function runConcurrently(
   }
 }
 
-function formatError(e: unknown): string {
+export function formatError(e: unknown): string {
   if (e && typeof e === "object") {
     const err = e as any;
     return err.message ?? err.data?.message ?? JSON.stringify(e);

--- a/packages/sync/test/modules/function.spec.ts
+++ b/packages/sync/test/modules/function.spec.ts
@@ -152,11 +152,151 @@ describe("functionModule.readRemote", () => {
   // instead of silently treating it as an empty remote.
   it("throws a helpful error when the endpoint returns a non-list body (e.g. panel HTML)", async () => {
     mockHttp.get.mockImplementation((url: string) => {
-      if (url === "function") return Promise.resolve("<!doctype html><html><body>Panel</body></html>");
+      if (url === "function")
+        return Promise.resolve("<!doctype html><html><body>Panel</body></html>");
       return Promise.resolve([]);
     });
 
     await expect(functionModule.readRemote(mockHttp)).rejects.toThrow(/context URL/);
+  });
+
+  // Regression: the per-function index/dependencies requests used to be fired all
+  // at once and swallowed on failure (`.catch(() => ({index: ""}))`), so a
+  // throttled or dropped request looked like an empty remote and `spica plan`
+  // reported an [index, dependencies] change that did not exist.
+  describe("failed detail requests", () => {
+    const envKeys = ["SPICA_SYNC_CONCURRENCY", "SPICA_SYNC_RETRIES"];
+    const originalEnv: Record<string, string | undefined> = {};
+
+    beforeEach(() => {
+      for (const key of envKeys) originalEnv[key] = process.env[key];
+    });
+
+    afterEach(() => {
+      for (const key of envKeys) {
+        if (originalEnv[key] === undefined) delete process.env[key];
+        else process.env[key] = originalEnv[key];
+      }
+    });
+
+    function httpError(status: number): Error & {status: number} {
+      return Object.assign(new Error(`request failed with ${status}`), {status});
+    }
+
+    it("aborts instead of reporting an empty index when the request keeps failing", async () => {
+      process.env.SPICA_SYNC_RETRIES = "0";
+      mockHttp.get.mockImplementation((url: string) => {
+        if (url === "function")
+          return Promise.resolve([{_id: "fn1", name: "MyFn", language: "javascript"}]);
+        if (url === "function/fn1/index") return Promise.reject(httpError(429));
+        if (url === "function/fn1/dependencies") return Promise.resolve([]);
+        return Promise.resolve([]);
+      });
+
+      await expect(functionModule.readRemote(mockHttp)).rejects.toThrow(/MyFn: index/);
+    });
+
+    it("names every function whose details could not be read", async () => {
+      process.env.SPICA_SYNC_RETRIES = "0";
+      mockHttp.get.mockImplementation((url: string) => {
+        if (url === "function")
+          return Promise.resolve([
+            {_id: "fn1", name: "First", language: "javascript"},
+            {_id: "fn2", name: "Second", language: "javascript"}
+          ]);
+        if (url === "function/fn1/index") return Promise.resolve({index: "ok"});
+        if (url === "function/fn1/dependencies") return Promise.reject(httpError(500));
+        if (url === "function/fn2/index") return Promise.reject(httpError(503));
+        if (url === "function/fn2/dependencies") return Promise.resolve([]);
+        return Promise.resolve([]);
+      });
+
+      const error = await functionModule.readRemote(mockHttp).catch(e => e as Error);
+      expect(error.message).toMatch(/First: dependencies/);
+      expect(error.message).toMatch(/Second: index/);
+    });
+
+    it("retries a temporary failure and returns the real index", async () => {
+      process.env.SPICA_SYNC_RETRIES = "2";
+      let indexAttempts = 0;
+      mockHttp.get.mockImplementation((url: string) => {
+        if (url === "function")
+          return Promise.resolve([{_id: "fn1", name: "MyFn", language: "javascript"}]);
+        if (url === "function/fn1/index") {
+          indexAttempts++;
+          return indexAttempts < 3
+            ? Promise.reject(httpError(429))
+            : Promise.resolve({index: "export default () => {};"});
+        }
+        if (url === "function/fn1/dependencies") return Promise.resolve([]);
+        return Promise.resolve([]);
+      });
+
+      const result = await functionModule.readRemote(mockHttp);
+      expect(indexAttempts).toBe(3);
+      expect(result[0].data.index).toBe("export default () => {};");
+    });
+
+    it("does not retry a client error that a retry cannot fix", async () => {
+      process.env.SPICA_SYNC_RETRIES = "3";
+      let indexAttempts = 0;
+      mockHttp.get.mockImplementation((url: string) => {
+        if (url === "function")
+          return Promise.resolve([{_id: "fn1", name: "MyFn", language: "javascript"}]);
+        if (url === "function/fn1/index") {
+          indexAttempts++;
+          return Promise.reject(httpError(403));
+        }
+        if (url === "function/fn1/dependencies") return Promise.resolve([]);
+        return Promise.resolve([]);
+      });
+
+      await expect(functionModule.readRemote(mockHttp)).rejects.toThrow(/MyFn: index/);
+      expect(indexAttempts).toBe(1);
+    });
+
+    it("treats a 404 as a function that has no index or dependencies yet", async () => {
+      mockHttp.get.mockImplementation((url: string) => {
+        if (url === "function")
+          return Promise.resolve([{_id: "fn1", name: "MyFn", language: "javascript"}]);
+        if (url === "function/fn1/index") return Promise.reject(httpError(404));
+        if (url === "function/fn1/dependencies") return Promise.reject(httpError(404));
+        return Promise.resolve([]);
+      });
+
+      const result = await functionModule.readRemote(mockHttp);
+      expect(result).toHaveLength(1);
+      expect(result[0].data.index).toBe("");
+      expect(result[0].data.dependencies).toEqual({});
+    });
+
+    it("keeps the number of in-flight detail requests within the configured limit", async () => {
+      process.env.SPICA_SYNC_CONCURRENCY = "2";
+      const fns = Array.from({length: 6}, (_, i) => ({
+        _id: `fn${i}`,
+        name: `Fn${i}`,
+        language: "javascript"
+      }));
+
+      let inFlight = 0;
+      let peak = 0;
+      mockHttp.get.mockImplementation((url: string) => {
+        if (url === "function") return Promise.resolve(fns);
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        return new Promise(resolve =>
+          setImmediate(() => {
+            inFlight--;
+            resolve(url.endsWith("/index") ? {index: ""} : []);
+          })
+        );
+      });
+
+      const result = await functionModule.readRemote(mockHttp);
+      expect(result).toHaveLength(6);
+      // 2 functions in flight, each with its index + dependencies request
+      expect(peak).toBeLessThanOrEqual(4);
+    });
   });
 });
 


### PR DESCRIPTION
## Problem

`functionModule.readRemote` needs two extra requests per function (`function/:id/index`
and `function/:id/dependencies`). Those were fired for every function at once and every
failure was swallowed:

```ts
http.get(`function/${id}/index`).catch(() => ({index: ""})),
http.get(`function/${id}/dependencies`).catch(() => [] as RemoteDependency[])
```

On an instance with a lot of functions (we hit this at ~87 functions → 174 concurrent
requests) some of those requests get throttled or dropped. A dropped request was then
read as "the remote index is empty", so the planner compared an empty remote against the
local file and `spica plan` reported an `[index, dependencies]` change for functions
nobody had touched — with exit code 0, so it looked legitimate. `spica apply` then
re-uploaded them, and the next `plan` showed a different random subset.

## Fix

`packages/sync/src/modules/function.ts`

- The per-function detail requests run with bounded concurrency, `SPICA_SYNC_CONCURRENCY`
  (default 5), instead of all at once.
- Transient failures (transport errors, 408/425/429, 5xx) are retried with backoff,
  `SPICA_SYNC_RETRIES` (default 3).
- Only a real 404 is treated as empty — that is a function which genuinely has no index
  or dependencies yet.
- If a read still fails, `readRemote` names the functions and requests that failed and
  throws, instead of producing a plan built on data it does not have.

`apps/cli/src/http.ts`

- The axios response interceptor rebuilt the error as `new Error(message)` and dropped the
  HTTP status, so `isNotFoundError` could never match. `status` (and the axios `code`) are
  now preserved on the rejected error.

`packages/sync/src/planner.ts`

- `formatError` is exported so the function module can reuse it rather than adding a third
  copy of it.

`apps/cli/package.json`

- Added the `./src/http` export subpath so the interceptor can be imported from tests, the
  same way the other tested modules are.

## Tests

- `packages/sync/test/modules/function.spec.ts` — aborts instead of reporting an empty
  index when a detail request keeps failing, names every function that could not be read,
  retries a temporary failure and returns the real index, does not retry a client error,
  still treats 404 as empty, and keeps in-flight requests within the configured limit.
- `apps/cli/test/http.spec.ts` — the rejected error keeps `status`/`code`, an error body
  that is already an `Error` is not given a status it already has, and a response-less
  network error is rejected untouched.

```
nx test sync   → 110 passed
nx test cli    →  68 passed
nx typecheck sync → ok
```

## Notes

The defaults are conservative on purpose: concurrency 5 and 3 retries keep the common case
fast while staying well under what a busy instance drops. Both are overridable via env vars
for instances that need to go lower.

---

Fixes #1940
