### PR TITLE
fix(passport): point strategy callback urls at the scoped routes

### DIFF
--- a/apps/migrate/src/migrations/0.19.7/add_user_scope_to_oauth_redirect_uri.ts
+++ b/apps/migrate/src/migrations/0.19.7/add_user_scope_to_oauth_redirect_uri.ts
@@ -1,0 +1,33 @@
+import {Context} from "../../migrate";
+
+const previousPath = "/passport/strategy/";
+const currentPath = "/passport/user/strategy/";
+
+export default async function (ctx: Context) {
+  const coll = ctx.database.collection("strategy");
+
+  const strategies = await coll
+    .find(
+      {type: "oauth", "options.code.params.redirect_uri": {$regex: previousPath}},
+      {session: ctx.session}
+    )
+    .toArray();
+
+  for (const strategy of strategies) {
+    const redirectUri = strategy.options.code.params.redirect_uri.replace(
+      previousPath,
+      currentPath
+    );
+
+    await coll.updateOne(
+      {_id: strategy._id},
+      {
+        $set: {
+          "options.code.params.redirect_uri": redirectUri,
+          "options.access_token.params.redirect_uri": redirectUri
+        }
+      },
+      {session: ctx.session}
+    );
+  }
+}

--- a/apps/migrate/src/migrations/index.json
+++ b/apps/migrate/src/migrations/index.json
@@ -19,5 +19,6 @@
   "0.17.0": ["0.17.0/set_mongodb_fcv_7.js"],
   "0.18.0": ["0.18.0/remove_position_from_bucket_properties.js"],
   "0.19.4": ["0.19.4/convert_function_relation_ids_to_objectid.js"],
-  "0.19.6": ["0.19.6/remove_memory_limit_from_functions.js"]
+  "0.19.6": ["0.19.6/remove_memory_limit_from_functions.js"],
+  "0.19.7": ["0.19.7/add_user_scope_to_oauth_redirect_uri.js"]
 }

--- a/apps/migrate/test/migrations/0_19_7_add_user_scope_to_oauth_redirect_uri.spec.ts
+++ b/apps/migrate/test/migrations/0_19_7_add_user_scope_to_oauth_redirect_uri.spec.ts
@@ -1,43 +1,96 @@
-import migration from "../../src/migrations/0.19.7/add_user_scope_to_oauth_redirect_uri";
+import {Db, getConnectionUri, getDatabaseName, start} from "@spica-server/database-testing";
+import color from "cli-color/lib/supports-color";
+import {run} from "@spica/migrate";
+import path from "path";
+
+process.env.TESTONLY_MIGRATION_LOOKUP_DIR = path.join(process.cwd(), "dist/src");
+
+jest.setTimeout(120_000);
 
 describe("Add user scope to oauth redirect uri", () => {
+  let db: Db;
+  let args: string[];
+
   const publicUrl = "http://localhost:4300";
   const strategyId = "5f30fffd4a51a68d6fec4d3b";
-  const session = {};
+  const previousUri = `${publicUrl}/passport/strategy/${strategyId}/complete`;
+  const currentUri = `${publicUrl}/passport/user/strategy/${strategyId}/complete`;
+
+  const oauthStrategy = {
+    type: "oauth",
+    name: "oauth",
+    title: "oauth",
+    icon: "login",
+    options: {
+      idp: "custom",
+      code: {
+        base_url: "/oauth/code",
+        params: {client_id: "client_id", redirect_uri: previousUri},
+        headers: {},
+        method: "get"
+      },
+      access_token: {
+        base_url: "/oauth/token",
+        params: {client_id: "client_id", redirect_uri: previousUri},
+        headers: {},
+        method: "get"
+      },
+      identifier: {base_url: "/oauth/info", params: {}, headers: {}, method: "get"}
+    }
+  };
+
+  const migratedOauthStrategy = {
+    type: "oauth",
+    name: "oauth",
+    title: "oauth",
+    icon: "login",
+    options: {
+      idp: "custom",
+      code: {
+        base_url: "/oauth/code",
+        params: {client_id: "client_id", redirect_uri: currentUri},
+        headers: {},
+        method: "get"
+      },
+      access_token: {
+        base_url: "/oauth/token",
+        params: {client_id: "client_id", redirect_uri: currentUri},
+        headers: {},
+        method: "get"
+      },
+      identifier: {base_url: "/oauth/info", params: {}, headers: {}, method: "get"}
+    }
+  };
+
+  const samlStrategy = {
+    type: "saml",
+    name: "strategy1",
+    title: "strategy1",
+    options: {
+      ip: {login_url: "/idp/login", logout_url: "/idp/logout", certificate: "CERTIFICATE"}
+    }
+  };
+
+  beforeAll(() => {
+    color.disableColor();
+  });
+
+  beforeEach(async () => {
+    const connection = await start("replset");
+    args = ["--database-uri", await getConnectionUri(), "--database-name", getDatabaseName()];
+    db = connection.db(args[3]);
+
+    await db.collection("strategy").insertMany([oauthStrategy, samlStrategy]);
+  });
 
   it("should move oauth redirect uris to the user scope", async () => {
-    const previousUri = `${publicUrl}/passport/strategy/${strategyId}/complete`;
-    const strategy = {
-      _id: strategyId,
-      type: "oauth",
-      options: {
-        code: {params: {client_id: "client_id", redirect_uri: previousUri}},
-        access_token: {params: {client_id: "client_id", redirect_uri: previousUri}}
-      }
-    };
+    await run([...args, "--from", "0.19.6", "--to", "0.19.7", "--continue-if-versions-are-equal"]);
 
-    const updateOne = jest.fn();
-    const find = jest.fn().mockReturnValue({toArray: () => Promise.resolve([strategy])});
-    const collection = jest.fn().mockReturnValue({find, updateOne});
+    const strategies = await db.collection("strategy").find().toArray();
 
-    await migration({database: {collection}, session, console} as any);
-
-    expect(collection).toHaveBeenCalledWith("strategy");
-    expect(find).toHaveBeenCalledWith(
-      {type: "oauth", "options.code.params.redirect_uri": {$regex: "/passport/strategy/"}},
-      {session}
-    );
-
-    const currentUri = `${publicUrl}/passport/user/strategy/${strategyId}/complete`;
-    expect(updateOne).toHaveBeenCalledWith(
-      {_id: strategyId},
-      {
-        $set: {
-          "options.code.params.redirect_uri": currentUri,
-          "options.access_token.params.redirect_uri": currentUri
-        }
-      },
-      {session}
-    );
+    expect(strategies).toEqual([
+      {...migratedOauthStrategy, _id: strategies[0]._id},
+      {...samlStrategy, _id: strategies[1]._id}
+    ]);
   });
 });

--- a/apps/migrate/test/migrations/0_19_7_add_user_scope_to_oauth_redirect_uri.spec.ts
+++ b/apps/migrate/test/migrations/0_19_7_add_user_scope_to_oauth_redirect_uri.spec.ts
@@ -1,0 +1,43 @@
+import migration from "../../src/migrations/0.19.7/add_user_scope_to_oauth_redirect_uri";
+
+describe("Add user scope to oauth redirect uri", () => {
+  const publicUrl = "http://localhost:4300";
+  const strategyId = "5f30fffd4a51a68d6fec4d3b";
+  const session = {};
+
+  it("should move oauth redirect uris to the user scope", async () => {
+    const previousUri = `${publicUrl}/passport/strategy/${strategyId}/complete`;
+    const strategy = {
+      _id: strategyId,
+      type: "oauth",
+      options: {
+        code: {params: {client_id: "client_id", redirect_uri: previousUri}},
+        access_token: {params: {client_id: "client_id", redirect_uri: previousUri}}
+      }
+    };
+
+    const updateOne = jest.fn();
+    const find = jest.fn().mockReturnValue({toArray: () => Promise.resolve([strategy])});
+    const collection = jest.fn().mockReturnValue({find, updateOne});
+
+    await migration({database: {collection}, session, console} as any);
+
+    expect(collection).toHaveBeenCalledWith("strategy");
+    expect(find).toHaveBeenCalledWith(
+      {type: "oauth", "options.code.params.redirect_uri": {$regex: "/passport/strategy/"}},
+      {session}
+    );
+
+    const currentUri = `${publicUrl}/passport/user/strategy/${strategyId}/complete`;
+    expect(updateOne).toHaveBeenCalledWith(
+      {_id: strategyId},
+      {
+        $set: {
+          "options.code.params.redirect_uri": currentUri,
+          "options.access_token.params.redirect_uri": currentUri
+        }
+      },
+      {session}
+    );
+  });
+});

--- a/packages/api/passport/src/strategy/services/oauth/custom.ts
+++ b/packages/api/passport/src/strategy/services/oauth/custom.ts
@@ -86,7 +86,7 @@ export class CustomOAuthService implements OAuthStrategyService {
   }
 
   afterInsert(strategy: OAuthStrategy): Promise<Strategy> {
-    const redirectUri = `${this.options.publicUrl}/passport/strategy/${strategy._id}/complete`;
+    const redirectUri = `${this.options.publicUrl}/passport/user/strategy/${strategy._id}/complete`;
     return this.strategyService.findOneAndUpdate(
       {
         _id: new ObjectId(strategy._id)

--- a/packages/api/passport/src/strategy/services/saml.service.ts
+++ b/packages/api/passport/src/strategy/services/saml.service.ts
@@ -68,8 +68,8 @@ export class SamlService implements StrategyTypeService {
     const sp = new saml2.ServiceProvider({
       entity_id: `${this.options.publicUrl}/passport/strategy/${strategy._id}`,
       assert_endpoint: state
-        ? `${this.options.publicUrl}/passport/strategy/${strategy._id}/complete?state=${state}`
-        : `${this.options.publicUrl}/passport/strategy/${strategy._id}/complete`,
+        ? `${this.options.publicUrl}/passport/identity/strategy/${strategy._id}/complete?state=${state}`
+        : `${this.options.publicUrl}/passport/identity/strategy/${strategy._id}/complete`,
       certificate: strategy.options.sp.certificate,
       private_key: strategy.options.sp.private_key,
       force_authn: true,

--- a/packages/api/passport/src/strategy/strategy.controller.ts
+++ b/packages/api/passport/src/strategy/strategy.controller.ts
@@ -38,8 +38,9 @@ export class StrategyController {
   @UseGuards(AuthGuard(["IDENTITY", "APIKEY"]), ActionGuard("passport:strategy:show"))
   findOne(@Param("id", OBJECT_ID) id: ObjectId) {
     return this.strategy.findOne({_id: id}).then(strategy => {
+      const scope = strategy.type === "oauth" ? "user" : "identity";
       strategy["callbackUrl"] =
-        `${this.options.publicUrl}/passport/strategy/${strategy._id}/complete`;
+        `${this.options.publicUrl}/passport/${scope}/strategy/${strategy._id}/complete`;
       return strategy;
     });
   }

--- a/packages/api/passport/test/e2e.spec.ts
+++ b/packages/api/passport/test/e2e.spec.ts
@@ -729,9 +729,8 @@ describe("E2E Tests", () => {
                   // this last request because of we use test environment,
                   // actual SSO implementation handles this last step automatically on browser environment and redirects user to the panel as logged in
                   const request = parseUrl(completeUrl, publicUrl);
-                  const completeEndpoint = `/passport/identity/strategy/${strategies[0]._id}/complete`;
                   req
-                    .post(completeEndpoint, {SAMLResponse: SAMLResponse}, {}, request.params)
+                    .post(request.url, {SAMLResponse: SAMLResponse}, {}, request.params)
                     .then(res => {
                       expect([res.statusCode, res.statusText]).toEqual([204, "No Content"]);
                       expect(res.body).toBeUndefined();
@@ -835,7 +834,7 @@ describe("E2E Tests", () => {
         expect(strategy.state).toBeDefined();
         expect(
           strategy.url.startsWith(
-            `${publicUrl}/oauth/code?client_id=client_id&redirect_uri=${publicUrl}/passport/strategy/${strategies[0]._id}/complete&state=`
+            `${publicUrl}/oauth/code?client_id=client_id&redirect_uri=${publicUrl}/passport/user/strategy/${strategies[0]._id}/complete&state=`
           )
         ).toBe(true);
       });
@@ -866,9 +865,11 @@ describe("E2E Tests", () => {
                 authorization: "testuser"
               })
               .then(({body: code}) => {
-                // send code to the strategy complete endpoint
-                const {params: completeParams} = parseUrl(strategyParams.redirect_uri, publicUrl);
-                const completeEndpoint = `/passport/user/strategy/${strategies[0]._id}/complete`;
+                // send code to the strategy complete endpoint the strategy itself advertises
+                const {url: completeEndpoint, params: completeParams} = parseUrl(
+                  strategyParams.redirect_uri,
+                  publicUrl
+                );
                 req
                   .get(completeEndpoint, {
                     ...completeParams,


### PR DESCRIPTION
OAuth and SAML strategies still advertised the pre-split passport/strategy/:id/complete route, which this build no longer serves: oauth is handled by passport/user/... and saml by passport/identity/... Every OAuth login broke at the callback with a 404, and the value could not be corrected through the API because afterInsert rewrites it on every update.

The e2e tests missed this because they threw away the path of the advertised redirect_uri and hardcoded the endpoint instead; they now follow the url the strategy itself hands out.

Existing strategies keep the stale redirect_uri in the database, so a migration rewrites them.


Claude-Session: https://claude.ai/code/session_016FHYUQchKyt5bieGHZEGLq