### PR TITLE
fix(cli): stop sync reporting function changes that do not exist

### DIFF
--- a/apps/cli/src/commands/sync/apply.ts
+++ b/apps/cli/src/commands/sync/apply.ts
@@ -11,7 +11,7 @@ import {cliReporter} from "./reporter";
 async function apply({args, options}: ActionParameters) {
   const rootDir = path.resolve((args.dir as string | undefined) ?? process.cwd());
   const autoApprove = !!options.autoApprove;
-  const concurrency = (options.concurrency as number) ?? 10;
+  const concurrency = options.concurrency as number;
   const abortOnError = !!options.abortOnError;
   const detailed = !!options.detailed;
   const moduleFilter = options.module
@@ -22,7 +22,11 @@ async function apply({args, options}: ActionParameters) {
   const http = await httpService.createFromCurrentCtx();
 
   console.log(bold("\nBuilding plan…"));
-  const p = await buildPlan(modules, http, rootDir, detailed, true, cliReporter);
+  const p = await buildPlan(modules, http, rootDir, {
+    detailed,
+    reporter: cliReporter,
+    concurrency
+  });
 
   const totalChanges = p.modules.reduce(
     (n, m) => n + m.creates.length + m.updates.length + m.deletes.length,

--- a/apps/cli/src/commands/sync/dev.ts
+++ b/apps/cli/src/commands/sync/dev.ts
@@ -399,7 +399,7 @@ async function dev({args, options}: ActionParameters) {
   console.log(bold("\nBuilding plan…"));
   let plan: Awaited<ReturnType<typeof buildPlan>>;
   try {
-    plan = await buildPlan(modules, http, rootDir, false, true, cliReporter);
+    plan = await buildPlan(modules, http, rootDir, {reporter: cliReporter});
   } catch (err) {
     console.log(`\n${bold(red(`✗ Failed to build plan: ${formatError(err)}`))}`);
     process.exitCode = 1;

--- a/apps/cli/src/commands/sync/fetch.ts
+++ b/apps/cli/src/commands/sync/fetch.ts
@@ -4,14 +4,21 @@ import caporalCore from "@caporal/core";
 const {CaporalValidator} = caporalCore;
 import {bold, green, red, yellow} from "colorette";
 import {httpService} from "../../http";
-import {buildPlan, fetchToDisk, renderPlan, resolveModules, MODULE_NAMES} from "@spica-server/sync";
+import {
+  buildPlan,
+  fetchToDisk,
+  renderPlan,
+  resolveModules,
+  DEFAULT_CONCURRENCY,
+  MODULE_NAMES
+} from "@spica-server/sync";
 import {confirm} from "./prompt";
 import {cliReporter} from "./reporter";
 
 async function fetch_({args, options}: ActionParameters) {
   const rootDir = path.resolve((args.dir as string | undefined) ?? process.cwd());
   const autoApprove = !!options.autoApprove;
-  const concurrency = (options.concurrency as number) ?? 10;
+  const concurrency = options.concurrency as number;
   const abortOnError = !!options.abortOnError;
   const detailed = !!options.detailed;
   const clean = !!options.clean;
@@ -23,7 +30,12 @@ async function fetch_({args, options}: ActionParameters) {
   const http = await httpService.createFromCurrentCtx();
 
   console.log(bold("\nBuilding plan…"));
-  const p = await buildPlan(modules, http, rootDir, detailed, false, cliReporter);
+  const p = await buildPlan(modules, http, rootDir, {
+    detailed,
+    detectRenames: false,
+    reporter: cliReporter,
+    concurrency
+  });
 
   // Fetch perspective: deletes = new remote files to write, updates = changed to overwrite,
   // creates = local-only stale files (removed only with --clean)
@@ -82,8 +94,8 @@ export default function (program: Program): Command {
     .option("--auto-approve, -y", "Skip confirmation prompt and write immediately.", {
       default: false
     })
-    .option("--concurrency <n>", "Maximum parallel file writes.", {
-      default: 10 as number,
+    .option("--concurrency <n>", "Maximum parallel API requests and file writes.", {
+      default: DEFAULT_CONCURRENCY as number,
       validator: CaporalValidator.NUMBER
     })
     .option("--abort-on-error", "Stop immediately if any operation fails.", {default: false})

--- a/apps/cli/src/commands/sync/plan.ts
+++ b/apps/cli/src/commands/sync/plan.ts
@@ -1,7 +1,15 @@
 import path from "path";
 import {ActionParameters, Command, Program} from "@caporal/core";
+import caporalCore from "@caporal/core";
+const {CaporalValidator} = caporalCore;
 import {httpService} from "../../http";
-import {buildPlan, renderPlan, resolveModules, MODULE_NAMES} from "@spica-server/sync";
+import {
+  buildPlan,
+  renderPlan,
+  resolveModules,
+  DEFAULT_CONCURRENCY,
+  MODULE_NAMES
+} from "@spica-server/sync";
 import {cliReporter} from "./reporter";
 
 async function plan({args, options}: ActionParameters) {
@@ -9,6 +17,7 @@ async function plan({args, options}: ActionParameters) {
     const rootDir = path.resolve((args.dir as string | undefined) ?? process.cwd());
     const detailed = !!options.detailed;
     const json = !!options.json;
+    const concurrency = options.concurrency as number;
     const moduleFilter = options.module
       ? (Array.isArray(options.module) ? options.module : [options.module]).map(String)
       : undefined;
@@ -16,7 +25,11 @@ async function plan({args, options}: ActionParameters) {
     const modules = resolveModules(moduleFilter);
     const http = await httpService.createFromCurrentCtx();
 
-    const p = await buildPlan(modules, http, rootDir, detailed, true, cliReporter);
+    const p = await buildPlan(modules, http, rootDir, {
+      detailed,
+      reporter: cliReporter,
+      concurrency
+    });
     renderPlan(p, {detailed, json});
 
     process.exitCode = 0;
@@ -40,6 +53,10 @@ export default function (program: Program): Command {
       {default: false}
     )
     .option("--json", "Output the plan as JSON (machine-readable).", {default: false})
+    .option("--concurrency <n>", "Maximum parallel API requests.", {
+      default: DEFAULT_CONCURRENCY as number,
+      validator: CaporalValidator.NUMBER
+    })
     .option(
       "--module <name>",
       `Filter to specific module(s). Available: ${MODULE_NAMES.join(", ")}.`,

--- a/apps/cli/src/http.ts
+++ b/apps/cli/src/http.ts
@@ -28,14 +28,12 @@ export namespace httpService {
           return Promise.reject(error);
         }
         const data = error.response.data || error.response;
-        if (data instanceof Error) {
-          return Promise.reject(data);
-        }
         const message =
           typeof data === "string"
             ? data
             : data?.message || data?.error || JSON.stringify(data);
-        return Promise.reject(new Error(message));
+        const rejection = data instanceof Error ? data : new Error(message);
+        return Promise.reject(Object.assign(rejection, {status: error.response.status}));
       }
     );
     instance.defaults.headers.common["Authorization"] = authorization;

--- a/packages/sync/src/modules/function.ts
+++ b/packages/sync/src/modules/function.ts
@@ -68,6 +68,20 @@ function normalizeSchema(schema: FunctionSchema): FunctionSchema {
   return normalized;
 }
 
+const DETAIL_CONCURRENCY = 10;
+
+async function mapInBatches<T, R>(
+  items: T[],
+  size: number,
+  fn: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = [];
+  for (let i = 0; i < items.length; i += size) {
+    results.push(...(await Promise.all(items.slice(i, i + size).map(fn))));
+  }
+  return results;
+}
+
 function isNotFoundError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
   const c = error as {
@@ -81,6 +95,13 @@ function isNotFoundError(error: unknown): boolean {
     c.response?.status === 404 ||
     c.response?.statusCode === 404
   );
+}
+
+function getOrEmptyOnNotFound<T>(http: SyncHttpClient, url: string, empty: T): Promise<T> {
+  return http.get<T>(url).catch(error => {
+    if (isNotFoundError(error)) return empty;
+    throw error;
+  });
 }
 
 // ─── Extended interface with granular read/write operations ──────────────────
@@ -148,33 +169,31 @@ export const functionModule: FunctionModule = {
     const res = await http.get<FunctionSchema[] | {data: FunctionSchema[]}>("function");
     const fns = unwrapList(res);
 
-    return Promise.all(
-      fns.map(async fn => {
-        const id = fn._id!;
+    return mapInBatches(fns, DETAIL_CONCURRENCY, async fn => {
+      const id = fn._id!;
 
-        const [indexRes, depsRes] = await Promise.all([
-          http.get<{index: string}>(`function/${id}/index`).catch(() => ({index: ""})),
-          http
-            .get<RemoteDependency[]>(`function/${id}/dependencies`)
-            .catch(() => [] as RemoteDependency[])
-        ]);
+      const [indexRes, depsRes] = await Promise.all([
+        getOrEmptyOnNotFound(http, `function/${id}/index`, {index: ""}),
+        getOrEmptyOnNotFound<RemoteDependency[]>(http, `function/${id}/dependencies`, [])
+      ]).catch(error => {
+        throw new Error(`Could not read function "${fn.name}": ${error?.message ?? error}`);
+      });
 
-        const dependencies: Record<string, string> = {};
-        for (const dep of depsRes) {
-          dependencies[dep.name] = dep.version;
+      const dependencies: Record<string, string> = {};
+      for (const dep of depsRes) {
+        dependencies[dep.name] = dep.version;
+      }
+
+      return {
+        slug: sanitizeSlug(fn.name),
+        id,
+        data: {
+          schema: normalizeSchema(fn),
+          index: indexRes.index ?? "",
+          dependencies
         }
-
-        return {
-          slug: sanitizeSlug(fn.name),
-          id,
-          data: {
-            schema: normalizeSchema(fn),
-            index: indexRes.index ?? "",
-            dependencies
-          }
-        };
-      })
-    );
+      };
+    });
   },
 
   async create(http, local) {

--- a/packages/sync/src/modules/function.ts
+++ b/packages/sync/src/modules/function.ts
@@ -17,7 +17,13 @@ import {
   writeText,
   writeYaml
 } from "../fs-utils";
-import {DevEventContext, LocalResource, RemoteResource, ResourceModule} from "../types";
+import {
+  DEFAULT_CONCURRENCY,
+  DevEventContext,
+  LocalResource,
+  RemoteResource,
+  ResourceModule
+} from "../types";
 
 interface FunctionSchema {
   _id?: string;
@@ -68,16 +74,16 @@ function normalizeSchema(schema: FunctionSchema): FunctionSchema {
   return normalized;
 }
 
-const DETAIL_CONCURRENCY = 10;
-
 async function mapInBatches<T, R>(
   items: T[],
   size: number,
   fn: (item: T) => Promise<R>
 ): Promise<R[]> {
+  // A non-positive size would never advance `i` — an unresponsive infinite loop.
+  const limit = Math.max(1, size);
   const results: R[] = [];
-  for (let i = 0; i < items.length; i += size) {
-    results.push(...(await Promise.all(items.slice(i, i + size).map(fn))));
+  for (let i = 0; i < items.length; i += limit) {
+    results.push(...(await Promise.all(items.slice(i, i + limit).map(fn))));
   }
   return results;
 }
@@ -97,12 +103,12 @@ function isNotFoundError(error: unknown): boolean {
   );
 }
 
-function getOrEmptyOnNotFound<T>(http: SyncHttpClient, url: string, empty: T): Promise<T> {
-  return http.get<T>(url).catch(error => {
+const emptyIfMissing =
+  <T>(empty: T) =>
+  (error: unknown): T => {
     if (isNotFoundError(error)) return empty;
     throw error;
-  });
-}
+  };
 
 // ─── Extended interface with granular read/write operations ──────────────────
 
@@ -165,16 +171,18 @@ export const functionModule: FunctionModule = {
     return results;
   },
 
-  async readRemote(http) {
+  async readRemote(http, options = {}) {
     const res = await http.get<FunctionSchema[] | {data: FunctionSchema[]}>("function");
     const fns = unwrapList(res);
 
-    return mapInBatches(fns, DETAIL_CONCURRENCY, async fn => {
+    return mapInBatches(fns, options.concurrency ?? DEFAULT_CONCURRENCY, async fn => {
       const id = fn._id!;
 
       const [indexRes, depsRes] = await Promise.all([
-        getOrEmptyOnNotFound(http, `function/${id}/index`, {index: ""}),
-        getOrEmptyOnNotFound<RemoteDependency[]>(http, `function/${id}/dependencies`, [])
+        http.get<{index: string}>(`function/${id}/index`).catch(emptyIfMissing({index: ""})),
+        http
+          .get<RemoteDependency[]>(`function/${id}/dependencies`)
+          .catch(emptyIfMissing<RemoteDependency[]>([]))
       ]).catch(error => {
         throw new Error(`Could not read function "${fn.name}": ${error?.message ?? error}`);
       });

--- a/packages/sync/src/planner.ts
+++ b/packages/sync/src/planner.ts
@@ -7,24 +7,36 @@ import {SyncReporter, silentReporter} from "./reporter";
 import {omit} from "./fs-utils";
 import {
   ChangeKind,
+  DEFAULT_CONCURRENCY,
   LocalResource,
   ModulePlan,
   Plan,
   PlanEntry,
+  ReadRemoteOptions,
   RemoteResource,
   ResourceModule
 } from "./types";
 
 // ─── Build ────────────────────────────────────────────────────────────────────
 
+export interface BuildPlanOptions extends ReadRemoteOptions {
+  detailed?: boolean;
+  detectRenames?: boolean;
+  reporter?: SyncReporter;
+}
+
 export async function buildPlan(
   modules: ResourceModule[],
   http: SyncHttpClient,
   rootDir: string,
-  detailed = false,
-  detectRenames = true,
-  reporter: SyncReporter = silentReporter
+  options: BuildPlanOptions = {}
 ): Promise<Plan> {
+  const {
+    detailed = false,
+    detectRenames = true,
+    reporter = silentReporter,
+    concurrency = DEFAULT_CONCURRENCY
+  } = options;
   const modulePlans: ModulePlan[] = [];
 
   for (const mod of modules) {
@@ -33,7 +45,7 @@ export async function buildPlan(
         mod.readLocal(rootDir)
       ),
       reporter.task<RemoteResource[]>(`Fetching remote ${mod.displayName}`, () =>
-        mod.readRemote(http)
+        mod.readRemote(http, {concurrency})
       )
     ]);
 
@@ -296,7 +308,7 @@ export async function applyPlan(
   http: SyncHttpClient,
   opts: ApplyOptions = {}
 ): Promise<{errors: string[]}> {
-  const concurrency = opts.concurrency ?? 10;
+  const concurrency = opts.concurrency ?? DEFAULT_CONCURRENCY;
   const reporter = opts.reporter ?? silentReporter;
   const errors: string[] = [];
 
@@ -360,7 +372,7 @@ export async function fetchToDisk(
   rootDir: string,
   opts: FetchOptions = {}
 ): Promise<{written: number; deleted: number; errors: string[]}> {
-  const concurrency = opts.concurrency ?? 10;
+  const concurrency = opts.concurrency ?? DEFAULT_CONCURRENCY;
   const reporter = opts.reporter ?? silentReporter;
   const errors: string[] = [];
   let written = 0;

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -89,6 +89,20 @@ export interface Plan {
 }
 
 /**
+ * Parallel API requests / file writes the sync engine issues. Every sync command
+ * surfaces it as `--concurrency <n>`; lower it when the instance answers 429.
+ */
+export const DEFAULT_CONCURRENCY = 10;
+
+export interface ReadRemoteOptions {
+  /**
+   * Maximum resources fetched in parallel; defaults to `DEFAULT_CONCURRENCY`.
+   * Modules whose remote read is a single request ignore it.
+   */
+  concurrency?: number;
+}
+
+/**
  * Strategy interface — one implementation per resource type.
  * Adding a new module = one new file implementing this interface.
  */
@@ -117,7 +131,7 @@ export interface ResourceModule<T = any> {
   /** Read all local resources from the project directory */
   readLocal(rootDir: string): Promise<LocalResource<T>[]>;
   /** Fetch all remote resources from the Spica API */
-  readRemote(http: SyncHttpClient): Promise<RemoteResource<T>[]>;
+  readRemote(http: SyncHttpClient, options?: ReadRemoteOptions): Promise<RemoteResource<T>[]>;
 
   /** Apply a create to the remote API */
   create(http: SyncHttpClient, local: LocalResource<T>): Promise<void>;

--- a/packages/sync/test/modules/function.spec.ts
+++ b/packages/sync/test/modules/function.spec.ts
@@ -158,6 +158,54 @@ describe("functionModule.readRemote", () => {
 
     await expect(functionModule.readRemote(mockHttp)).rejects.toThrow(/context URL/);
   });
+
+  // Regression: a throttled/dropped detail request used to be swallowed into an
+  // empty index, so `plan` reported changes for functions nobody had touched.
+  it("fails naming the function when a detail request fails for any reason but 404", async () => {
+    mockHttp.get.mockImplementation((url: string) => {
+      if (url === "function") return Promise.resolve([{_id: "fn1", name: "MyFn"}]);
+      if (url === "function/fn1/index")
+        return Promise.reject(Object.assign(new Error("Too Many Requests"), {status: 429}));
+      return Promise.resolve([]);
+    });
+
+    await expect(functionModule.readRemote(mockHttp)).rejects.toThrow(
+      /Could not read function "MyFn".*Too Many Requests/
+    );
+  });
+
+  it("treats a 404 as a function that has no index or dependencies yet", async () => {
+    mockHttp.get.mockImplementation((url: string) => {
+      if (url === "function") return Promise.resolve([{_id: "fn1", name: "MyFn"}]);
+      return Promise.reject(Object.assign(new Error("Index does not exist."), {status: 404}));
+    });
+
+    const result = await functionModule.readRemote(mockHttp);
+    expect(result[0].data.index).toBe("");
+    expect(result[0].data.dependencies).toEqual({});
+  });
+
+  it("keeps the per-function detail requests within a concurrency limit", async () => {
+    const fns = Array.from({length: 50}, (_, i) => ({_id: `fn${i}`, name: `Fn${i}`}));
+    let inFlight = 0;
+    let peak = 0;
+
+    mockHttp.get.mockImplementation((url: string) => {
+      if (url === "function") return Promise.resolve(fns);
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      return new Promise(resolve =>
+        setImmediate(() => {
+          inFlight--;
+          resolve(url.endsWith("/index") ? {index: ""} : []);
+        })
+      );
+    });
+
+    const result = await functionModule.readRemote(mockHttp);
+    expect(result).toHaveLength(50);
+    expect(peak).toBeLessThanOrEqual(20);
+  });
 });
 
 describe("functionModule.create", () => {

--- a/packages/sync/test/modules/function.spec.ts
+++ b/packages/sync/test/modules/function.spec.ts
@@ -185,26 +185,42 @@ describe("functionModule.readRemote", () => {
     expect(result[0].data.dependencies).toEqual({});
   });
 
-  it("keeps the per-function detail requests within a concurrency limit", async () => {
-    const fns = Array.from({length: 50}, (_, i) => ({_id: `fn${i}`, name: `Fn${i}`}));
-    let inFlight = 0;
-    let peak = 0;
-
+  it("does not hang when a non-positive concurrency is requested", async () => {
     mockHttp.get.mockImplementation((url: string) => {
-      if (url === "function") return Promise.resolve(fns);
-      inFlight++;
-      peak = Math.max(peak, inFlight);
+      if (url === "function") return Promise.resolve([{_id: "fn1", name: "MyFn"}]);
+      return Promise.resolve(url.endsWith("/index") ? {index: ""} : []);
+    });
+
+    const result = await functionModule.readRemote(mockHttp, {concurrency: 0});
+    expect(result).toHaveLength(1);
+  });
+
+  it("keeps the per-function detail requests within the requested concurrency", async () => {
+    const CONCURRENCY = 4;
+    const REQUESTS_PER_FUNCTION = 2; // index + dependencies, fired together
+    const fns = Array.from({length: 50}, (_, i) => ({_id: `fn${i}`, name: `Fn${i}`}));
+
+    let inFlight = 0;
+    let peakInFlight = 0;
+
+    const detailRequest = (url: string) => {
+      peakInFlight = Math.max(peakInFlight, ++inFlight);
       return new Promise(resolve =>
         setImmediate(() => {
           inFlight--;
           resolve(url.endsWith("/index") ? {index: ""} : []);
         })
       );
-    });
+    };
 
-    const result = await functionModule.readRemote(mockHttp);
+    mockHttp.get.mockImplementation((url: string) =>
+      url === "function" ? Promise.resolve(fns) : detailRequest(url)
+    );
+
+    const result = await functionModule.readRemote(mockHttp, {concurrency: CONCURRENCY});
+
     expect(result).toHaveLength(50);
-    expect(peak).toBeLessThanOrEqual(20);
+    expect(peakInFlight).toBeLessThanOrEqual(CONCURRENCY * REQUESTS_PER_FUNCTION);
   });
 });
 

--- a/packages/sync/test/planner.spec.ts
+++ b/packages/sync/test/planner.spec.ts
@@ -169,8 +169,15 @@ describe("buildPlan", () => {
     const mod = makeMockModule("test", [local], [remote]);
     const renderDetailSpy = jest.spyOn(mod, "renderDetail");
 
-    await buildPlan([mod], mockHttp, "/tmp", true);
+    await buildPlan([mod], mockHttp, "/tmp", {detailed: true});
     expect(renderDetailSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards the requested concurrency to every module's readRemote", async () => {
+    const mod = makeMockModule("test", [], []);
+
+    await buildPlan([mod], mockHttp, "/tmp", {concurrency: 3});
+    expect(mod.readRemote).toHaveBeenCalledWith(mockHttp, {concurrency: 3});
   });
 });
 
@@ -236,7 +243,7 @@ describe("buildPlan — rename detection", () => {
 
     const mod = makeMockModuleWithId([local], [remote], d => d._id);
     // detectRenames=false simulates fetch path
-    const plan = await buildPlan([mod], mockHttp, "/tmp", false, false);
+    const plan = await buildPlan([mod], mockHttp, "/tmp", {detectRenames: false});
     const mp = plan.modules[0];
 
     expect(mp.creates).toHaveLength(1);


### PR DESCRIPTION
readRemote fired the per-function index and dependencies requests all at once and swallowed every failure (`.catch(() => ({index: ""}))`). On an instance with many functions those requests get throttled, and a dropped request was then read as an empty remote: `plan` reported an [index, dependencies] change for functions nobody had touched, and exited 0.

The detail requests now run in batches of 10, matching the existing --concurrency default, so the throttling does not happen in the first place. Only a real 404 still counts as "this function has no index yet"; any other failure names the function and aborts instead of guessing.

The CLI's axios response interceptor now keeps `status` on the rejected error, without which the module's existing isNotFoundError helper could never match.

Refs #1940